### PR TITLE
Add shortened unicode prop form

### DIFF
--- a/backrefs/uniprops/__init__.py
+++ b/backrefs/uniprops/__init__.py
@@ -38,12 +38,14 @@ def get_gc_property(value):
 
     if not negate:
         p1, p2 = (value[0], value[1]) if len(value) > 1 else (value[0], None)
-        return ''.join(
+        value = ''.join(
             [v for k, v in unidata.unicode_properties.get(p1, {}).items() if not k.startswith('^')]
         ) if p2 is None else unidata.unicode_properties.get(p1, {}).get(p2, '')
     else:
         p1, p2 = (value[0], value[1]) if len(value) > 1 else (value[0], '')
-        return unidata.unicode_properties.get(p1, {}).get('^' + p2, '')
+        value = unidata.unicode_properties.get(p1, {}).get('^' + p2, '')
+    assert value, 'Invalid property!'
+    return value
 
 
 def get_binary_property(value):

--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.3.0
+
+- **NEW**: Support Unicode property form `\pP` and `\PP`.
+- **FIX**: Fix issue where an invalid general category could sometimes pass and return no characters.
+
 ## 2.2.0
 
 - **NEW**: Proper support for `\N{Unicode Name}`.

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -410,7 +410,7 @@ class TestSearchTemplate(unittest.TestCase):
         m = pattern.match('ex!mple')
         self.assertTrue(m is None)
 
-    def test_unicode_short_properties_letters(self):
+    def test_inverse_unicode_short_properties_letters(self):
         """Exercise the inverse Unicode shortened properties for letters."""
 
         pattern = bre.compile_search(r'ex\PLmple', re.UNICODE)
@@ -419,7 +419,7 @@ class TestSearchTemplate(unittest.TestCase):
         m = pattern.match('exámple')
         self.assertTrue(m is None)
 
-    def test_unicode_short_properties_in_char_group(self):
+    def test_inverse_unicode_short_properties_in_char_group(self):
         """Exercise the inverse Unicode shortened properties inside a character group."""
 
         pattern = bre.compile_search(r'ex[\PL]mple', re.UNICODE)

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -371,7 +371,7 @@ class TestSearchTemplate(unittest.TestCase):
         pattern = bre.compile_search(r'EX\p{Lu}MPLE', re.UNICODE)
         m = pattern.match(r'EXÁMPLE')
         self.assertTrue(m is not None)
-        m = pattern.match(r'exámple')
+        m = pattern.match(r'EXáMPLE')
         self.assertTrue(m is None)
 
     def test_unicode_properties_lower(self):
@@ -380,7 +380,7 @@ class TestSearchTemplate(unittest.TestCase):
         pattern = bre.compile_search(r'ex\p{Ll}mple', re.UNICODE)
         m = pattern.match('exámple')
         self.assertTrue(m is not None)
-        m = pattern.match('EXÁMPLE')
+        m = pattern.match('exÁmple')
         self.assertTrue(m is None)
 
     def test_unicode_properties_in_char_group(self):
@@ -391,6 +391,42 @@ class TestSearchTemplate(unittest.TestCase):
         self.assertTrue(m is not None)
         m = pattern.match('exÁmple')
         self.assertTrue(m is not None)
+
+    def test_unicode_short_properties_letters(self):
+        """Exercise the Unicode shortened properties for letters."""
+
+        pattern = bre.compile_search(r'ex\pLmple', re.UNICODE)
+        m = pattern.match('exámple')
+        self.assertTrue(m is not None)
+        m = pattern.match('ex!mple')
+        self.assertTrue(m is None)
+
+    def test_unicode_short_properties_in_char_group(self):
+        """Exercise the Unicode shortened properties inside a character group."""
+
+        pattern = bre.compile_search(r'ex[\pL]mple', re.UNICODE)
+        m = pattern.match('exámple')
+        self.assertTrue(m is not None)
+        m = pattern.match('ex!mple')
+        self.assertTrue(m is None)
+
+    def test_unicode_short_properties_letters(self):
+        """Exercise the inverse Unicode shortened properties for letters."""
+
+        pattern = bre.compile_search(r'ex\PLmple', re.UNICODE)
+        m = pattern.match('ex!mple')
+        self.assertTrue(m is not None)
+        m = pattern.match('exámple')
+        self.assertTrue(m is None)
+
+    def test_unicode_short_properties_in_char_group(self):
+        """Exercise the inverse Unicode shortened properties inside a character group."""
+
+        pattern = bre.compile_search(r'ex[\PL]mple', re.UNICODE)
+        m = pattern.match('ex!mple')
+        self.assertTrue(m is not None)
+        m = pattern.match('exÁmple')
+        self.assertTrue(m is None)
 
     def test_unicode_properties_names(self):
         """Test Unicode group friendly names."""
@@ -1530,6 +1566,14 @@ class TestExceptions(unittest.TestCase):
 
         with self.assertRaises(ValueError) as e:
             bre.compile_search(r'\p{alphanumeric: bad}', re.UNICODE)
+
+        self.assertTrue(str(e), 'Invalid Unicode property!')
+
+    def test_bad_short_category(self):
+        """Test bad category."""
+
+        with self.assertRaises(ValueError) as e:
+            bre.compile_search(r'\pQ', re.UNICODE)
 
         self.assertTrue(str(e), 'Invalid Unicode property!')
 


### PR DESCRIPTION
Add support for \pP and \PP (inverse). Also fix a case where an invalid general category could return no characters.