### PR TITLE
Bug/better search template

### DIFF
--- a/backrefs/bre.py
+++ b/backrefs/bre.py
@@ -393,7 +393,7 @@ class SearchTokens(compat.Tokens):
             if text == self._uni_prop:
                 raise SyntaxError('Format for Unicode property is \\p{property} or \\pP!')
             elif text == self._inverse_uni_prop:
-                raise SyntaxError('Format for inverse Unicode property is \\P{property} or \\pP!')
+                raise SyntaxError('Format for inverse Unicode property is \\P{property} or \\PP!')
             self.index = m.end(0)
             self.current = text
             text = text[1:]

--- a/backrefs/bre.py
+++ b/backrefs/bre.py
@@ -838,7 +838,6 @@ class SearchTemplate(object):
         self._rc_bracket = ctokens["rc_bracket"]
         self._unicode_flag = ctokens["unicode_flag"]
         self._ascii_flag = tokens["ascii_flag"]
-        self._esc_end = ctokens["esc_end"]
         self._end = ctokens["end"]
         self._re_property_strip = tokens['re_property_strip']
         self._re_property_gc = tokens.get('re_property_gc', None)
@@ -868,7 +867,6 @@ class SearchTemplate(object):
             self._lc, self._lc_span, self._uc,
             self._uc_span, self._uni_prop, self._inverse_uni_prop, self._unicode_name
         )
-        self.extended = []
 
     def process_quotes(self, string):
         """Process quotes."""

--- a/backrefs/bre.py
+++ b/backrefs/bre.py
@@ -112,7 +112,7 @@ _UNAME = r'N(?:\{[\w ]+\})?'
 utokens = {
     "re_posix": re.compile(r'(?i)\[:(?:\\.|[^\\:}]+)+:\]'),
     "re_comments": re.compile(r'\(\?\#[^)]*\)'),
-    "re_uniprops": re.compile(r'(?:p|P)(?:\{(?:\\.|[^\\}]+)+\}|[a-zA-Z])?'),
+    "re_uniprops": re.compile(r'(?:p|P)(?:\{(?:\\.|[^\\}]+)+\}|[A-Z])?'),
     "re_named_props": re.compile(r'N(?:\{[\w ]+\})?'),
     "property_amp": '&',
     "property_c": 'c',
@@ -159,8 +159,7 @@ utokens = {
     "ascii_lower": 'lower',
     "ascii_upper": 'upper',
     "re_flags": re.compile(r'\(\?([aiLmsux]+)\)' if compat.PY3 else r'\(\?([iLmsux]+)\)'),
-    "ascii_flag": "a",
-    "long_search_refs": ("p", "P", "N")
+    "ascii_flag": "a"
 }
 
 # Byte string related references
@@ -208,8 +207,7 @@ btokens = {
     "ascii_lower": b"lower",
     "ascii_upper": b"upper",
     "re_flags": re.compile(br'\(\?([aiLmsux]+)\)' if compat.PY3 else br'\(\?([iLmsux]+)\)'),
-    "ascii_flag": b"a",
-    "long_search_refs": tuple()
+    "ascii_flag": b"a"
 }
 
 
@@ -318,7 +316,6 @@ class SearchTokens(compat.Tokens):
         self.string = string
         self._re_uniprops = tokens["re_uniprops"]
         self._re_named_props = tokens["re_named_props"]
-        self._long_search_refs = tokens["long_search_refs"]
         self._re_posix = tokens["re_posix"]
         self._unicode_name = ctokens["unicode_name"]
         self._re_flags = tokens["re_flags"]
@@ -862,7 +859,6 @@ class SearchTemplate(object):
         self._nl = ctokens["nl"]
         self._lr_bracket = ctokens["lr_bracket"]
         self._rr_bracket = ctokens["rr_bracket"]
-        self._question = ctokens["question"]
         self._hashtag = ctokens["hashtag"]
         self._unicode_name = ctokens["unicode_name"]
         self.search = search

--- a/backrefs/bre.py
+++ b/backrefs/bre.py
@@ -877,29 +877,26 @@ class SearchTemplate(object):
         quoted = []
         i = SearchTokens(string)
         iter(i)
-        try:
-            for t in i:
-                if not escaped and t == self._b_slash:
-                    escaped = True
-                elif escaped:
-                    escaped = False
-                    if t == self._end:
-                        if in_quotes:
-                            current.append(escape(self._empty.join(quoted)))
-                            quoted = []
-                            in_quotes = False
-                    elif t == self._quote and not in_quotes:
-                        in_quotes = True
-                    elif in_quotes:
-                        quoted.extend([self._b_slash, t])
-                    else:
-                        current.extend([self._b_slash, t])
+        for t in i:
+            if not escaped and t == self._b_slash:
+                escaped = True
+            elif escaped:
+                escaped = False
+                if t == self._end:
+                    if in_quotes:
+                        current.append(escape(self._empty.join(quoted)))
+                        quoted = []
+                        in_quotes = False
+                elif t == self._quote and not in_quotes:
+                    in_quotes = True
                 elif in_quotes:
-                    quoted.extend(t)
+                    quoted.extend([self._b_slash, t])
                 else:
-                    current.append(t)
-        except StopIteration:
-            pass
+                    current.extend([self._b_slash, t])
+            elif in_quotes:
+                quoted.extend(t)
+            else:
+                current.append(t)
 
         if in_quotes and escaped:
             quoted.append(self._b_slash)
@@ -1226,8 +1223,6 @@ class SearchTemplate(object):
             self.verbose = self.live_verbose
             self.unicode = self.live_unicode
             self.ascii = self.live_ascii
-        except StopIteration:
-            pass
         except Exception as e:
             if self.flags_updated:
                 retry = True
@@ -1247,11 +1242,9 @@ class SearchTemplate(object):
 
             i = SearchTokens(string)
             iter(i)
-            try:
-                for t in i:
-                    new_pattern.extend(self.normal(t, i))
-            except StopIteration:
-                pass
+            for t in i:
+                new_pattern.extend(self.normal(t, i))
+
         return self._empty.join(new_pattern)
 
 

--- a/backrefs/bre.py
+++ b/backrefs/bre.py
@@ -1223,7 +1223,7 @@ class SearchTemplate(object):
             self.verbose = self.live_verbose
             self.unicode = self.live_unicode
             self.ascii = self.live_ascii
-        except Exception as e:
+        except Exception as e:  # pragma: no cover
             if self.flags_updated:
                 retry = True
                 self.verbose = self.live_verbose

--- a/backrefs/bre.py
+++ b/backrefs/bre.py
@@ -111,7 +111,7 @@ _UNAME = r'N(?:\{[\w ]+\})?'
 # Unicode string related references
 utokens = {
     "re_posix": re.compile(r'(?i)\[:(?:\\.|[^\\:}]+)+:\]'),
-    "re_comments": re.compile(r'\(\?\#[^)]\)'),
+    "re_comments": re.compile(r'\(\?\#[^)]*\)'),
     "re_uniprops": re.compile(r'(?:p|P)(?:\{(?:\\.|[^\\}]+)+\}|[a-zA-Z])?'),
     "re_named_props": re.compile(r'N(?:\{[\w ]+\})?'),
     "property_amp": '&',
@@ -384,7 +384,7 @@ class SearchTokens(compat.Tokens):
         return text
 
     def get_unicode_property(self):
-        """Get Unicode properites."""
+        """Get Unicode properties."""
 
         text = None
         m = self._re_uniprops.match(self.string, self.index - 1)
@@ -995,7 +995,7 @@ class SearchTemplate(object):
         return current
 
     def parens(self, t, i):
-        """Hanlde parenthesis."""
+        """Handle parenthesis."""
 
         current = []
 

--- a/backrefs/bregex.py
+++ b/backrefs/bregex.py
@@ -635,7 +635,7 @@ if REGEX_SUPPORT:
                 retry = True
                 self.version = self.live_version
                 self.verbose = self.live_verbose
-            except Exception as e:
+            except Exception as e:  # pragma: no cover
                 if self.flags_updated:
                     retry = True
                     self.version = self.live_version

--- a/backrefs/bregex.py
+++ b/backrefs/bregex.py
@@ -393,29 +393,26 @@ if REGEX_SUPPORT:
             quoted = []
             i = RegexSearchTokens(string)
             iter(i)
-            try:
-                for t in i:
-                    if not escaped and t == self._b_slash:
-                        escaped = True
-                    elif escaped:
-                        escaped = False
-                        if t == self._end:
-                            if in_quotes:
-                                current.append(escape(self._empty.join(quoted)))
-                                quoted = []
-                                in_quotes = False
-                        elif t == self._quote and not in_quotes:
-                            in_quotes = True
-                        elif in_quotes:
-                            quoted.extend([self._b_slash, t])
-                        else:
-                            current.extend([self._b_slash, t])
+            for t in i:
+                if not escaped and t == self._b_slash:
+                    escaped = True
+                elif escaped:
+                    escaped = False
+                    if t == self._end:
+                        if in_quotes:
+                            current.append(escape(self._empty.join(quoted)))
+                            quoted = []
+                            in_quotes = False
+                    elif t == self._quote and not in_quotes:
+                        in_quotes = True
                     elif in_quotes:
-                        quoted.extend(t)
+                        quoted.extend([self._b_slash, t])
                     else:
-                        current.append(t)
-            except StopIteration:
-                pass
+                        current.extend([self._b_slash, t])
+                elif in_quotes:
+                    quoted.extend(t)
+                else:
+                    current.append(t)
 
             if in_quotes and escaped:
                 quoted.append(self._b_slash)
@@ -638,8 +635,6 @@ if REGEX_SUPPORT:
                 retry = True
                 self.version = self.live_version
                 self.verbose = self.live_verbose
-            except StopIteration:
-                pass
             except Exception as e:
                 if self.flags_updated:
                     retry = True
@@ -654,11 +649,8 @@ if REGEX_SUPPORT:
 
                 i = RegexSearchTokens(string)
                 iter(i)
-                try:
-                    for t in i:
-                        new_pattern.extend(self.normal(t, i))
-                except StopIteration:
-                    pass
+                for t in i:
+                    new_pattern.extend(self.normal(t, i))
             return self._empty.join(new_pattern)
 
     class ReplaceTemplate(object):

--- a/backrefs/common_tokens.py
+++ b/backrefs/common_tokens.py
@@ -29,6 +29,9 @@ utokens = {
     "group": "g",
     "lc_bracket": "{",
     "rc_bracket": "}",
+    "lr_bracket": "(",
+    "rr_bracket": ")",
+    "question": "?",
     "group_start": r"\g<",
     "group_end": ">",
     "format_replace_group": re.compile(
@@ -70,6 +73,9 @@ btokens = {
     "group": b"g",
     "lc_bracket": b"{",
     "rc_bracket": b"}",
+    "lr_bracket": b"(",
+    "rr_bracket": b")",
+    "question": b"?",
     "group_start": br"\g<",
     "group_end": b">",
     "format_replace_group": re.compile(

--- a/backrefs/common_tokens.py
+++ b/backrefs/common_tokens.py
@@ -31,7 +31,6 @@ utokens = {
     "rc_bracket": "}",
     "lr_bracket": "(",
     "rr_bracket": ")",
-    "question": "?",
     "group_start": r"\g<",
     "group_end": ">",
     "format_replace_group": re.compile(
@@ -75,7 +74,6 @@ btokens = {
     "rc_bracket": b"}",
     "lr_bracket": b"(",
     "rr_bracket": b")",
-    "question": b"?",
     "group_start": br"\g<",
     "group_end": b">",
     "format_replace_group": re.compile(

--- a/backrefs/compat.py
+++ b/backrefs/compat.py
@@ -14,16 +14,6 @@ if PY3:
     binary_type = bytes
     unichar = chr
 
-    def iterstring(string):
-        """Iterate through a string."""
-
-        if isinstance(string, binary_type):
-            for x in range(0, len(string)):
-                yield string[x:x + 1]
-        else:
-            for c in string:
-                yield c
-
     class Tokens(object):
         """Tokens base for Python 3."""
 
@@ -39,12 +29,6 @@ else:
     string_type = unicode  # noqa F821
     binary_type = str  # noqa F821
     unichar = unichr  # noqa F821
-
-    def iterstring(string):
-        """Iterate through a string."""
-
-        for c in string:
-            yield c
 
     class Tokens(object):
         """Tokens base for Python 2."""

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -42,6 +42,12 @@ class TestSearchTemplate(unittest.TestCase):
         pattern = bre.compile_search(r'(?x)test # \l \p{numbers}', re.UNICODE)
         self.assertEqual(pattern.pattern, r'(?x)test # \\l \\p{numbers}', re.UNICODE)
 
+    def test_char_group_nested_opening(self):
+        """Test char group with nested opening [."""
+
+        pattern = bre.compile_search(r'test [[] \N{black club suit}', re.UNICODE)
+        self.assertEqual(pattern.pattern, 'test [[] \u2663', re.UNICODE)
+
     def test_inline_comments(self):
         """Test that we properly find inline comments and avoid them."""
         pattern = bre.compile_search(r'test(?#\l\p{^IsLatin})', re.UNICODE)

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -6,6 +6,7 @@ from backrefs import bre
 import re
 import sys
 import pytest
+import sre_constants
 
 PY3 = (3, 0) <= sys.version_info < (4, 0)
 PY36_PLUS = (3, 6) <= sys.version_info
@@ -132,12 +133,6 @@ class TestSearchTemplate(unittest.TestCase):
 
         pattern = bre.compile_search(r'Test [:graph:]]')
         self.assertEqual(pattern.pattern, r'Test [:graph:]]')
-
-    def test_not_posix_at_end_group(self):
-        """Test a situation that is not a POSIX at the end of a group."""
-
-        pattern = bre.compile_search(r'Test [[:graph:]')
-        self.assertEqual(pattern.pattern, r'Test [[:graph:]')
 
     def test_ascii_upper_props(self):
         """Test ASCII uppercase properties."""
@@ -1520,6 +1515,14 @@ class TestExceptions(unittest.TestCase):
     #     with self.assertRaises(SyntaxError) as e:
     #         bre.compile_replace(p, r'Replace \U fail!')
     #     self.assertTrue(str(e), 'Format for wide Unicode is \\UXXXXXXXX!')
+
+    def test_not_posix_at_end_group(self):
+        """Test a situation that is not a POSIX at the end of a group."""
+
+        with pytest.raises(sre_constants.error) as excinfo:
+            pattern = bre.compile_search(r'Test [[:graph:]')
+        print(str(excinfo))
+        self.assertTrue('unterminated' in str(excinfo))
 
     def test_incomplete_replace_unicode_name(self):
         """Test incomplete replace with Unicode name."""

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -21,6 +21,28 @@ else:
 class TestSearchTemplate(unittest.TestCase):
     """Search template tests."""
 
+    def test_comments(self):
+        """Test comments v0."""
+
+        pattern = bre.compile_search(
+            r'''(?xu)
+            Test # \p{XDigit}
+            (Test (?#\p{XDigit}))
+            Test \p{XDigit}
+            '''
+        )
+
+        self.assertEqual(
+            pattern.pattern,
+            r'''(?xu)
+            Test # \\p{XDigit}
+            (Test (?#\p{XDigit}))
+            Test [0-9A-Fa-f]
+            '''
+        )
+
+        self.assertTrue(pattern.match('TestTestTestA') is not None)
+
     def test_trailing_bslash(self):
         """Test trailing back slash."""
 

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -21,6 +21,13 @@ else:
 class TestSearchTemplate(unittest.TestCase):
     """Search template tests."""
 
+    def test_inline_comments(self):
+        """Test that we properly find inline comments and avoid them."""
+        pattern = bre.compile_search(r'test(?#\l\p{^IsLatin})', re.UNICODE)
+        m = pattern.match('test')
+        self.assertEqual(pattern.pattern, r'test(?#\l\p{^IsLatin})')
+        self.assertTrue(m is not None)
+
     def test_unicode_name(self):
         """Test Unicode block."""
 

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -21,6 +21,27 @@ else:
 class TestSearchTemplate(unittest.TestCase):
     """Search template tests."""
 
+    def test_trailing_bslash(self):
+        """Test trailing back slash."""
+
+        with pytest.raises(sre_constants.error):
+            pattern = bre.compile_search('test\\', re.UNICODE)
+
+        with pytest.raises(sre_constants.error):
+            pattern = bre.compile_search('test[\\', re.UNICODE)
+
+        with pytest.raises(sre_constants.error):
+            pattern = bre.compile_search('test(\\', re.UNICODE)
+
+        pattern = bre.compile_search('\\Qtest\\', re.UNICODE)
+        self.assertEqual(pattern.pattern, 'test\\\\')
+
+    def test_escape_values_in_verbose_comments(self):
+        """Test added escapes in verbose comments."""
+
+        pattern = bre.compile_search(r'(?x)test # \l \p{numbers}', re.UNICODE)
+        self.assertEqual(pattern.pattern, r'(?x)test # \\l \\p{numbers}', re.UNICODE)
+
     def test_inline_comments(self):
         """Test that we properly find inline comments and avoid them."""
         pattern = bre.compile_search(r'test(?#\l\p{^IsLatin})', re.UNICODE)

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -1412,88 +1412,87 @@ class TestExceptions(unittest.TestCase):
 
         with pytest.raises(sre_constants.error) as excinfo:
             bre.compile_search(r'Test [[:graph:]')
-        print(str(excinfo))
-        self.assertTrue('unterminated' in str(excinfo))
+        self.assertTrue(excinfo is not None)
 
     def test_incomplete_replace_unicode_name(self):
         """Test incomplete replace with Unicode name."""
 
         p = bre.compile_search(r'test')
-        with self.assertRaises(SyntaxError) as e:
+        with pytest.raises(SyntaxError) as e:
             bre.compile_replace(p, r'Replace \N fail!')
-        self.assertTrue(str(e), 'Format for Unicode name is \\N{name}!')
+        self.assertEqual(str(e.value), 'Format for Unicode name is \\N{name}!')
 
     def test_incomplete_replace_group(self):
         """Test incomplete replace group."""
 
         p = bre.compile_search(r'test')
-        with self.assertRaises(SyntaxError) as e:
+        with pytest.raises(SyntaxError) as e:
             bre.compile_replace(p, r'Replace \g fail!')
-        self.assertTrue(str(e), 'Format for group is \\g<group_name_or_index>!')
+        self.assertEqual(str(e.value), 'Format for group is \\g<group_name_or_index>!')
 
     def test_incomplete_replace_byte(self):
         """Test incomplete byte group."""
 
         p = bre.compile_search(r'test')
-        with self.assertRaises(SyntaxError) as e:
+        with pytest.raises(SyntaxError) as e:
             bre.compile_replace(p, r'Replace \x fail!')
-        self.assertTrue(str(e), 'Format for byte is \\xXX!')
+        self.assertEqual(str(e.value), 'Format for byte is \\xXX!')
 
     def test_bad_posix(self):
         """Test bad posix."""
 
-        with self.assertRaises(ValueError) as e:
+        with pytest.raises(ValueError) as e:
             bre.compile_search(r'[[:bad:]]', re.UNICODE)
 
-        self.assertTrue(str(e), 'Invalid POSIX property!')
+        self.assertEqual(str(e.value), 'Invalid POSIX property!')
 
     def test_bad_binary(self):
         """Test bad binary."""
 
-        with self.assertRaises(ValueError) as e:
+        with pytest.raises(ValueError) as e:
             bre.compile_search(r'\p{bad_binary:n}', re.UNICODE)
 
-        self.assertTrue(str(e), 'Invalid Unicode property!')
+        self.assertEqual(str(e.value), 'Invalid Unicode property!')
 
     def test_bad_category(self):
         """Test bad category."""
 
-        with self.assertRaises(ValueError) as e:
+        with pytest.raises(ValueError) as e:
             bre.compile_search(r'\p{alphanumeric: bad}', re.UNICODE)
 
-        self.assertTrue(str(e), 'Invalid Unicode property!')
+        self.assertEqual(str(e.value), 'Invalid Unicode property!')
 
     def test_bad_short_category(self):
         """Test bad category."""
 
-        with self.assertRaises(ValueError) as e:
+        with pytest.raises(ValueError) as e:
             bre.compile_search(r'\pQ', re.UNICODE)
 
-        self.assertTrue(str(e), 'Invalid Unicode property!')
+        self.assertEqual(str(e.value), 'Invalid Unicode property!')
 
     def test_incomplete_inverse_category(self):
         """Test incomplete inverse category."""
 
-        with self.assertRaises(SyntaxError) as e:
+        with pytest.raises(SyntaxError) as e:
             bre.compile_search(r'\p', re.UNICODE)
 
-        self.assertTrue(str(e), 'Format for inverse Unicode property is \\P{property}!')
+        self.assertEqual(str(e.value), 'Format for Unicode property is \\p{property} or \\pP!')
 
     def test_incomplete_category(self):
         """Test incomplete category."""
 
-        with self.assertRaises(SyntaxError) as e:
+        with pytest.raises(SyntaxError) as e:
             bre.compile_search(r'\P', re.UNICODE)
 
-        self.assertTrue(str(e), 'Format for Unicode property is \\p{property}!')
+        self.assertEqual(str(e.value), 'Format for inverse Unicode property is \\P{property} or \\PP!')
 
     def test_incomplete_unicode_name(self):
         """Test incomplete Unicode name."""
 
-        with self.assertRaises(SyntaxError) as e:
+        with pytest.raises(SyntaxError) as e:
             bre.compile_search(r'\N', re.UNICODE)
 
-        self.assertTrue(str(e), 'Format for Unicode name is \\N{name}!')
+        self.assertEqual(str(e.value), 'Format for Unicode name is \\N{name}!')
 
     def test_bad_left_format_bracket(self):
         """Test bad left format bracket."""

--- a/tests/test_bregex.py
+++ b/tests/test_bregex.py
@@ -19,6 +19,54 @@ else:
 class TestSearchTemplate(unittest.TestCase):
     """Search template tests."""
 
+    def test_comments_v0(self):
+        """Test comments v0."""
+
+        pattern = bregex.compile_search(
+            r'''(?uV0)Test # \R(?#\R\)(?x:
+            Test #\R(?#\R\)
+            (Test # \R
+            )Test #\R
+            )Test # \R'''
+        )
+
+        self.assertEqual(
+            pattern.pattern,
+            r'''(?uV0)Test # (?>\r\n|\n|\x0b|\f|\r|\x85|\u2028|\u2029)(?#\R\)(?x:
+            Test #\\R(?#\\R\)
+            (Test # \\R
+            )Test #\\R
+            )Test # (?>\r\n|\n|\x0b|\f|\r|\x85|\u2028|\u2029)'''
+        )
+
+        self.assertTrue(pattern.match('Test # \nTestTestTestTest # \n') is not None)
+
+    def test_comments_v1(self):
+        """Test comments v1."""
+
+        pattern = bregex.compile_search(
+            r'''(?xuV1)
+            Test # \R
+            (?-x:Test #\R(?#\R\)((?x)
+            Test # \R
+            )Test #\R)
+            Test # \R
+            '''
+        )
+
+        self.assertEqual(
+            pattern.pattern,
+            r'''(?xuV1)
+            Test # \\R
+            (?-x:Test #(?>\r\n|\n|\x0b|\f|\r|\x85|\u2028|\u2029)(?#\R\)((?x)
+            Test # \\R
+            )Test #(?>\r\n|\n|\x0b|\f|\r|\x85|\u2028|\u2029))
+            Test # \\R
+            '''
+        )
+
+        self.assertTrue(pattern.match('TestTest #\nTestTest #\nTest') is not None)
+
     def test_trailing_bslash(self):
         """Test trailing back slash."""
 

--- a/tests/test_bregex.py
+++ b/tests/test_bregex.py
@@ -6,6 +6,7 @@ from backrefs import bregex
 import regex
 import sys
 import pytest
+import _regex_core
 
 PY3 = (3, 0) <= sys.version_info < (4, 0)
 
@@ -17,6 +18,27 @@ else:
 
 class TestSearchTemplate(unittest.TestCase):
     """Search template tests."""
+
+    def test_trailing_bslash(self):
+        """Test trailing back slash."""
+
+        with pytest.raises(_regex_core.error):
+            pattern = bregex.compile_search('test\\', regex.UNICODE)
+
+        with pytest.raises(_regex_core.error):
+            pattern = bregex.compile_search('test[\\', regex.UNICODE)
+
+        with pytest.raises(_regex_core.error):
+            pattern = bregex.compile_search('test(\\', regex.UNICODE)
+
+        pattern = bregex.compile_search('\\Qtest\\', regex.UNICODE)
+        self.assertEqual(pattern.pattern, 'test\\\\')
+
+    def test_escape_values_in_verbose_comments(self):
+        """Test added escapes in verbose comments."""
+
+        pattern = bregex.compile_search(r'(?x)test # \R', regex.UNICODE)
+        self.assertEqual(pattern.pattern, r'(?x)test # \\R', regex.UNICODE)
 
     def test_inline_comments(self):
         """Test that we properly find inline comments and avoid them."""

--- a/tests/test_bregex.py
+++ b/tests/test_bregex.py
@@ -40,6 +40,21 @@ class TestSearchTemplate(unittest.TestCase):
         pattern = bregex.compile_search(r'(?x)test # \R', regex.UNICODE)
         self.assertEqual(pattern.pattern, r'(?x)test # \\R', regex.UNICODE)
 
+    def test_char_group_nested_opening(self):
+        """Test char group with nested opening [."""
+
+        pattern = bregex.compile_search(r'test [[] \R', regex.UNICODE)
+        self.assertEqual(pattern.pattern, r'test [[] (?>\r\n|\n|\x0b|\f|\r|\x85|\u2028|\u2029)', regex.UNICODE)
+
+    def test_posix_parse(self):
+        """Test posix in a group."""
+
+        pattern = bregex.compile_search(r'test [[:graph:]] \R', regex.V0)
+        self.assertNotEqual(pattern.pattern, r'test [[:graph:]] (?>\r\n|\n|\x0b|\f|\r|\x85|\u2028|\u2029)')
+
+        pattern = bregex.compile_search(r'test [[:graph:]] \R', regex.V1)
+        self.assertNotEqual(pattern.pattern, r'test [[:graph:]] (?>\r\n|\n|\x0b|\f|\r|\x85|\u2028|\u2029)')
+
     def test_inline_comments(self):
         """Test that we properly find inline comments and avoid them."""
         pattern = bregex.compile_search(r'test(?#\l\p{^IsLatin})', regex.UNICODE)


### PR DESCRIPTION
This addresses general search template preprocessing issues:

- `\Q...\E` is applied first and does not care about comments, character groups, etc.
- Better parsing that is aware of normal comments (`(?#comment)`) and verbose comments (`# comment`).
- Preprocesser will better capture things like `[[:ascii:]]` when accounting for group boundaries.
- Unicode property form `\pX` requires `X` to be an uppercase letter.

Still more testing needs to be done to increase confidence in changes, and code coverage should be brought back up.