### PR TITLE
Handle zero in `\g` groups

### DIFF
--- a/backrefs/bre.py
+++ b/backrefs/bre.py
@@ -110,7 +110,7 @@ utokens = {
     "re_search_ref": re.compile(r'(\\)|([lLcCEQ]|%(uni_prop)s)' % {"uni_prop": _UPROP}),
     "re_search_ref_verbose": re.compile(r'(\\)|([lLcCEQ#]|%(uni_prop)s)' % {"uni_prop": _UPROP}),
     "re_flags": re.compile(r'(?s)(\\.)|\(\?([aiLmsux]+)\)|(.)' if compat.PY3 else r'(?s)(\\.)|\(\?([iLmsux]+)\)|(.)'),
-    "re_replace_group_ref": re.compile(r'(\\)|([1-9][0-9]?|[cClLE]|g<(?:[a-zA-Z]+[a-zA-Z\d_]*|[1-9][0-9]?)>)'),
+    "re_replace_group_ref": re.compile(r'(\\)|([1-9][0-9]?|[cClLE]|g<(?:[a-zA-Z]+[a-zA-Z\d_]*|0+|0*[1-9][0-9]?)>)'),
     "ascii_flag": "a",
     "group": "g"
 }
@@ -134,7 +134,7 @@ btokens = {
     "re_search_ref": re.compile(br'(\\)|([lLcCEQ])'),
     "re_search_ref_verbose": re.compile(br'(\\)|([lLcCEQ#])'),
     "re_flags": re.compile(br'(?s)(\\.)|\(\?([aiLmsux]+)\)|(.)' if compat.PY3 else br'(?s)(\\.)|\(\?([iLmsux]+)\)|(.)'),
-    "re_replace_group_ref": re.compile(br'(\\)|([1-9][0-9]?|[cClLE]|g<(?:[a-zA-Z]+[a-zA-Z\d_]*|[1-9][0-9]?)>)'),
+    "re_replace_group_ref": re.compile(br'(\\)|([1-9][0-9]?|[cClLE]|g<(?:[a-zA-Z]+[a-zA-Z\d_]*|0+|0*[1-9][0-9]?)>)'),
     "ascii_flag": b"a",
     "group": b"g"
 }

--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -3,6 +3,7 @@
 ## 1.1.1
 
 - **FIX**: Fix bad regular expression pattern for binary replace in `bre`.
+- **FIX**: For `\g<digit>`, ensure you can use group `0` and also allow leading `0` on non-zero digits.
 
 ## 1.1.0
 

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -1184,6 +1184,21 @@ class TestReplaceTemplate(unittest.TestCase):
 
         self.assertEqual('Success!', result)
 
+    def test_numeric_groups(self):
+        """Test numeric capture groups."""
+
+        text = "this is a test for numeric capture groups!"
+        text_pattern = r"(this )(.*?)(numeric capture )(groups)(!)"
+        pattern = re.compile(text_pattern)
+
+        # This will pass because we do not need to resolve named groups.
+        expand = bre.compile_replace(text_pattern, r'\l\C\g<0001>\l\g<02>\L\c\g<03>\E\g<004>\E\5\n\C\g<000>\E')
+        results = expand(pattern.match(text))
+        self.assertEqual(
+            'tHIS iS A TEST FOR Numeric capture GROUPS!\nTHIS IS A TEST FOR NUMERIC CAPTURE GROUPS!',
+            results
+        )
+
 
 class TestConvenienceFunctions(unittest.TestCase):
     """Test convenience functions."""


### PR DESCRIPTION
For `\g<digit>`, ensure you can use group `0` and also allow leading `0` on non-zero digits.