### PR TITLE
Re parse Unicode, byte, and octal

### DIFF
--- a/backrefs/__init__.py
+++ b/backrefs/__init__.py
@@ -1,7 +1,7 @@
 """Backrefs package."""
 
 #   (major, minor, micro, release type, pre-release build, post-release build)
-version_info = (2, 0, 2, 'final', 0, 0)
+version_info = (2, 1, 0, 'beta', 1, 0)
 
 
 def _version():

--- a/backrefs/bre.py
+++ b/backrefs/bre.py
@@ -117,7 +117,10 @@ utokens = {
             [0-7]{3}|
             [1-9][0-9]?|
             [cClLEabfrtnv]|
-            g<(?:[a-zA-Z]+[a-zA-Z\d_]*|0+|0*[1-9][0-9]?)>
+            g<(?:[a-zA-Z]+[a-zA-Z\d_]*|0+|0*[1-9][0-9]?)>|
+            U[0-9a-fA-F]{8}|
+            u[0-9a-fA-F]{4}|
+            x[0-9a-fA-F]{2}
         )
         '''
     ),
@@ -126,6 +129,9 @@ utokens = {
         (\\)|
         (
             [cClLEabfrtnv]|
+            U[0-9a-fA-F]{8}|
+            u[0-9a-fA-F]{4}|
+            x[0-9a-fA-F]{2}|
             [0-7]{1,3}|
             (
                 g<(?:[a-zA-Z]+[a-zA-Z\d_]*|0+|0*[1-9][0-9]?)>
@@ -162,7 +168,8 @@ btokens = {
             [0-7]{3}|
             [1-9][0-9]?|
             [cClLEabfrtnv]|
-            g<(?:[a-zA-Z]+[a-zA-Z\d_]*|0+|0*[1-9][0-9]?)>
+            g<(?:[a-zA-Z]+[a-zA-Z\d_]*|0+|0*[1-9][0-9]?)>|
+            x[0-9a-fA-F]{2}
         )
         '''
     ),
@@ -172,6 +179,7 @@ btokens = {
         (
             [cClLEabfrtnv]|
             [0-7]{1,3}|
+            x[0-9a-fA-F]{2}|
             (
                 g<(?:[a-zA-Z]+[a-zA-Z\d_]*|0+|0*[1-9][0-9]?)>
             )
@@ -374,12 +382,18 @@ class ReplaceTemplate(object):
                     self.handle_format_group(t[1:-1].strip())
                 else:
                     c = t[1:]
-                    if c[0:1].isdigit() and (self.use_format or len(c) == 3):
+                    first = c[0:1]
+                    if first.isdigit() and (self.use_format or len(c) == 3):
                         value = int(c, 8)
-                        if value > 0xFF:
-                            # Re fails on octal greater than 0o377 or 0xFF
-                            raise ValueError("octal escape value outside of range 0-0o377!")
-                        self.result.append(self.string_convert('\\%03o' % value))
+                        if self.binary:
+                            if value > 0xFF:
+                                value -= 0x100
+                            self.result.append(self.string_convert('\\%03o' % value))
+                        else:
+                            if value <= 0xFF:
+                                self.result.append('\\%03o' % value)
+                            else:
+                                self.result.append(compat.uchr(value))
                     elif not self.use_format and (c[0:1].isdigit() or c[0:1] == self._group):
                         self.handle_group(t)
                     elif c == self._lc:
@@ -393,6 +407,17 @@ class ReplaceTemplate(object):
                     elif c == self._end:
                         # This is here just as a reminder that \E is ignored
                         pass
+                    elif (
+                        not self.binary and
+                        (first == self._unicode_narrow or (not NARROW and first == self._unicode_wide))
+                    ):
+                        value = int(t[2:], 16)
+                        if value <= 0xFF:
+                            self.result.append('\\%03o' % value)
+                        else:
+                            self.result.append(compat.uchr(value))
+                    elif first == self._hex:
+                        self.result.append('\\%03o' % int(t[2:], 16))
                     else:
                         self.result.append(t)
             else:
@@ -420,15 +445,24 @@ class ReplaceTemplate(object):
                         self.handle_format_group(t[1:-1].strip())
                     else:
                         c = t[1:]
-                        if c[0:1].isdigit() and (self.use_format or len(c) == 3):
+                        first = c[0:1]
+                        if first.isdigit() and (self.use_format or len(c) == 3):
                             value = int(c, 8)
-                            if value > 0xFF:
-                                # Re fails on octal greater than 0o377 or 0xFF
-                                raise ValueError("octal escape value outside of range 0-0o377!")
-                            text = getattr(compat.uchr(value), attr)()
-                            single = self.get_single_stack()
-                            value = ord(getattr(text, single)()) if single is not None else ord(text)
-                            self.result.append(self.string_convert('\\%03o' % value))
+                            if self.binary:
+                                if value > 0xFF:
+                                    value -= 0x100
+                                text = getattr(compat.uchr(value), attr)()
+                                single = self.get_single_stack()
+                                value = ord(getattr(text, single)()) if single is not None else ord(text)
+                                self.result.append(self.string_convert('\\%03o' % value))
+                            else:
+                                text = getattr(compat.uchr(value), attr)()
+                                single = self.get_single_stack()
+                                value = ord(getattr(text, single)()) if single is not None else ord(text)
+                                if value <= 0xFF:
+                                    self.result.append('\\%03o' % value)
+                                else:
+                                    self.result.append(compat.uchr(value))
                         elif not self.use_format and (c[0:1].isdigit() or c[0:1] == self._group):
                             self.handle_group(t)
                         elif c == self._uc:
@@ -439,6 +473,24 @@ class ReplaceTemplate(object):
                             self.span_case(i, _UPPER)
                         elif c == self._lc_span:
                             self.span_case(i, _LOWER)
+                        elif (
+                            not self.binary and
+                            (first == self._unicode_narrow or (not NARROW and first == self._unicode_wide))
+                        ):
+                            uc = compat.uchr(int(t[2:], 16))
+                            text = getattr(uc, attr)()
+                            single = self.get_single_stack()
+                            value = ord(getattr(text, single)()) if single is not None else ord(text)
+                            if value <= 0xFF:
+                                self.result.append('\\%03o' % value)
+                            else:
+                                self.result.append(compat.uchr(value))
+                        elif first == self._hex:
+                            hc = chr(int(t[2:], 16))
+                            text = getattr(hc, attr)()
+                            single = self.get_single_stack()
+                            value = ord(getattr(text, single)()) if single is not None else ord(text)
+                            self.result.append(self.string_convert("\\%03o" % value))
                         else:
                             self.get_single_stack()
                             self.result.append(t)
@@ -469,14 +521,20 @@ class ReplaceTemplate(object):
                     self.handle_format_group(t[1:-1].strip())
                 else:
                     c = t[1:]
-                    if c[0:1].isdigit() and (self.use_format or len(c) == 3):
+                    first = c[0:1]
+                    if first.isdigit() and (self.use_format or len(c) == 3):
                         value = int(c, 8)
-                        if value > 0xFF:
-                            # Re fails on octal greater than 0o377 or 0xFF
-                            raise ValueError("octal escape value outside of range 0-0o377!")
-                        text = compat.uchr(value)
-                        value = ord(getattr(text, self.get_single_stack())())
-                        self.result.append(self.string_convert('\\%03o' % value))
+                        if self.binary:
+                            if value > 0xFF:
+                                value -= 0x100
+                            value = ord(getattr(compat.uchr(value), self.get_single_stack())())
+                            self.result.append(self.string_convert('\\%03o' % value))
+                        else:
+                            value = ord(getattr(compat.uchr(value), self.get_single_stack())())
+                            if value <= 0xFF:
+                                self.result.append('\\%03o' % value)
+                            else:
+                                self.result.append(compat.uchr(value))
                     elif not self.use_format and (c[0:1].isdigit() or c[0:1] == self._group):
                         self.handle_group(t)
                     elif c == self._uc:
@@ -489,6 +547,21 @@ class ReplaceTemplate(object):
                         self.span_case(i, _LOWER)
                     elif c == self._end:
                         self.end_found = True
+                    elif (
+                        not self.binary and
+                        (first == self._unicode_narrow or (not NARROW and first == self._unicode_wide))
+                    ):
+                        uc = compat.uchr(int(t[2:], 16))
+                        value = ord(getattr(uc, self.get_single_stack())())
+                        if value <= 0xFF:
+                            self.result.append('\\%03o' % value)
+                        else:
+                            self.result.append(compat.uchr(value))
+                    elif first == self._hex:
+                        hc = chr(int(t[2:], 16))
+                        self.result.append(
+                            self.string_convert("\\%03o" % ord(getattr(hc, self.get_single_stack())()))
+                        )
                     else:
                         self.get_single_stack()
                         self.result.append(t)

--- a/backrefs/bregex.py
+++ b/backrefs/bregex.py
@@ -646,7 +646,7 @@ if REGEX_SUPPORT:
                         else:
                             c = t[1:]
                             first = c[0:1]
-                            if c[0:1].isdigit() and (self.use_format or len(c) == 3):
+                            if first.isdigit() and (self.use_format or len(c) == 3):
                                 value = int(c, 8)
                                 if self.binary:
                                     if value > 0xFF:
@@ -716,17 +716,15 @@ if REGEX_SUPPORT:
                     else:
                         c = t[1:]
                         first = c[0:1]
-                        if c[0:1].isdigit() and (self.use_format or len(c) == 3):
+                        if first.isdigit() and (self.use_format or len(c) == 3):
                             value = int(c, 8)
                             if self.binary:
                                 if value > 0xFF:
                                     value -= 0x100
-                                text = compat.uchr(value)
-                                value = ord(getattr(text, self.get_single_stack())())
+                                value = ord(getattr(compat.uchr(value), self.get_single_stack())())
                                 self.result.append(self.string_convert('\\%03o' % value))
                             else:
-                                text = compat.uchr(value)
-                                value = ord(getattr(text, self.get_single_stack())())
+                                value = ord(getattr(compat.uchr(value), self.get_single_stack())())
                                 self.result.append(('\\%03o' if value <= 0xFF else '\\u%04x') % value)
                         elif not self.use_format and (c[0:1].isdigit() or c[0:1] == self._group):
                                 self.handle_group(t)

--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.1.0
+
+- **NEW**: Handle Unicode and byte notation in Re replace templates.
+- **FIX**: Fix octal/group logic in Regex and Re.
+
 ## 2.0.2
 
 Sep 26, 2017

--- a/docs/src/markdown/index.md
+++ b/docs/src/markdown/index.md
@@ -168,8 +168,10 @@ Back&nbsp;References | Description
 ---------------------|-------------
 `\c`                 | Uppercase the next character. 
 `\l`                 | Lowercase the next character. 
-`\C...\E`            | Apply uppercase to all characters until either the end of the string or the end marker `\E` is found. 
-`\L...\E`            | Apply lowercase to all characters until either the end of the string or the end marker `\E` is found. 
+`\C...\E`            | Apply uppercase to all characters until either the end of the string or the end marker `\E` is found.
+`\L...\E`            | Apply lowercase to all characters until either the end of the string or the end marker `\E` is found.
+
+Though `\U`, `\u`, and `\x` are not new back references, Re will not process then in raw string templates (`r"..."`), nor will Regex in format templates.  Backrefs will ensure these get processed in Re and in Regex's format replace templates.
 
 !!! tip "Tip"
     Complex configurations of casing should work fine.
@@ -177,6 +179,7 @@ Back&nbsp;References | Description
     - `\L\cTEST\E` --> `Test`
     - `\c\LTEST\E` --> `Test`
     - `\L\cTEST \cTEST\E` --> `Test Test`
+
 
 ## Unicode Properties
 

--- a/docs/src/markdown/index.md
+++ b/docs/src/markdown/index.md
@@ -156,22 +156,23 @@ Back\ References      | Description
 
 ### Regex
 
-Back\ References | Description 
+Back\ References | Description
 ---------------- | -----------
-`\Q...\E`        | Quotes (escapes) text for regular expression.  `\E` signifies the end of the quoting. Will be ignored in character classes `[]`. 
+`\Q...\E`        | Quotes (escapes) text for regular expression.  `\E` signifies the end of the quoting. Will be ignored in character classes `[]`.
 
 ## Replace Back References
 
 Added features available for replace patterns. None of the replace back references can be used in character classes `[]`.  The references below apply to both Re **and** Regex.
 
-Back&nbsp;References | Description 
+Back&nbsp;References | Description
 ---------------------|-------------
-`\c`                 | Uppercase the next character. 
-`\l`                 | Lowercase the next character. 
+`\c`                 | Uppercase the next character.
+`\l`                 | Lowercase the next character.
 `\C...\E`            | Apply uppercase to all characters until either the end of the string or the end marker `\E` is found.
 `\L...\E`            | Apply lowercase to all characters until either the end of the string or the end marker `\E` is found.
-
-Though `\U`, `\u`, and `\x` are not new back references, Re will not process then in raw string templates (`r"..."`), nor will Regex in format templates.  Backrefs will ensure these get processed in Re and in Regex's format replace templates.
+`\U`                 | Wide Unicode character `\U00000057`. Re doesn't translate this notation in raw strings (`r"..."`), and Regex doesn't in format templates in raw strings (`r"{} {}"`).  This adds support for them.
+`\u`                 | Narrow Unicode character `\u0057`. Re doesn't translate this notation in raw strings (`r"..."`), and Regex doesn't in format templates in raw strings (`r"{} {}"`).  This adds support for them.
+`\x`                 | Byte character `\x57`. Re doesn't translate this notation in raw strings (`r"..."`), and Regex doesn't in format templates in raw strings (`r"{} {}"`).  This adds support for them.
 
 !!! tip "Tip"
     Complex configurations of casing should work fine.
@@ -179,7 +180,6 @@ Though `\U`, `\u`, and `\x` are not new back references, Re will not process the
     - `\L\cTEST\E` --> `Test`
     - `\c\LTEST\E` --> `Test`
     - `\L\cTEST \cTEST\E` --> `Test Test`
-
 
 ## Unicode Properties
 

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -1340,40 +1340,69 @@ class TestReplaceTemplate(unittest.TestCase):
         )
 
     def test_dont_case_special_refs(self):
-        """Test that we don't case unicode and bytes symbols."""
+        """Test that we don't case unicode and bytes tokens, but case the character."""
 
         # Unicode and bytes should get evaluated proper
-        # (on Re Unicode and bytes notation passes throgh raw strings)
         pattern = re.compile('Test')
-        expand = bre.compile_replace(pattern, r'\C\t\n\E\c\t')
+        expand = bre.compile_replace(pattern, r'\C\u0109\n\x77\E\l\x57\c\u0109')
         results = expand(pattern.match('Test'))
-        self.assertEqual('\t\n\t', results)
+        self.assertEqual('\u0108\nWw\u0108', results)
 
-        expandf = bre.compile_replace(pattern, r'\C\t\n\E\c\t', bre.FORMAT)
+        expandf = bre.compile_replace(pattern, r'\C\u0109\n\x77\E\l\x57\c\u0109', bre.FORMAT)
         results = expandf(pattern.match('Test'))
-        self.assertEqual('\t\n\t', results)
+        self.assertEqual('\u0108\nWw\u0108', results)
+
+        # Wide Unicode must be evaluated before narrow Unicode
+        pattern = re.compile('Test')
+        expand = bre.compile_replace(pattern, r'\C\U00000109\n\x77\E\l\x57\c\U00000109')
+        results = expand(pattern.match('Test'))
+        self.assertEqual('\u0108\nWw\u0108', results)
+
+        expandf = bre.compile_replace(pattern, r'\C\U00000109\n\x77\E\l\x57\c\U00000109', bre.FORMAT)
+        results = expandf(pattern.match('Test'))
+        self.assertEqual('\u0108\nWw\u0108', results)
+
+        # Binary doesn't care about Unicode, but should evaluate bytes
+        pattern = re.compile(b'Test')
+        expand = bre.compile_replace(pattern, br'\C\u0109\n\x77\E\l\x57\c\u0109')
+        results = expand(pattern.match(b'Test'))
+        self.assertEqual(b'\\U0109\nWw\\u0109', results)
+
+        expandf = bre.compile_replace(pattern, br'\C\u0109\n\x77\E\l\x57\c\u0109', bre.FORMAT)
+        results = expandf(pattern.match(b'Test'))
+        self.assertEqual(b'\\U0109\nWw\\u0109', results)
+
+        pattern = re.compile(b'Test')
+        expand = bre.compile_replace(pattern, br'\C\U00000109\n\x77\E\l\x57\c\U00000109')
+        results = expand(pattern.match(b'Test'))
+        self.assertEqual(b'\U00000109\nWw\U00000109', results)
+
+        expandf = bre.compile_replace(pattern, br'\C\U00000109\n\x77\E\l\x57\c\U00000109', bre.FORMAT)
+        results = expandf(pattern.match(b'Test'))
+        self.assertEqual(b'\U00000109\nWw\U00000109', results)
 
         # Format doesn't care about groups
         pattern = re.compile('Test')
-        expand = bre.compile_replace(pattern, r'\127\C\167\n\E\l\127', bre.FORMAT)
+        expand = bre.compile_replace(pattern, r'\127\666\C\167\666\n\E\l\127\c\666', bre.FORMAT)
         results = expand(pattern.match('Test'))
-        self.assertEqual('WW\nw', results)
+        self.assertEqual('W\u01b6W\u01b5\nw\u01b5', results)
 
         pattern = re.compile(b'Test')
-        expandf = bre.compile_replace(pattern, br'\127\C\167\n\E\l\127', bre.FORMAT)
+        expandf = bre.compile_replace(pattern, br'\127\666\C\167\666\n\E\l\127\c\666', bre.FORMAT)
         results = expandf(pattern.match(b'Test'))
-        self.assertEqual(b'WW\nw', results)
+        self.assertEqual(b'W\xb6W\xb6\nw\xb6', results)
 
-        # Octal behavior in regex grabs \127 before it evaluates \12, so we must match that behavior
+        # Octal behavior in regex grabs \127 before it evaluates \27, so we must match that behavior
         pattern = re.compile('Test')
-        expand = bre.compile_replace(pattern, r'\127\C\167\n\E\l\127')
+        expand = bre.compile_replace(pattern, r'\127\666\C\167\666\n\E\l\127\c\666')
         results = expand(pattern.match('Test'))
-        self.assertEqual('WW\nw', results)
+        self.assertEqual('W\u01b6W\u01b5\nw\u01b5', results)
 
+        # Regex uniquely seems to roll over octal in binary strings.
         pattern = re.compile(b'Test')
-        expandf = bre.compile_replace(pattern, br'\127\C\167\n\E\l\127')
+        expandf = bre.compile_replace(pattern, br'\127\666\C\167\666\n\E\l\127\c\666')
         results = expandf(pattern.match(b'Test'))
-        self.assertEqual(b'WW\nw', results)
+        self.assertEqual(b'W\xb6W\xb6\nw\xb6', results)
 
         # Null should pass through
         pattern = re.compile('Test')
@@ -1637,26 +1666,6 @@ class TestExceptions(unittest.TestCase):
             bre.compile_replace(pattern, repl)
 
         assert "Not a valid type!" in str(excinfo.value)
-
-    def test_octal_fail(self):
-        """Test that octal fails properly."""
-
-        pattern = re.compile('Test')
-
-        with pytest.raises(ValueError) as excinfo:
-            bre.compile_replace(pattern, r'\666')
-
-        assert "octal escape value outside of range 0-0o377!" in str(excinfo.value)
-
-        with pytest.raises(ValueError) as excinfo:
-            bre.compile_replace(pattern, r'\C\666\E')
-
-        assert "octal escape value outside of range 0-0o377!" in str(excinfo.value)
-
-        with pytest.raises(ValueError) as excinfo:
-            bre.compile_replace(pattern, r'\c\666')
-
-        assert "octal escape value outside of range 0-0o377!" in str(excinfo.value)
 
 
 class TestConvenienceFunctions(unittest.TestCase):

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -1345,9 +1345,9 @@ class TestReplaceTemplate(unittest.TestCase):
 
         # Unicode and bytes should get evaluated proper
         pattern = re.compile('Test')
-        expand = bre.compile_replace(pattern, r'\C\u0109\n\x77\E\l\x57\c\u0109')
+        expand = bre.compile_replace(pattern, r'\x57\u0057\u0109\C\u0077\u0109\n\x77\E\l\x57\c\u0109\c\u0077')
         results = expand(pattern.match('Test'))
-        self.assertEqual('\u0108\nWw\u0108', results)
+        self.assertEqual('WW\u0109W\u0108\nWw\u0108W', results)
 
         expandf = bre.compile_replace(pattern, r'\C\u0109\n\x77\E\l\x57\c\u0109', bre.FORMAT)
         results = expandf(pattern.match('Test'))

--- a/tests/test_bregex.py
+++ b/tests/test_bregex.py
@@ -8,7 +8,6 @@ import sys
 import pytest
 
 PY3 = (3, 0) <= sys.version_info < (4, 0)
-PY37 = (3, 7) <= sys.version_info
 
 if PY3:
     binary_type = bytes  # noqa
@@ -1113,27 +1112,24 @@ class TestReplaceTemplate(unittest.TestCase):
         results = expandf(pattern.match('Test'))
         self.assertEqual('\u0108\nWw\u0108', results)
 
-        # Python 3.7 will choke on \U and \u as invalid escapes, so
-        # don't bother running these tests there.
-        if not PY37:
-            # Binary doesn't care about Unicode, but should evaluate bytes
-            pattern = regex.compile(b'Test')
-            expand = bregex.compile_replace(pattern, br'\C\u0109\n\x77\E\l\x57\c\u0109')
-            results = expand(pattern.match(b'Test'))
-            self.assertEqual(b'\\U0109\nWw\\u0109', results)
+        # Binary doesn't care about Unicode, but should evaluate bytes
+        pattern = regex.compile(b'Test')
+        expand = bregex.compile_replace(pattern, br'\C\u0109\n\x77\E\l\x57\c\u0109')
+        results = expand(pattern.match(b'Test'))
+        self.assertEqual(b'\\U0109\nWw\\u0109', results)
 
-            expandf = bregex.compile_replace(pattern, br'\C\u0109\n\x77\E\l\x57\c\u0109', bregex.FORMAT)
-            results = expandf(pattern.match(b'Test'))
-            self.assertEqual(b'\\U0109\nWw\\u0109', results)
+        expandf = bregex.compile_replace(pattern, br'\C\u0109\n\x77\E\l\x57\c\u0109', bregex.FORMAT)
+        results = expandf(pattern.match(b'Test'))
+        self.assertEqual(b'\\U0109\nWw\\u0109', results)
 
-            pattern = regex.compile(b'Test')
-            expand = bregex.compile_replace(pattern, br'\C\U00000109\n\x77\E\l\x57\c\U00000109')
-            results = expand(pattern.match(b'Test'))
-            self.assertEqual(b'\U00000109\nWw\U00000109', results)
+        pattern = regex.compile(b'Test')
+        expand = bregex.compile_replace(pattern, br'\C\U00000109\n\x77\E\l\x57\c\U00000109')
+        results = expand(pattern.match(b'Test'))
+        self.assertEqual(b'\U00000109\nWw\U00000109', results)
 
-            expandf = bregex.compile_replace(pattern, br'\C\U00000109\n\x77\E\l\x57\c\U00000109', bregex.FORMAT)
-            results = expandf(pattern.match(b'Test'))
-            self.assertEqual(b'\U00000109\nWw\U00000109', results)
+        expandf = bregex.compile_replace(pattern, br'\C\U00000109\n\x77\E\l\x57\c\U00000109', bregex.FORMAT)
+        results = expandf(pattern.match(b'Test'))
+        self.assertEqual(b'\U00000109\nWw\U00000109', results)
 
         # Format doesn't care about groups
         pattern = regex.compile('Test')

--- a/tests/test_bregex.py
+++ b/tests/test_bregex.py
@@ -8,6 +8,7 @@ import sys
 import pytest
 
 PY3 = (3, 0) <= sys.version_info < (4, 0)
+PY37 = (3, 7) <= sys.version_info
 
 if PY3:
     binary_type = bytes  # noqa
@@ -1112,24 +1113,27 @@ class TestReplaceTemplate(unittest.TestCase):
         results = expandf(pattern.match('Test'))
         self.assertEqual('\u0108\nWw\u0108', results)
 
-        # Binary doesn't care about Unicode, but should evaluate bytes
-        pattern = regex.compile(b'Test')
-        expand = bregex.compile_replace(pattern, br'\C\u0109\n\x77\E\l\x57\c\u0109')
-        results = expand(pattern.match(b'Test'))
-        self.assertEqual(b'\\U0109\nWw\\u0109', results)
+        # Python 3.7 will choke on \U and \u as invalid escapes, so
+        # don't bother running these tests there.
+        if not PY37:
+            # Binary doesn't care about Unicode, but should evaluate bytes
+            pattern = regex.compile(b'Test')
+            expand = bregex.compile_replace(pattern, br'\C\u0109\n\x77\E\l\x57\c\u0109')
+            results = expand(pattern.match(b'Test'))
+            self.assertEqual(b'\\U0109\nWw\\u0109', results)
 
-        expandf = bregex.compile_replace(pattern, br'\C\u0109\n\x77\E\l\x57\c\u0109', bregex.FORMAT)
-        results = expandf(pattern.match(b'Test'))
-        self.assertEqual(b'\\U0109\nWw\\u0109', results)
+            expandf = bregex.compile_replace(pattern, br'\C\u0109\n\x77\E\l\x57\c\u0109', bregex.FORMAT)
+            results = expandf(pattern.match(b'Test'))
+            self.assertEqual(b'\\U0109\nWw\\u0109', results)
 
-        pattern = regex.compile(b'Test')
-        expand = bregex.compile_replace(pattern, br'\C\U00000109\n\x77\E\l\x57\c\U00000109')
-        results = expand(pattern.match(b'Test'))
-        self.assertEqual(b'\U00000109\nWw\U00000109', results)
+            pattern = regex.compile(b'Test')
+            expand = bregex.compile_replace(pattern, br'\C\U00000109\n\x77\E\l\x57\c\U00000109')
+            results = expand(pattern.match(b'Test'))
+            self.assertEqual(b'\U00000109\nWw\U00000109', results)
 
-        expandf = bregex.compile_replace(pattern, br'\C\U00000109\n\x77\E\l\x57\c\U00000109', bregex.FORMAT)
-        results = expandf(pattern.match(b'Test'))
-        self.assertEqual(b'\U00000109\nWw\U00000109', results)
+            expandf = bregex.compile_replace(pattern, br'\C\U00000109\n\x77\E\l\x57\c\U00000109', bregex.FORMAT)
+            results = expandf(pattern.match(b'Test'))
+            self.assertEqual(b'\U00000109\nWw\U00000109', results)
 
         # Format doesn't care about groups
         pattern = regex.compile('Test')


### PR DESCRIPTION
1. Adjust octal logic to wrap octal as this seems like something re does in many places too (I must have been on a older Python asserted).
2. Parse Unicode notation in raw strings.
3. Parse bytes notation in raw strings.