### PR TITLE
Byte string properties and named characters

### DIFF
--- a/backrefs/bre.py
+++ b/backrefs/bre.py
@@ -1161,7 +1161,7 @@ class SearchTemplate(object):
                 pattern = uniprops.get_posix_property(prop, uniprops.POSIX_UNICODE)
         except Exception:
             raise ValueError('Invalid POSIX property!')
-        if not in_group and not pattern:
+        if not in_group and not pattern:  # pragma: no cover
             pattern = '^%s' % ('\x00-\xff' if self.binary else uniprops.UNICODE_RANGE)
 
         return [pattern]

--- a/backrefs/bregex.py
+++ b/backrefs/bregex.py
@@ -177,8 +177,7 @@ if REGEX_SUPPORT:
         "binary_re_line_break": r'(?>\r\n|\n|\x0b|\f|\r|\x85)',
         "v0": 'V0',
         "v1": 'V1',
-        "new_refs": ("e", "R", "Q", "E"),
-        "binary_new_refs": ("e", "R", "Q", "E")
+        "new_refs": ("e", "R", "Q", "E")
     }
 
     class RetryException(Exception):
@@ -400,10 +399,9 @@ if REGEX_SUPPORT:
             self._V1 = tokens["v1"]
             if self.binary:
                 self._re_line_break = tokens["binary_re_line_break"]
-                self._new_refs = tokens["binary_new_refs"]
             else:
-                self._new_refs = tokens["new_refs"]
                 self._re_line_break = tokens["re_line_break"]
+            self._new_refs = tokens["new_refs"]
             self._verbose_off = tokens["verbose_off"]
             self.re_verbose = re_verbose
             self.re_version = re_version

--- a/backrefs/uniprops/__init__.py
+++ b/backrefs/uniprops/__init__.py
@@ -3,6 +3,12 @@ from __future__ import unicode_literals
 from . import unidata
 import sys
 
+NARROW = sys.maxunicode == 0xFFFF
+if NARROW:
+    UNICODE_RANGE = '\u0000-\uffff'
+else:
+    UNICODE_RANGE = '\u0000-\U0010ffff'
+
 PY3 = sys.version_info >= (3, 0) and sys.version_info[0:2] < (4, 0)
 if PY3:
     binary_type = bytes  # noqa
@@ -18,17 +24,19 @@ def get_posix_property(value, mode=POSIX):
     """Retrieve the posix category."""
 
     if mode == POSIX_BINARY:
-        return unidata.bposix_properties[value]
+        return unidata.ascii_posix_properties[value]
     elif mode == POSIX_UNICODE:
         return unidata.unicode_binary[
             ('^posix' + value[1:]) if value.startswith('^') else ('posix' + value)
         ]
     else:
-        return unidata.posix_properties[value]
+        return unidata.unicode_posix_properties[value]
 
 
-def get_gc_property(value):
+def get_gc_property(value, binary=False):
     """Get `GC` property."""
+
+    obj = unidata.ascii_properties if binary else unidata.unicode_properties
 
     if value.startswith('^'):
         negate = True
@@ -43,17 +51,19 @@ def get_gc_property(value):
     if not negate:
         p1, p2 = (value[0], value[1]) if len(value) > 1 else (value[0], None)
         value = ''.join(
-            [v for k, v in unidata.unicode_properties.get(p1, {}).items() if not k.startswith('^')]
-        ) if p2 is None else unidata.unicode_properties.get(p1, {}).get(p2, '')
+            [v for k, v in obj.get(p1, {}).items() if not k.startswith('^')]
+        ) if p2 is None else obj.get(p1, {}).get(p2, '')
     else:
         p1, p2 = (value[0], value[1]) if len(value) > 1 else (value[0], '')
-        value = unidata.unicode_properties.get(p1, {}).get('^' + p2, '')
+        value = obj.get(p1, {}).get('^' + p2, '')
     assert value, 'Invalid property!'
     return value
 
 
-def get_binary_property(value):
+def get_binary_property(value, binary=False):
     """Get `BINARY` property."""
+
+    obj = unidata.ascii_binary if binary else unidata.unicode_binary
 
     if value.startswith('^'):
         negated = value[1:]
@@ -61,11 +71,13 @@ def get_binary_property(value):
     else:
         value = unidata.unicode_alias['binary'].get(value, value)
 
-    return unidata.unicode_binary[value]
+    return obj[value]
 
 
-def get_canonical_combining_class_property(value):
+def get_canonical_combining_class_property(value, binary=False):
     """Get `CANONICAL COMBINING CLASS` property."""
+
+    obj = unidata.ascii_canonical_combining_class if binary else unidata.unicode_canonical_combining_class
 
     if value.startswith('^'):
         negated = value[1:]
@@ -73,11 +85,13 @@ def get_canonical_combining_class_property(value):
     else:
         value = unidata.unicode_alias['canonicalcombiningclass'].get(value, value)
 
-    return unidata.uniocde_canonical_combining_class[value]
+    return obj[value]
 
 
-def get_east_asian_width_property(value):
+def get_east_asian_width_property(value, binary=False):
     """Get `EAST ASIAN WIDTH` property."""
+
+    obj = unidata.ascii_east_asian_width if binary else unidata.unicode_east_asian_width
 
     if value.startswith('^'):
         negated = value[1:]
@@ -85,11 +99,13 @@ def get_east_asian_width_property(value):
     else:
         value = unidata.unicode_alias['eastasianwidth'].get(value, value)
 
-    return unidata.unicode_east_asian_width[value]
+    return obj[value]
 
 
-def get_grapheme_cluster_break_property(value):
+def get_grapheme_cluster_break_property(value, binary=False):
     """Get `GRAPHEME CLUSTER BREAK` property."""
+
+    obj = unidata.ascii_grapheme_cluster_break if binary else unidata.unicode_grapheme_cluster_break
 
     if value.startswith('^'):
         negated = value[1:]
@@ -97,11 +113,13 @@ def get_grapheme_cluster_break_property(value):
     else:
         value = unidata.unicode_alias['graphemeclusterbreak'].get(value, value)
 
-    return unidata.unicode_grapheme_cluster_break[value]
+    return obj[value]
 
 
-def get_line_break_property(value):
+def get_line_break_property(value, binary=False):
     """Get `LINE BREAK` property."""
+
+    obj = unidata.ascii_line_break if binary else unidata.unicode_line_break
 
     if value.startswith('^'):
         negated = value[1:]
@@ -109,11 +127,13 @@ def get_line_break_property(value):
     else:
         value = unidata.unicode_alias['linebreak'].get(value, value)
 
-    return unidata.unicode_line_break[value]
+    return obj[value]
 
 
-def get_sentence_break_property(value):
+def get_sentence_break_property(value, binary=False):
     """Get `SENTENCE BREAK` property."""
+
+    obj = unidata.ascii_sentence_break if binary else unidata.unicode_sentence_break
 
     if value.startswith('^'):
         negated = value[1:]
@@ -121,11 +141,13 @@ def get_sentence_break_property(value):
     else:
         value = unidata.unicode_alias['sentencebreak'].get(value, value)
 
-    return unidata.unicode_sentence_break[value]
+    return obj[value]
 
 
-def get_word_break_property(value):
+def get_word_break_property(value, binary=False):
     """Get `WORD BREAK` property."""
+
+    obj = unidata.ascii_word_break if binary else unidata.unicode_word_break
 
     if value.startswith('^'):
         negated = value[1:]
@@ -133,11 +155,13 @@ def get_word_break_property(value):
     else:
         value = unidata.unicode_alias['wordbreak'].get(value, value)
 
-    return unidata.unicode_word_break[value]
+    return obj[value]
 
 
-def get_hangul_syllable_type_property(value):
+def get_hangul_syllable_type_property(value, binary=False):
     """Get `HANGUL SYLLABLE TYPE` property."""
+
+    obj = unidata.ascii_hangul_syllable_type if binary else unidata.unicode_hangul_syllable_type
 
     if value.startswith('^'):
         negated = value[1:]
@@ -145,11 +169,13 @@ def get_hangul_syllable_type_property(value):
     else:
         value = unidata.unicode_alias['hangulsyllabletype'].get(value, value)
 
-    return unidata.unicode_hangul_syllable_type[value]
+    return obj[value]
 
 
-def get_decomposition_type_property(value):
+def get_decomposition_type_property(value, binary=False):
     """Get `DECOMPOSITION TYPE` property."""
+
+    obj = unidata.ascii_decomposition_type if binary else unidata.unicode_decomposition_type
 
     if value.startswith('^'):
         negated = value[1:]
@@ -157,11 +183,13 @@ def get_decomposition_type_property(value):
     else:
         value = unidata.unicode_alias['decompositiontype'].get(value, value)
 
-    return unidata.unicode_decomposition_type[value]
+    return obj[value]
 
 
-def get_nfc_quick_check_property(value):
+def get_nfc_quick_check_property(value, binary=False):
     """Get `NFC QUICK CHECK` property."""
+
+    obj = unidata.ascii_nfc_quick_check if binary else unidata.unicode_nfc_quick_check
 
     if value.startswith('^'):
         negated = value[1:]
@@ -169,11 +197,13 @@ def get_nfc_quick_check_property(value):
     else:
         value = unidata.unicode_alias['nfcquickcheck'].get(value, value)
 
-    return unidata.unicode_nfc_quick_check[value]
+    return obj[value]
 
 
-def get_nfd_quick_check_property(value):
+def get_nfd_quick_check_property(value, binary=False):
     """Get `NFD QUICK CHECK` property."""
+
+    obj = unidata.ascii_nfd_quick_check if binary else unidata.unicode_nfd_quick_check
 
     if value.startswith('^'):
         negated = value[1:]
@@ -181,11 +211,13 @@ def get_nfd_quick_check_property(value):
     else:
         value = unidata.unicode_alias['nfdquickcheck'].get(value, value)
 
-    return unidata.unicode_nfd_quick_check[value]
+    return obj[value]
 
 
-def get_nfkc_quick_check_property(value):
+def get_nfkc_quick_check_property(value, binary=False):
     """Get `NFKC QUICK CHECK` property."""
+
+    obj = unidata.ascii_nfkc_quick_check if binary else unidata.unicode_nfkc_quick_check
 
     if value.startswith('^'):
         negated = value[1:]
@@ -193,11 +225,13 @@ def get_nfkc_quick_check_property(value):
     else:
         value = unidata.unicode_alias['nfkcquickcheck'].get(value, value)
 
-    return unidata.unicode_nfkc_quick_check[value]
+    return obj[value]
 
 
-def get_nfkd_quick_check_property(value):
+def get_nfkd_quick_check_property(value, binary=False):
     """Get `NFKD QUICK CHECK` property."""
+
+    obj = unidata.ascii_nfkd_quick_check if binary else unidata.unicode_nfkd_quick_check
 
     if value.startswith('^'):
         negated = value[1:]
@@ -205,11 +239,13 @@ def get_nfkd_quick_check_property(value):
     else:
         value = unidata.unicode_alias['nfkdquickcheck'].get(value, value)
 
-    return unidata.unicode_nfkd_quick_check[value]
+    return obj[value]
 
 
-def get_numeric_type_property(value):
+def get_numeric_type_property(value, binary=False):
     """Get `NUMERIC TYPE` property."""
+
+    obj = unidata.ascii_numeric_type if binary else unidata.unicode_numeric_type
 
     if value.startswith('^'):
         negated = value[1:]
@@ -217,11 +253,13 @@ def get_numeric_type_property(value):
     else:
         value = unidata.unicode_alias['numerictype'].get(value, value)
 
-    return unidata.unicode_numeric_type[value]
+    return obj[value]
 
 
-def get_numeric_value_property(value):
+def get_numeric_value_property(value, binary=False):
     """Get `NUMERIC VALUE` property."""
+
+    obj = unidata.ascii_numeric_values if binary else unidata.unicode_numeric_values
 
     if value.startswith('^'):
         negated = value[1:]
@@ -229,11 +267,13 @@ def get_numeric_value_property(value):
     else:
         value = unidata.unicode_alias['numericvalue'].get(value, value)
 
-    return unidata.unicode_numeric_values[value]
+    return obj[value]
 
 
-def get_age_property(value):
+def get_age_property(value, binary=False):
     """Get `AGE` property."""
+
+    obj = unidata.ascii_age if binary else unidata.unicode_age
 
     if value.startswith('^'):
         negated = value[1:]
@@ -241,11 +281,13 @@ def get_age_property(value):
     else:
         value = unidata.unicode_alias['age'].get(value, value)
 
-    return unidata.unicode_age[value]
+    return obj[value]
 
 
-def get_joining_type_property(value):
+def get_joining_type_property(value, binary=False):
     """Get `JOINING TYPE` property."""
+
+    obj = unidata.ascii_joining_type if binary else unidata.unicode_joining_type
 
     if value.startswith('^'):
         negated = value[1:]
@@ -253,11 +295,13 @@ def get_joining_type_property(value):
     else:
         value = unidata.unicode_alias['joiningtype'].get(value, value)
 
-    return unidata.unicode_joining_type[value]
+    return obj[value]
 
 
-def get_joining_group_property(value):
+def get_joining_group_property(value, binary=False):
     """Get `JOINING GROUP` property."""
+
+    obj = unidata.ascii_joining_group if binary else unidata.unicode_joining_group
 
     if value.startswith('^'):
         negated = value[1:]
@@ -265,11 +309,13 @@ def get_joining_group_property(value):
     else:
         value = unidata.unicode_alias['joininggroup'].get(value, value)
 
-    return unidata.unicode_joining_group[value]
+    return obj[value]
 
 
-def get_script_property(value):
+def get_script_property(value, binary=False):
     """Get `SC` property."""
+
+    obj = unidata.ascii_scripts if binary else unidata.unicode_scripts
 
     if value.startswith('^'):
         negated = value[1:]
@@ -277,11 +323,13 @@ def get_script_property(value):
     else:
         value = unidata.unicode_alias['script'].get(value, value)
 
-    return unidata.unicode_scripts[value]
+    return obj[value]
 
 
-def get_block_property(value):
+def get_block_property(value, binary=False):
     """Get `BLK` property."""
+
+    obj = unidata.ascii_blocks if binary else unidata.unicode_blocks
 
     if value.startswith('^'):
         negated = value[1:]
@@ -289,11 +337,13 @@ def get_block_property(value):
     else:
         value = unidata.unicode_alias['block'].get(value, value)
 
-    return unidata.unicode_blocks[value]
+    return obj[value]
 
 
-def get_bidi_property(value):
+def get_bidi_property(value, binary=False):
     """Get `BC` property."""
+
+    obj = unidata.ascii_bidi_classes if binary else unidata.unicode_bidi_classes
 
     if value.startswith('^'):
         negated = value[1:]
@@ -301,7 +351,7 @@ def get_bidi_property(value):
     else:
         value = unidata.unicode_alias['bidiclass'].get(value, value)
 
-    return unidata.unicode_bidi_classes[value]
+    return obj[value]
 
 
 def is_enum(name):
@@ -310,56 +360,56 @@ def is_enum(name):
     return name in unidata.enum_names
 
 
-def get_unicode_property(value, prop=None):
+def get_unicode_property(value, prop=None, binary=False):
     """Retrieve the Unicode category from the table."""
 
     if prop is not None:
         prop = unidata.unicode_alias['_'].get(prop, prop)
         try:
             if prop == 'generalcategory':
-                return get_gc_property(value)
+                return get_gc_property(value, binary)
             elif prop == 'script':
-                return get_script_property(value)
+                return get_script_property(value, binary)
             elif prop == 'block':
-                return get_block_property(value)
+                return get_block_property(value, binary)
             elif prop == 'binary':
-                return get_binary_property(value)
+                return get_binary_property(value, binary)
             elif prop == 'bidiclass':
-                return get_bidi_property(value)
+                return get_bidi_property(value, binary)
             elif prop == 'age':
-                return get_age_property(value)
+                return get_age_property(value, binary)
             elif prop == 'eastasianwidth':
-                return get_east_asian_width_property(value)
+                return get_east_asian_width_property(value, binary)
             elif prop == 'hangulsyllabletype':
-                return get_hangul_syllable_type_property(value)
+                return get_hangul_syllable_type_property(value, binary)
             elif prop == 'decompositiontype':
-                return get_decomposition_type_property(value)
+                return get_decomposition_type_property(value, binary)
             elif prop == 'canonicalcombiningclass':
-                return get_canonical_combining_class_property(value)
+                return get_canonical_combining_class_property(value, binary)
             elif prop == 'numerictype':
-                return get_numeric_type_property(value)
+                return get_numeric_type_property(value, binary)
             elif prop == 'numericvalue':
-                return get_numeric_value_property(value)
+                return get_numeric_value_property(value, binary)
             elif prop == 'joiningtype':
-                return get_joining_type_property(value)
+                return get_joining_type_property(value, binary)
             elif prop == 'joininggroup':
-                return get_joining_group_property(value)
+                return get_joining_group_property(value, binary)
             elif prop == 'graphemeclusterbreak':
-                return get_grapheme_cluster_break_property(value)
+                return get_grapheme_cluster_break_property(value, binary)
             elif prop == 'linebreak':
-                return get_line_break_property(value)
+                return get_line_break_property(value, binary)
             elif prop == 'sentencebreak':
-                return get_sentence_break_property(value)
+                return get_sentence_break_property(value, binary)
             elif prop == 'wordbreak':
-                return get_word_break_property(value)
+                return get_word_break_property(value, binary)
             elif prop == 'nfcquickcheck':
-                return get_nfc_quick_check_property(value)
+                return get_nfc_quick_check_property(value, binary)
             elif prop == 'nfdquickcheck':
-                return get_nfd_quick_check_property(value)
+                return get_nfd_quick_check_property(value, binary)
             elif prop == 'nfkcquickcheck':
-                return get_nfkc_quick_check_property(value)
+                return get_nfkc_quick_check_property(value, binary)
             elif prop == 'nfkdquickcheck':
-                return get_nfkd_quick_check_property(value)
+                return get_nfkd_quick_check_property(value, binary)
             else:
                 raise ValueError('Invalid Unicode property!')
         except Exception:
@@ -373,30 +423,30 @@ def get_unicode_property(value, prop=None):
         negate = ''
 
     try:
-        return get_gc_property(value)
+        return get_gc_property(value, binary)
     except Exception:
         pass
 
     if temp.startswith('is'):
         try:
-            return get_script_property(negate + temp[2:])
+            return get_script_property(negate + temp[2:], binary)
         except Exception:
             pass
     try:
-        return get_script_property(value)
+        return get_script_property(value, binary)
     except Exception:
         pass
     if temp.startswith('in'):
         try:
-            return get_block_property(negate + temp[2:])
+            return get_block_property(negate + temp[2:], binary)
         except Exception:
             pass
     try:
-        return get_block_property(value)
+        return get_block_property(value, binary)
     except Exception:
         pass
     try:
-        return get_binary_property(value)
+        return get_binary_property(value, binary)
     except Exception:
         pass
 

--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -8,6 +8,7 @@
 - **NEW**: Support Unicode property form `\pP` and `\PP`.
 - **NEW**: Add support for properly handling per group, scoped verbose flags in the preprocess step (Regex).
 - **NEW**: Handle `(?#comments)` properly in the preprocess step.
+- **NEW**: Add support for `\N` in byte strings (characters out of range won't be included).
 - **NEW**: Add support for `\p` and `\P` in byte strings (characters out of range won't be included).
 - **FIX**: Missing block properties on narrow systems when the property starts beyond the narrow limit.
 - **FIX**: Fix issue where an invalid general category could sometimes pass and return no characters.

--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -8,6 +8,8 @@
 - **NEW**: Support Unicode property form `\pP` and `\PP`.
 - **NEW**: Add support for properly handling per group, scoped verbose flags in the preprocess step (Regex).
 - **NEW**: Handle `(?#comments)` properly in the preprocess step.
+- **NEW**: Add support for `\p` and `\P` in byte strings (characters out of range won't be included).
+- **FIX**: Missing block properties on narrow systems when the property starts beyond the narrow limit.
 - **FIX**: Fix issue where an invalid general category could sometimes pass and return no characters.
 - **FIX**: Fix `\Q...\E` behavior so it is applied first as a separate step. No longer avoids `\Q...\E` in things like character groups or comments.
 

--- a/docs/src/markdown/index.md
+++ b/docs/src/markdown/index.md
@@ -156,7 +156,7 @@ Back\ References      | Description
 `\P{UnicodeProperty}` | Inverse Unicode property character class. Can be used in character classes `[]`. See [Unicode Properties](#unicode-properties) for more info.
 `\PX`                 | Inverse Unicode property character class where `X` is the uppercase letter that represents the General Category property. For instance, `\PL` would be equivalent to `\P{L}` or `\P{Letter}`.
 `[[:alnum:]]`         | Though not really a back reference, support for Posix style character classes is available. See [Posix Style Properties](#posix-style-properties) for more info.
-`\N{UnicodeName}`     | Named characters are are normally ignored in Re, but Backrefs adds support for them. Like `\p` and `\P`, search string must be a Unicode string.
+`\N{UnicodeName}`     | Named characters are are normally ignored in Re, but Backrefs adds support for them.
 
 ### Regex
 
@@ -195,7 +195,7 @@ Back&nbsp;References | Description
 
 There are quite a few properties that are also supported and an exhaustive list is not currently provided. This documentation will only briefly touch on `General_Category`, `Block`, `Script`, and binary properties.
 
-Unicode properties can be used with the format: `\p{property=value}`, `\p{property:value}`, `\p{value}`, `\p{^property=value}`, `\p{^value}`.  Though you don't have to specify the `UNICODE` flag, the search pattern must be a Unicode string and the search buffer must also be Unicode.
+Unicode properties can be used with the format: `\p{property=value}`, `\p{property:value}`, `\p{value}`, `\p{^property=value}`, `\p{^value}`. Unicode properties can be used in byte strings, but the patterns will be restricted to the range `\x00-\xff`.
 
 The inverse of properties can also be used to specify everything not in a Unicode property: `\P{value}` or `\p{^value}` etc.  They are only used in the search patterns. Only one property may specified between the curly braces.  If you want to use multiple properties, you can place them in a character class: `[\p{UnicodeProperty}\p{OtherUnicodeProperty}]`.
 

--- a/docs/src/markdown/index.md
+++ b/docs/src/markdown/index.md
@@ -151,9 +151,9 @@ Back\ References      | Description
 `\C`                  | Inverse uppercase character class.  ASCII or Unicode when re Unicode flag is used.  Can be used in character classes `[]`.
 `\L`                  | Inverse lowercase character class.  ASCII or Unicode when re Unicode flag is used.  Can be used in character classes `[]`.
 `\Q...\E`             | Quotes (escapes) text for regular expression.  `\E` signifies the end of the quoting. Affects any and all characters no matter where in the regular expression pattern it is placed.
-`\p{UnicodeProperty}` | Unicode property character class. Search string must be a Unicode string. Can be used in character classes `[]`. See [Unicode Properties](#unicode-properties) for more info.
+`\p{UnicodeProperty}` | Unicode property character class. Can be used in character classes `[]`. See [Unicode Properties](#unicode-properties) for more info.
 `\pX`                 | Unicode property character class where `X` is the uppercase letter that represents the General Category property.  For instance, `\pL` would be equivalent to `\p{L}` or `\p{Letter}`.
-`\P{UnicodeProperty}` | Inverse Unicode property character class. Search string must be a Unicode string. Can be used in character classes `[]`. See [Unicode Properties](#unicode-properties) for more info.
+`\P{UnicodeProperty}` | Inverse Unicode property character class. Can be used in character classes `[]`. See [Unicode Properties](#unicode-properties) for more info.
 `\PX`                 | Inverse Unicode property character class where `X` is the uppercase letter that represents the General Category property. For instance, `\PL` would be equivalent to `\P{L}` or `\P{Letter}`.
 `[[:alnum:]]`         | Though not really a back reference, support for Posix style character classes is available. See [Posix Style Properties](#posix-style-properties) for more info.
 `\N{UnicodeName}`     | Named characters are are normally ignored in Re, but Backrefs adds support for them. Like `\p` and `\P`, search string must be a Unicode string.

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ def generate_unicode_table():
     fp, pathname, desc = imp.find_module('unipropgen', [path])
     try:
         unipropgen = imp.load_module('unipropgen', fp, pathname, desc)
-        unipropgen.build_unicode_property_table(
+        unipropgen.build_tables(
             os.path.join(
                 os.path.dirname(__file__),
                 'backrefs', 'uniprops', 'unidata'

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -518,23 +518,45 @@ class TestSearchTemplate(unittest.TestCase):
         m = pattern.match(r'P')
         self.assertTrue(m is None)
 
-    def test_binary_unicode_ignore(self):
-        r"""Binary patterns should not process `\p` references."""
-        import sre_constants
+    def test_binary_property(self):
+        r"""Binary patterns should match `\p` references."""
 
-        if PY36_PLUS:
-            def no_unicode():
-                """Should fail on Unicode back reference."""
-                bre.compile_search(br'EX\p{Lu}MPLE')
+        pattern = bre.compile_search(br'EX\p{Lu}MPLE')
+        m = pattern.match(br'EXAMPLE')
+        self.assertTrue(m is not None)
 
-            # Python 3.6+ fails on invalid back references (which ours are)
-            # Since this one is not valid in a bytes string, it shouldn't
-            # be used.  It is okay that Python fails on this.
-            self.assertRaises(sre_constants.error, no_unicode)
-        else:
-            pattern = bre.compile_search(br'EX\p{Lu}MPLE')
-            m = pattern.match(br'EXp{Lu}MPLE')
-            self.assertTrue(m is not None)
+    def test_binary_property_no_value(self):
+        """Test when a property returns nothing in byte string."""
+
+        pattern = bre.compile_search(br'EX\p{OtherAlphabetic}MPLE')
+        self.assertEqual(pattern.pattern, b'EX[^\x00-\xff]MPLE')
+
+        pattern = bre.compile_search(br'EX\P{OtherAlphabetic}MPLE')
+        self.assertEqual(pattern.pattern, b'EX[\x00-\xff]MPLE')
+
+        pattern = bre.compile_search(br'EX[\p{OtherAlphabetic}]MPLE')
+        self.assertEqual(pattern.pattern, b'EX[^\x00-\xff]MPLE')
+
+        pattern = bre.compile_search(br'EX[\P{OtherAlphabetic}]MPLE')
+        self.assertEqual(pattern.pattern, b'EX[\x00-\xff]MPLE')
+
+        pattern = bre.compile_search(br'EX[^\p{OtherAlphabetic}]MPLE')
+        self.assertEqual(pattern.pattern, b'EX[\x00-\xff]MPLE')
+
+        pattern = bre.compile_search(br'EX[^\P{OtherAlphabetic}]MPLE')
+        self.assertEqual(pattern.pattern, b'EX[^\x00-\xff]MPLE')
+
+        pattern = bre.compile_search(br'EX[\p{OtherAlphabetic}a]MPLE')
+        self.assertEqual(pattern.pattern, b'EX[a]MPLE')
+
+        pattern = bre.compile_search(br'EX[\P{OtherAlphabetic}a]MPLE')
+        self.assertEqual(pattern.pattern, b'EX[\x00-\xffa]MPLE')
+
+        pattern = bre.compile_search(br'EX[^\p{OtherAlphabetic}a]MPLE')
+        self.assertEqual(pattern.pattern, b'EX[^a]MPLE')
+
+        pattern = bre.compile_search(br'EX[^\P{OtherAlphabetic}a]MPLE')
+        self.assertEqual(pattern.pattern, b'EX[^\x00-\xffa]MPLE')
 
     def test_unicode_and_verbose_flag(self):
         """Test that `VERBOSE` and `UNICODE` together come through."""

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -1546,6 +1546,11 @@ class TestExceptions(unittest.TestCase):
 
         self.assertEqual(str(e.value), 'Invalid Unicode property!')
 
+        with pytest.raises(ValueError) as e:
+            bre.compile_search(r'\p{bad_binary:y}', re.UNICODE)
+
+        self.assertEqual(str(e.value), 'Invalid Unicode property!')
+
     def test_bad_category(self):
         """Test bad category."""
 

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -21,6 +21,44 @@ else:
 class TestSearchTemplate(unittest.TestCase):
     """Search template tests."""
 
+    def test_byte_string_named_chars(self):
+        """Test byte string named char."""
+
+        pattern = bre.compile_search(br'\N{Latin small letter a}')
+        self.assertEqual(
+            pattern.pattern,
+            br'\141'
+        )
+        self.assertTrue(pattern.match(b'a') is not None)
+
+        pattern = bre.compile_search(br'[^\N{Latin small letter a}]')
+        self.assertEqual(
+            pattern.pattern,
+            br'[^\141]'
+        )
+        self.assertTrue(pattern.match(b'b') is not None)
+
+        pattern = bre.compile_search(br'\N{black club suit}')
+        self.assertEqual(
+            pattern.pattern,
+            b'[^\x00-\xff]'
+        )
+        self.assertTrue(pattern.match(b'a') is None)
+
+        pattern = bre.compile_search(br'[\N{black club suit}]')
+        self.assertEqual(
+            pattern.pattern,
+            b'[^\x00-\xff]'
+        )
+        self.assertTrue(pattern.match(b'a') is None)
+
+        pattern = bre.compile_search(br'[^\N{black club suit}]')
+        self.assertEqual(
+            pattern.pattern,
+            b'[\x00-\xff]'
+        )
+        self.assertTrue(pattern.match(b'a') is not None)
+
     def test_escape_char(self):
         """Test escape char."""
 

--- a/tests/test_uniprops.py
+++ b/tests/test_uniprops.py
@@ -79,13 +79,13 @@ class TestUniprops(unittest.TestCase):
         """Test `canonical combining class type` Category."""
 
         result = uniprops.get_unicode_property('200', 'ccc')
-        self.assertEqual(result, uniprops.unidata.uniocde_canonical_combining_class['200'])
+        self.assertEqual(result, uniprops.unidata.unicode_canonical_combining_class['200'])
 
     def test_inverse_canonical(self):
         """Test inverse `canonical combining class type` Category."""
 
         result = uniprops.get_unicode_property('^200', 'ccc')
-        self.assertEqual(result, uniprops.unidata.uniocde_canonical_combining_class['^200'])
+        self.assertEqual(result, uniprops.unidata.unicode_canonical_combining_class['^200'])
 
     def test_eastasianwidth(self):
         """Test `east asian width` Category."""
@@ -395,25 +395,25 @@ class TestUniprops(unittest.TestCase):
         """Test binary `posix` Category."""
 
         result = uniprops.get_posix_property('punct', uniprops.POSIX_BINARY)
-        self.assertEqual(result, uniprops.unidata.bposix_properties['punct'])
+        self.assertEqual(result, uniprops.unidata.ascii_posix_properties['punct'])
 
     def test_inverse_posix_binary(self):
         """Test inverse binary `posix` Category."""
 
         result = uniprops.get_posix_property('^punct', uniprops.POSIX_BINARY)
-        self.assertEqual(result, uniprops.unidata.bposix_properties['^punct'])
+        self.assertEqual(result, uniprops.unidata.ascii_posix_properties['^punct'])
 
     def test_posix(self):
         """Test `posix` Category."""
 
         result = uniprops.get_posix_property('punct')
-        self.assertEqual(result, uniprops.unidata.posix_properties['punct'])
+        self.assertEqual(result, uniprops.unidata.unicode_posix_properties['punct'])
 
     def test_inverse_posix(self):
         """Test inverse `posix` Category."""
 
         result = uniprops.get_posix_property('^punct')
-        self.assertEqual(result, uniprops.unidata.posix_properties['^punct'])
+        self.assertEqual(result, uniprops.unidata.unicode_posix_properties['^punct'])
 
     def test_uposix(self):
         """Test Unicode `posix` Category."""

--- a/tools/unipropgen.py
+++ b/tools/unipropgen.py
@@ -11,12 +11,13 @@ import codecs
 import os
 import re
 
-__version__ = '2.0.0'
+__version__ = '3.0.0'
 
 UNIVERSION = unicodedata.unidata_version
 UNIVERSION_INFO = tuple([int(x) for x in UNIVERSION.split('.')])
 HOME = os.path.dirname(os.path.abspath(__file__))
 MAXUNICODE = sys.maxunicode
+MAXASCII = 0xFF
 NARROW = sys.maxunicode == 0xFFFF
 
 # Compatibility
@@ -25,12 +26,14 @@ if NARROW:
     UNICODE_RANGE = (0x0000, 0xFFFF)
 else:
     UNICODE_RANGE = (0x0000, 0x10FFFF)
+ASCII_RANGE = (0x00, 0xFF)
 if PY3:
     unichar = chr  # noqa
 else:
     unichar = unichr  # noqa
 
 ALL_CHARS = set([x for x in range(UNICODE_RANGE[0], UNICODE_RANGE[1] + 1)])
+ALL_ASCII = set([x for x in range(ASCII_RANGE[0], ASCII_RANGE[1] + 1)])
 HEADER = '''\
 """Unicode Properties from Unicode version %s (autogen)."""
 from __future__ import unicode_literals
@@ -51,8 +54,7 @@ def uniformat(value):
     """Convert a Unicode char."""
 
     # Escape #^-\]
-    # We include # in case we are using (?x)
-    if value in (0x23, 0x55, 0x5c, 0x5d):
+    if value in (0x55, 0x5c, 0x5d):
         c = "\\u%04x\\u%04x" % (0x5c, value)
     elif value <= 0xFFFF:
         c = "\\u%04x" % value
@@ -70,19 +72,24 @@ def binaryformat(value):
     """Convert a binary value."""
 
     # Escape #^-\]
-    # We include # in case we are using (?x)
-    if value in (0x23, 0x55, 0x5c, 0x5d):
+    if value in (0x55, 0x5c, 0x5d):
         c = "\\x%02x\\x%02x" % (0x5c, value)
     else:
         c = "\\x%02x" % value
     return c
 
 
-def create_span(unirange):
+def create_span(unirange, binary=False):
     """Clamp the Unicode range."""
+
     if len(unirange) < 2:
         unirange.append(unirange[0])
-    if NARROW:
+    if binary:
+        if unirange[0] > MAXASCII:
+            return None
+        if unirange[1] > MAXASCII:
+            unirange[1] = MAXASCII
+    elif NARROW:
         if unirange[0] > MAXUNICODE:
             return None
         if unirange[1] > MAXUNICODE:
@@ -90,23 +97,24 @@ def create_span(unirange):
     return [x for x in range(unirange[0], unirange[1] + 1)]
 
 
-def not_explicitly_defined(table, name):
+def not_explicitly_defined(table, name, binary=False):
     """Compose a table with the specified entry name of values not explicitly defined."""
 
+    all_chars = ALL_ASCII if binary else ALL_CHARS
     s = set()
     for k, v in table.items():
         s.update(v)
     if name in table:
-        table[name] = list(set(table[name]) | (ALL_CHARS - s))
+        table[name] = list(set(table[name]) | (all_chars - s))
     else:
-        table[name] = list(ALL_CHARS - s)
+        table[name] = list(all_chars - s)
 
 
 def char2range(d, binary=False, invert=True):
     """Convert the characters in the dict to a range in string form."""
 
     fmt = binaryformat if binary else uniformat
-    maxrange = 0xff if binary else MAXUNICODE
+    maxrange = MAXASCII if binary else MAXUNICODE
 
     for k1 in sorted(d.keys()):
         v1 = d[k1]
@@ -169,14 +177,18 @@ def char2range(d, binary=False, invert=True):
                 d[k1[1:] if inverted else '^' + k1] = ''.join(iv2)
 
 
-def gen_blocks(output):
+def gen_blocks(output, ascii_props=False, append=False, prefix=""):
     """Generate Unicode blocks."""
 
-    with codecs.open(output, 'w', 'utf-8') as f:
-        f.write(HEADER)
-        f.write('unicode_blocks = {')
+    with codecs.open(output, 'a' if append else 'w', 'utf-8') as f:
+        if not append:
+            f.write(HEADER)
+        f.write('%s_blocks = {' % prefix)
         no_block = []
         last = -1
+
+        max_range = MAXASCII if ascii_props else MAXUNICODE
+        formatter = binaryformat if ascii_props else uniformat
 
         with open(os.path.join(HOME, 'unicodedata', UNIVERSION, 'Blocks.txt'), 'r') as uf:
             for line in uf:
@@ -186,38 +198,47 @@ def gen_blocks(output):
                         continue
                     block = [int(i, 16) for i in data[0].strip().split('..')]
                     if block[0] > last + 1:
-                        no_block.append((last + 1, block[0] - 1))
+                        if (last + 1) <= max_range:
+                            endval = block[0] - 1 if (block[0] - 1) < max_range else max_range
+                            no_block.append((last + 1, endval))
                     last = block[1]
-                    if NARROW and block[0] > MAXUNICODE:
-                        break
-                    inverse_range = []
-                    if block[0] > 0:
-                        inverse_range.append("%s-%s" % (uniformat(0), uniformat(block[0] - 1)))
-                    if block[1] < MAXUNICODE:
-                        inverse_range.append("%s-%s" % (uniformat(block[1] + 1), uniformat(MAXUNICODE)))
                     name = format_name(data[1])
-                    f.write('\n    "%s": "%s-%s",' % (name, uniformat(block[0]), uniformat(block[1])))
+                    inverse_range = []
+                    if block[0] > max_range:
+                        if ascii_props:
+                            f.write('\n    "%s": "",' % name)
+                            f.write('\n    "^%s": "%s-%s",' % (name, formatter(0), formatter(max_range)))
+                        continue
+                    if block[0] > 0:
+                        inverse_range.append("%s-%s" % (formatter(0), formatter(block[0] - 1)))
+                    if block[1] < max_range:
+                        inverse_range.append("%s-%s" % (formatter(block[1] + 1), formatter(max_range)))
+                    f.write('\n    "%s": "%s-%s",' % (name, formatter(block[0]), formatter(block[1])))
                     f.write('\n    "^%s": "%s",' % (name, ''.join(inverse_range)))
-            if last < MAXUNICODE:
-                no_block.append((last + 1, MAXUNICODE))
+            if last < max_range:
+                if (last + 1) <= max_range:
+                    no_block.append((last + 1, max_range))
             last = -1
             no_block_inverse = []
-            for piece in no_block:
-                if piece[0] > last + 1:
-                    no_block_inverse.append((last + 1, piece[0] - 1))
-                last = piece[1]
+            if not no_block:
+                no_block_inverse.append((0, max_range))
+            else:
+                for piece in no_block:
+                    if piece[0] > last + 1:
+                        no_block_inverse.append((last + 1, piece[0] - 1))
+                    last = piece[1]
             for block, name in ((no_block, 'noblock'), (no_block_inverse, '^noblock')):
                 f.write('\n    "%s": "' % name)
                 for piece in block:
                     if piece[0] == piece[1]:
-                        f.write(uniformat(piece[0]))
+                        f.write(formatter(piece[0]))
                     else:
-                        f.write("%s-%s" % (uniformat(piece[0]), uniformat(piece[1])))
+                        f.write("%s-%s" % (formatter(piece[0]), formatter(piece[1])))
                 f.write('",')
             f.write('\n}\n')
 
 
-def gen_ccc(output):
+def gen_ccc(output, ascii_props=False, append=False, prefix=""):
     """Generate canonical combining class."""
 
     obj = {}
@@ -227,7 +248,7 @@ def gen_ccc(output):
                 data = line.split('#')[0].split(';')
                 if len(data) < 2:
                     continue
-                span = create_span([int(i, 16) for i in data[0].strip().split('..')])
+                span = create_span([int(i, 16) for i in data[0].strip().split('..')], binary=ascii_props)
                 if span is None:
                     continue
                 name = format_name(data[1])
@@ -245,15 +266,16 @@ def gen_ccc(output):
         s = set(obj[name])
         obj[name] = sorted(s)
 
-    not_explicitly_defined(obj, '0')
+    not_explicitly_defined(obj, '0', binary=ascii_props)
 
     # Convert characters values to ranges
-    char2range(obj)
+    char2range(obj, binary=ascii_props)
 
-    with codecs.open(output, 'w', 'utf-8') as f:
-        f.write(HEADER)
+    with codecs.open(output, 'a' if append else 'w', 'utf-8') as f:
+        if not append:
+            f.write(HEADER)
         # Write out the unicode properties
-        f.write('%s = {\n' % 'uniocde_canonical_combining_class')
+        f.write('%s_canonical_combining_class = {\n' % prefix)
         count = len(obj) - 1
         i = 0
         for k1, v1 in sorted(obj.items()):
@@ -265,7 +287,7 @@ def gen_ccc(output):
             i += 1
 
 
-def gen_enum(file_name, obj_name, output, field=1, notexplicit=None):
+def gen_enum(file_name, obj_name, output, field=1, notexplicit=None, ascii_props=False, append=False, prefix=""):
     """Generate generic enum."""
 
     obj = {}
@@ -275,13 +297,14 @@ def gen_enum(file_name, obj_name, output, field=1, notexplicit=None):
                 data = line.split('#')[0].split(';')
                 if len(data) < 2:
                     continue
-                span = create_span([int(i, 16) for i in data[0].strip().split('..')])
-                if span is None:
-                    continue
+                span = create_span([int(i, 16) for i in data[0].strip().split('..')], binary=ascii_props)
                 name = format_name(data[field])
-
                 if name not in obj:
                     obj[name] = []
+
+                if span is None:
+                    continue
+
                 obj[name].extend(span)
 
     for name in list(obj.keys()):
@@ -289,15 +312,16 @@ def gen_enum(file_name, obj_name, output, field=1, notexplicit=None):
         obj[name] = sorted(s)
 
     if notexplicit:
-        not_explicitly_defined(obj, notexplicit)
+        not_explicitly_defined(obj, notexplicit, binary=ascii_props)
 
     # Convert characters values to ranges
-    char2range(obj)
+    char2range(obj, binary=ascii_props)
 
-    with codecs.open(output, 'w', 'utf-8') as f:
-        f.write(HEADER)
+    with codecs.open(output, 'a' if append else 'w', 'utf-8') as f:
+        if not append:
+            f.write(HEADER)
         # Write out the unicode properties
-        f.write('%s = {\n' % obj_name)
+        f.write('%s_%s = {\n' % (prefix, obj_name))
         count = len(obj) - 1
         i = 0
         for k1, v1 in sorted(obj.items()):
@@ -309,41 +333,45 @@ def gen_enum(file_name, obj_name, output, field=1, notexplicit=None):
             i += 1
 
 
-def gen_age(output):
+def gen_age(output, ascii_props=False, append=False, prefix=""):
     """Generate Age."""
 
     obj = {}
+    all_chars = ALL_ASCII if ascii_props else ALL_CHARS
     with open(os.path.join(HOME, 'unicodedata', UNIVERSION, 'DerivedAge.txt'), 'r') as uf:
         for line in uf:
             if not line.startswith('#'):
                 data = line.split('#')[0].split(';')
                 if len(data) < 2:
                     continue
-                span = create_span([int(i, 16) for i in data[0].strip().split('..')])
-                if span is None:
-                    continue
+                span = create_span([int(i, 16) for i in data[0].strip().split('..')], binary=ascii_props)
                 name = format_name(data[1])
 
                 if name not in obj:
                     obj[name] = []
+
+                if span is None:
+                    continue
+
                 obj[name].extend(span)
 
     unassigned = set()
     for x in obj.values():
         unassigned |= set(x)
-    obj['na'] = list(ALL_CHARS - unassigned)
+    obj['na'] = list(all_chars - unassigned)
 
     for name in list(obj.keys()):
         s = set(obj[name])
         obj[name] = sorted(s)
 
     # Convert characters values to ranges
-    char2range(obj)
+    char2range(obj, binary=ascii_props)
 
-    with codecs.open(output, 'w', 'utf-8') as f:
-        f.write(HEADER)
+    with codecs.open(output, 'a' if append else 'w', 'utf-8') as f:
+        if not append:
+            f.write(HEADER)
         # Write out the unicode properties
-        f.write('%s = {\n' % 'unicode_age')
+        f.write('%s_age = {\n' % prefix)
         count = len(obj) - 1
         i = 0
         for k1, v1 in sorted(obj.items()):
@@ -355,11 +383,12 @@ def gen_age(output):
             i += 1
 
 
-def gen_nf_quick_check(output):
+def gen_nf_quick_check(output, ascii_props=False, append=False, prefix=""):
     """Generate binary properties."""
 
     categories = []
     nf = {}
+    all_chars = ALL_ASCII if ascii_props else ALL_CHARS
     with open(os.path.join(HOME, 'unicodedata', UNIVERSION, 'DerivedNormalizationProps.txt'), 'r') as uf:
         for line in uf:
             if not line.startswith('#'):
@@ -368,7 +397,7 @@ def gen_nf_quick_check(output):
                     continue
                 if not data[1].strip().lower().endswith('_qc'):
                     continue
-                span = create_span([int(i, 16) for i in data[0].strip().split('..')])
+                span = create_span([int(i, 16) for i in data[0].strip().split('..')], binary=ascii_props)
                 if span is None:
                     continue
                 name = format_name(data[1][:-3] + 'quickcheck')
@@ -385,7 +414,7 @@ def gen_nf_quick_check(output):
         temp = set()
         for k2 in list(v1.keys()):
             temp |= set(v1[k2])
-        v1['y'] = list(ALL_CHARS - temp)
+        v1['y'] = list(all_chars - temp)
 
     for k1, v1 in nf.items():
         for name in list(v1.keys()):
@@ -393,13 +422,14 @@ def gen_nf_quick_check(output):
             nf[k1][name] = sorted(s)
 
     # Convert characters values to ranges
-    char2range(nf)
+    char2range(nf, binary=ascii_props)
 
-    with codecs.open(output, 'w', 'utf-8') as f:
-        f.write(HEADER)
+    with codecs.open(output, 'a' if append else 'w', 'utf-8') as f:
+        if not append:
+            f.write(HEADER)
         for key, value in sorted(nf.items()):
             # Write out the unicode properties
-            f.write('unicode_%s = {\n' % key.replace('quickcheck', '_quick_check'))
+            f.write('%s_%s = {\n' % (prefix, key.replace('quickcheck', '_quick_check')))
             count = len(value) - 1
             i = 0
             for k1, v1 in sorted(value.items()):
@@ -413,7 +443,7 @@ def gen_nf_quick_check(output):
     return categories
 
 
-def gen_binary(table, output):
+def gen_binary(table, output, ascii_props=False, append=False, prefix=""):
     """Generate binary properties."""
 
     categories = []
@@ -432,14 +462,14 @@ def gen_binary(table, output):
                         continue
                     if include and data[1].strip() not in include:
                         continue
-                    span = create_span([int(i, 16) for i in data[0].strip().split('..')])
-                    if span is None:
-                        continue
+                    span = create_span([int(i, 16) for i in data[0].strip().split('..')], binary=ascii_props)
                     name = format_name(data[1])
 
                     if name not in binary:
                         binary[name] = []
                         categories.append(name)
+                    if span is None:
+                        continue
                     binary[name].extend(span)
 
     with open(os.path.join(HOME, 'unicodedata', UNIVERSION, 'CompositionExclusions.txt'), 'r') as uf:
@@ -449,7 +479,7 @@ def gen_binary(table, output):
                 data = [x.strip() for x in line.split('#')[0] if x.strip()]
                 if not data:
                     continue
-                span = create_span([int(data[0], 16)])
+                span = create_span([int(data[0], 16)], binary=ascii_props)
                 if span is None:
                     continue
 
@@ -466,7 +496,7 @@ def gen_binary(table, output):
             if data:
                 if data[9].strip().lower() != 'y':
                     continue
-                span = create_span([int(data[0].strip(), 16)])
+                span = create_span([int(data[0].strip(), 16)], binary=ascii_props)
                 if span is None:
                     continue
 
@@ -482,12 +512,13 @@ def gen_binary(table, output):
     gen_uposix(table, binary)
 
     # Convert characters values to ranges
-    char2range(binary)
+    char2range(binary, binary=ascii_props)
 
-    with codecs.open(output, 'w', 'utf-8') as f:
-        f.write(HEADER)
+    with codecs.open(output, 'a' if append else 'w', 'utf-8') as f:
+        if not append:
+            f.write(HEADER)
         # Write out the unicode properties
-        f.write('unicode_binary = {\n')
+        f.write('%s_binary = {\n' % prefix)
         count = len(binary) - 1
         i = 0
         for k1, v1 in sorted(binary.items()):
@@ -501,10 +532,11 @@ def gen_binary(table, output):
     return categories[:]
 
 
-def gen_bidi(output):
+def gen_bidi(output, ascii_props=False, append=False, prefix=""):
     """Generate bidi class properties."""
 
     bidi_class = {}
+    max_range = MAXASCII if ascii_props else MAXUNICODE
     with open(os.path.join(HOME, 'unicodedata', UNIVERSION, 'UnicodeData.txt'), 'r') as uf:
         for line in uf:
             data = line.strip().split(';')
@@ -513,11 +545,13 @@ def gen_bidi(output):
                 if not bidi:
                     continue
                 value = int(data[0].strip(), 16)
-                if value > MAXUNICODE:
-                    continue
 
                 if bidi not in bidi_class:
                     bidi_class[bidi] = []
+
+                if value > max_range:
+                    continue
+
                 bidi_class[bidi].append(value)
 
     for name in list(bidi_class.keys()):
@@ -525,11 +559,12 @@ def gen_bidi(output):
         bidi_class[name] = sorted(s)
 
     # Convert characters values to ranges
-    char2range(bidi_class)
+    char2range(bidi_class, binary=ascii_props)
 
-    with codecs.open(output, 'w', 'utf-8') as f:
-        f.write(HEADER)
-        f.write('unicode_bidi_classes = {\n')
+    with codecs.open(output, 'a' if append else 'w', 'utf-8') as f:
+        if not append:
+            f.write(HEADER)
+        f.write('%s_bidi_classes = {\n' % prefix)
         count = len(bidi_class) - 1
         i = 0
         for k1, v1 in sorted(bidi_class.items()):
@@ -541,12 +576,10 @@ def gen_bidi(output):
             i += 1
 
 
-def gen_posix(output, binary=False, append=False):
+def gen_posix(output, binary=False, append=False, prefix=""):
     """Generate the binary posix table and write out to file."""
 
     posix_table = {}
-
-    prefix = 'b' if binary else ''
 
     # Alnum: [a-zA-Z0-9]
     s = set([x for x in range(0x30, 0x39 + 1)])
@@ -615,7 +648,7 @@ def gen_posix(output, binary=False, append=False):
         if not append:
             f.write(HEADER)
         # Write out the unicode properties
-        f.write('%sposix_properties = {\n' % prefix)
+        f.write('%s_posix_properties = {\n' % prefix)
         count = len(posix_table) - 1
         i = 0
         for k1, v1 in sorted(posix_table.items()):
@@ -702,7 +735,7 @@ def gen_uposix(table, posix_table):
     posix_table["posixxdigit"] = list(s)
 
 
-def gen_alias(enum, binary, output):
+def gen_alias(enum, binary, output, ascii_props=False, append=False, prefix=""):
     """Generate alias."""
 
     alias_re = re.compile(r'^#\s+(\w+)\s+\((\w+)\)\s*$')
@@ -799,9 +832,10 @@ def gen_alias(enum, binary, output):
     for prop in posix_props:
         alias['binary'][prop] = 'posix' + prop
 
-    with codecs.open(output, 'w', 'utf-8') as f:
-        f.write(HEADER)
-        f.write('unicode_alias = {\n')
+    with codecs.open(output, 'a' if append else 'w', 'utf-8') as f:
+        if not append:
+            f.write(HEADER)
+        f.write('%s_alias = {\n' % prefix)
         count = len(alias) - 1
         i = 0
         for k1, v1 in sorted(alias.items()):
@@ -839,7 +873,7 @@ def gen_alias(enum, binary, output):
             i += 1
 
 
-def gen_properties(output):
+def gen_properties(output, ascii_props=False, append=False):
     """Generate the property table and dump it to the provided file."""
 
     files = {
@@ -866,6 +900,8 @@ def gen_properties(output):
         'alias': os.path.join(output, 'alias.py')
     }
 
+    prefix = "ascii" if ascii_props else 'unicode'
+
     # L& or Lc won't be found in the table,
     # so intialize 'c' at the start. & will have to be converted to 'c'
     # before sending it through.
@@ -877,7 +913,13 @@ def gen_properties(output):
         'joininggroup', 'numerictype', 'numericvalue',
         'canonicalcombiningclass', 'age'
     ]
+    if ascii_props:
+        print('=========Ascii Tables=========')
+    else:
+        print('========Unicode Tables========')
     print('Building: General Category')
+    max_range = ASCII_RANGE if ascii_props else UNICODE_RANGE
+    all_chars = ALL_ASCII if ascii_props else ALL_CHARS
     table = {'l': {'c': []}}
     itable = {'l': {}}
     with open(os.path.join(HOME, 'unicodedata', UNIVERSION, 'UnicodeData.txt'), 'r') as uf:
@@ -885,7 +927,7 @@ def gen_properties(output):
             data = line.strip().split(';')
             if data:
                 i = int(data[0], 16)
-                if NARROW and i > UNICODE_RANGE[1]:
+                if i > max_range[1]:
                     continue
                 p = data[2].lower()
                 if p[0] not in table:
@@ -904,84 +946,121 @@ def gen_properties(output):
         for k2, v2 in v1.items():
             s = set(v2)
             inverse_category |= s
-        itable[k1]['^'] = list(ALL_CHARS - inverse_category)
+        itable[k1]['^'] = list(all_chars - inverse_category)
 
     # Generate Unicode blocks
     print('Building: Blocks')
-    gen_blocks(files['blk'])
+    gen_blocks(files['blk'], ascii_props, append, prefix)
 
     # Generate Unicode scripts
     print('Building: Scripts')
-    gen_enum('Scripts.txt', 'unicode_scripts', files['sc'], notexplicit='zzzz')
+    gen_enum(
+        'Scripts.txt', 'scripts', files['sc'], notexplicit='zzzz',
+        ascii_props=ascii_props, append=append, prefix=prefix
+    )
 
     # Generate Unicode bidi classes
     print('Building: Bidi Classes')
-    gen_bidi(files['bc'])
+    gen_bidi(files['bc'], ascii_props, append, prefix)
 
     # Generate Unicode binary
     print('Building: Binary')
-    binary = gen_binary(table, files['binary'])
+    binary = gen_binary(table, files['binary'], ascii_props, append, prefix)
 
     # Generate posix table and write out to file.
     print('Building: Posix')
-    gen_posix(files['posix'], binary=True)
-    gen_posix(files['posix'], append=True)
+    gen_posix(files['posix'], binary=ascii_props, append=append, prefix=prefix)
 
     print('Building: Age')
-    gen_age(files['age'])
+    gen_age(files['age'], ascii_props, append, prefix)
 
     print('Building: East Asian Width')
-    gen_enum('EastAsianWidth.txt', 'unicode_east_asian_width', files['ea'], notexplicit='n')
+    gen_enum(
+        'EastAsianWidth.txt', 'east_asian_width', files['ea'],
+        notexplicit='n', ascii_props=ascii_props, append=append, prefix=prefix
+    )
 
     print('Building: Grapheme Cluster Break')
-    gen_enum('GraphemeBreakProperty.txt', 'unicode_grapheme_cluster_break', files['gcb'], notexplicit='other')
+    gen_enum(
+        'GraphemeBreakProperty.txt', 'grapheme_cluster_break', files['gcb'], notexplicit='other',
+        ascii_props=ascii_props, append=append, prefix=prefix
+    )
 
     print('Building: Line Break')
-    gen_enum('LineBreak.txt', 'unicode_line_break', files['lb'], notexplicit='unknown')
+    gen_enum(
+        'LineBreak.txt', 'line_break', files['lb'], notexplicit='unknown',
+        ascii_props=ascii_props, append=append, prefix=prefix
+    )
 
     print('Building: Sentence Break')
-    gen_enum('SentenceBreakProperty.txt', 'unicode_sentence_break', files['sb'], notexplicit='other')
+    gen_enum(
+        'SentenceBreakProperty.txt', 'sentence_break', files['sb'], notexplicit='other',
+        ascii_props=ascii_props, append=append, prefix=prefix
+    )
 
     print('Building: Word Break')
-    gen_enum('WordBreakProperty.txt', 'unicode_word_break', files['wb'], notexplicit='other')
+    gen_enum(
+        'WordBreakProperty.txt', 'word_break', files['wb'], notexplicit='other',
+        ascii_props=ascii_props, append=append, prefix=prefix
+    )
 
     print('Building: Hangul Syllable Type')
-    gen_enum('HangulSyllableType.txt', 'unicode_hangul_syllable_type', files['hst'], notexplicit='na')
+    gen_enum(
+        'HangulSyllableType.txt', 'hangul_syllable_type', files['hst'], notexplicit='na',
+        ascii_props=ascii_props, append=append, prefix=prefix
+    )
 
     print('Building: Decomposition Type')
-    gen_enum('DerivedDecompositionType.txt', 'unicode_decomposition_type', files['dt'], notexplicit='none')
+    gen_enum(
+        'DerivedDecompositionType.txt', 'decomposition_type', files['dt'], notexplicit='none',
+        ascii_props=ascii_props, append=append, prefix=prefix
+    )
 
     print('Building: Joining Type')
-    gen_enum('DerivedJoiningType.txt', 'unicode_joining_type', files['jt'], notexplicit='u')
+    gen_enum(
+        'DerivedJoiningType.txt', 'joining_type', files['jt'], notexplicit='u',
+        ascii_props=ascii_props, append=append, prefix=prefix
+    )
 
     print('Building: Joining Group')
-    gen_enum('DerivedJoiningGroup.txt', 'unicode_joining_group', files['jg'], notexplicit='nonjoining')
+    gen_enum(
+        'DerivedJoiningGroup.txt', 'joining_group', files['jg'], notexplicit='nonjoining',
+        ascii_props=ascii_props, append=append, prefix=prefix
+    )
 
     print('Building: Numeric Type')
-    gen_enum('DerivedNumericType.txt', 'unicode_numeric_type', files['nt'], notexplicit='none')
+    gen_enum(
+        'DerivedNumericType.txt', 'numeric_type', files['nt'], notexplicit='none',
+        ascii_props=ascii_props, append=append, prefix=prefix
+    )
 
     print('Building: Numeric Value')
-    gen_enum('DerivedNumericValues.txt', 'unicode_numeric_values', files['nv'], field=3, notexplicit='nan')
+    gen_enum(
+        'DerivedNumericValues.txt', 'numeric_values', files['nv'], field=3, notexplicit='nan',
+        ascii_props=ascii_props, append=append, prefix=prefix
+    )
 
     print('Building: Canonical Combining Class')
-    gen_ccc(files['ccc'])
+    gen_ccc(files['ccc'], ascii_props, append, prefix)
 
     print('Building: NF* Quick Check')
-    categories.extend(gen_nf_quick_check(files['qc']))
+    categories.extend(gen_nf_quick_check(files['qc'], ascii_props, append, prefix))
 
-    print('Building: Aliases')
-    gen_alias(categories, binary, files['alias'])
+    if not ascii_props:
+        print('Building: Aliases')
+        gen_alias(categories, binary, files['alias'], ascii_props, append, prefix)
 
     # Convert char values to string ranges.
-    char2range(table)
-    char2range(itable, invert=False)
+    char2range(table, binary=ascii_props)
+    char2range(itable, binary=ascii_props, invert=False)
     for k1, v1 in itable.items():
         table[k1]['^'] = v1['^']
 
-    with codecs.open(files['gc'], 'w', 'utf-8') as f:
-        f.write(HEADER)
+    with codecs.open(files['gc'], 'a' if append else 'w', 'utf-8') as f:
+        if not append:
+            f.write(HEADER)
         # Write out the unicode properties
-        f.write('unicode_properties = {\n')
+        f.write('%s_properties = {\n' % prefix)
         count = len(table) - 1
         i = 0
         for k1, v1 in sorted(table.items()):
@@ -1001,10 +1080,11 @@ def gen_properties(output):
                 f.write(',\n')
             i += 1
 
-    with codecs.open(os.path.join(output, '__init__.py'), 'w') as f:
-        f.write(HEADER)
-        for x in sorted(files):
-            f.write('from .%s import *  # noqa\n' % os.path.basename(files[x])[:-3])
+    if not append:
+        with codecs.open(os.path.join(output, '__init__.py'), 'w') as f:
+            f.write(HEADER)
+            for x in sorted(files):
+                f.write('from .%s import *  # noqa\n' % os.path.basename(files[x])[:-3])
 
 
 def build_unicode_property_table(output):
@@ -1013,6 +1093,14 @@ def build_unicode_property_table(output):
     if not os.path.exists(output):
         os.mkdir(output)
     gen_properties(output)
+
+
+def build_ascii_property_table(output):
+    """Build and write out Unicode property table."""
+
+    if not os.path.exists(output):
+        os.mkdir(output)
+    gen_properties(output, ascii_props=True, append=True)
 
 
 if __name__ == '__main__':
@@ -1024,3 +1112,4 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     build_unicode_property_table(args.output)
+    build_ascii_property_table(args.output)

--- a/tools/unipropgen.py
+++ b/tools/unipropgen.py
@@ -1103,6 +1103,13 @@ def build_ascii_property_table(output):
     gen_properties(output, ascii_props=True, append=True)
 
 
+def build_tables(output):
+    """Build output tables."""
+
+    build_unicode_property_table(output)
+    build_ascii_property_table(output)
+
+
 if __name__ == '__main__':
     import argparse
 
@@ -1111,5 +1118,4 @@ if __name__ == '__main__':
     parser.add_argument('output', default=None, help='Output file.')
     args = parser.parse_args()
 
-    build_unicode_property_table(args.output)
-    build_ascii_property_table(args.output)
+    build_tables(args.output)


### PR DESCRIPTION
- Rework table generation to output blocks that contain no characters due to characters being out of range of narrow Unicode limit and ASCII limit.
- Generate ASCII tables.
- Rework bre code to generate proper classes to behave as expected when properties return nothing due to characters being out of range.
- Enable named Unicode chars (which are in ASCII range) in byte strings.
- Enable properties in byte strings.