### PR TITLE
Flag fixes

### DIFF
--- a/backrefs/bre.py
+++ b/backrefs/bre.py
@@ -965,7 +965,6 @@ class SearchTemplate(object):
     def flags(self, text, scoped=False):
         """Analyze flags."""
 
-        retry = False
         global_retry = False
         if compat.PY3 and self._ascii_flag in text and self.unicode:
             self.unicode = False
@@ -1050,7 +1049,6 @@ class SearchTemplate(object):
             t = flags
             self.flags(flags[2:-1], scoped=True)
 
-        index = i.index
         current = []
         try:
             while t != self._rr_bracket:

--- a/backrefs/bre.py
+++ b/backrefs/bre.py
@@ -112,7 +112,7 @@ _SEARCH_ASCII = re.ASCII if compat.PY3 else 0
 # Unicode string related references
 tokens = {
     "re_posix": re.compile(r'(?i)\[:(?:\\.|[^\\:}]+)+:\]', _SEARCH_ASCII),
-    "re_comments": re.compile(r'\(\?\#[^)]*\)', _SEARCH_ASCII),
+    "re_comments": re.compile(r'\(\?\#(?:\\.|[^)])*\)', _SEARCH_ASCII),
     "re_flags": re.compile((r'\(\?([aiLmsux]+)\)' if compat.PY3 else r'\(\?([iLmsux]+)\)'), _SEARCH_ASCII),
     "re_uniprops": re.compile(r'(?:p|P)(?:\{(?:\\.|[^\\}]+)+\}|[A-Z])?', _SEARCH_ASCII),
     "re_named_props": re.compile(r'N(?:\{[\w ]+\})?', _SEARCH_ASCII),

--- a/backrefs/bre.py
+++ b/backrefs/bre.py
@@ -966,7 +966,7 @@ class SearchTemplate(object):
         """Analyze flags."""
 
         global_retry = False
-        if compat.PY3 and self._ascii_flag in text and self.unicode:
+        if compat.PY3 and (self._ascii_flag in text  or 'L' in text) and self.unicode:
             self.unicode = False
             if not _SCOPED_FLAG_SUPPORT or not scoped:
                 self.temp_global_flag_swap["unicode"] = True
@@ -1419,7 +1419,7 @@ def _apply_search_backrefs(pattern, flags=0):
     if isinstance(pattern, (compat.string_type, compat.binary_type)):
         re_verbose = bool(VERBOSE & flags)
         re_unicode = None
-        if compat.PY3 and bool(ASCII & flags):
+        if compat.PY3 and bool((ASCII | LOCALE) & flags):
             re_unicode = False
         elif bool(UNICODE & flags):
             re_unicode = True

--- a/backrefs/bre.py
+++ b/backrefs/bre.py
@@ -966,7 +966,7 @@ class SearchTemplate(object):
         """Analyze flags."""
 
         global_retry = False
-        if compat.PY3 and (self._ascii_flag in text  or 'L' in text) and self.unicode:
+        if compat.PY3 and (self._ascii_flag in text or 'L' in text) and self.unicode:
             self.unicode = False
             if not _SCOPED_FLAG_SUPPORT or not scoped:
                 self.temp_global_flag_swap["unicode"] = True

--- a/backrefs/bre.py
+++ b/backrefs/bre.py
@@ -336,7 +336,7 @@ class SearchTokens(compat.Tokens):
         """Get scoped flags."""
 
         # Only PY36+ allow scoped flags
-        if not _SCOPED_FLAG_SUPPORT:
+        if not _SCOPED_FLAG_SUPPORT:  # pragma: no cover
             return None
 
         text = None

--- a/backrefs/bregex.py
+++ b/backrefs/bregex.py
@@ -473,17 +473,20 @@ if REGEX_SUPPORT:
                 current.append(t)
             return current
 
-        def flags(self, text):
+        def flags(self, text, scoped=False):
             """Analyze flags."""
 
             retry = False
             global_retry = False
-            if self.version == VERSION1 and self._verbose_off in text and self.verbose:
+            if (self.version == VERSION1 or scoped) and self._verbose_off in text and self.verbose:
                 self.verbose = False
                 retry = True
             elif self._verbose_flag in text and not self.verbose:
                 self.verbose = True
-                retry = True
+                if (self.version == VERSION1 or scoped):
+                    retry = True
+                else:
+                    global_retry = True
             if self._V0 in text and self.version == VERSION1:  # pragma: no cover
                 # Default is V0 if none is selected,
                 # so it is unlikely that this will be selected.
@@ -536,7 +539,7 @@ if REGEX_SUPPORT:
             if flags:
                 t = flags
                 try:
-                    self.flags(flags[2:-1])
+                    self.flags(flags[2:-1], scoped=True)
                 except RetryException:
                     index = i.index
                     pass

--- a/backrefs/bregex.py
+++ b/backrefs/bregex.py
@@ -105,8 +105,7 @@ if REGEX_SUPPORT:
         "re_comments": re.compile(r'\(\?\#[^)]*\)', _SEARCH_ASCII),
         "regex_flags": re.compile(r'\(\?(?:[Laberup]|V0|V1|-?[imsfwx])+\)', _SEARCH_ASCII),
         "regex_flags_v0": re.compile(r'\(\?(?:[Laberup]|V0|V1|[imsfwx])+\)', _SEARCH_ASCII),
-        "scoped_regex_flags": re.compile(r'\(\?(?:-?[ixmsfw])+:', _SEARCH_ASCII),
-        "scoped_regex_flags_v0": re.compile(r'\(\?(?:[imsfwx])+:', _SEARCH_ASCII),
+        "scoped_regex_flags": re.compile(r'\(\?(?:[Laberup]|V0|V1|-?[ixmsfw])+:', _SEARCH_ASCII),
         "replace_group_ref": re.compile(
             r'''(?x)
             (\\)|
@@ -180,8 +179,8 @@ if REGEX_SUPPORT:
         "new_refs": ("e", "R", "Q", "E")
     }
 
-    class RetryException(Exception):
-        """Retry exception."""
+    class RecursionException(Exception):
+        """Recursion exception."""
 
     class GlobalRetryException(Exception):
         """Global retry exception."""
@@ -199,7 +198,6 @@ if REGEX_SUPPORT:
             self._regex_flags = tokens["regex_flags"]
             self._regex_flags_v0 = tokens["regex_flags_v0"]
             self._scoped_regex_flags = tokens["scoped_regex_flags"]
-            self._scoped_regex_flags_v0 = tokens["scoped_regex_flags_v0"]
             self._re_comments = tokens["re_comments"]
 
             self.max_index = len(string) - 1
@@ -220,7 +218,7 @@ if REGEX_SUPPORT:
             """Get scoped flags."""
 
             text = None
-            pattern = self._scoped_regex_flags if not version0 else self._scoped_regex_flags_v0
+            pattern = self._scoped_regex_flags
             m = pattern.match(self.string, self.index - 1)
             if m:
                 text = m.group(0)
@@ -480,25 +478,23 @@ if REGEX_SUPPORT:
             global_retry = False
             if (self.version == VERSION1 or scoped) and self._verbose_off in text and self.verbose:
                 self.verbose = False
-                retry = True
             elif self._verbose_flag in text and not self.verbose:
                 self.verbose = True
-                if (self.version == VERSION1 or scoped):
-                    retry = True
-                else:
+                if not scoped and self.version == VERSION0:
+                    self.temp_global_flag_swap['verbose'] = True
                     global_retry = True
             if self._V0 in text and self.version == VERSION1:  # pragma: no cover
                 # Default is V0 if none is selected,
                 # so it is unlikely that this will be selected.
+                self.temp_global_flag_swap['version'] = True
                 self.version = VERSION0
                 global_retry = True
             elif self._V1 in text and self.version == VERSION0:
+                self.temp_global_flag_swap['version'] = True
                 self.version = VERSION1
                 global_retry = True
             if global_retry:
                 raise GlobalRetryException('Global Retry')
-            if retry:
-                raise RetryException("Retry")
 
         def reference(self, t, i):
             """Handle references."""
@@ -538,32 +534,20 @@ if REGEX_SUPPORT:
             flags = i.get_scoped_flags(version0=self.version == VERSION0)
             if flags:
                 t = flags
-                try:
-                    self.flags(flags[2:-1], scoped=True)
-                except RetryException:
-                    index = i.index
-                    pass
+                self.flags(flags[2:-1], scoped=True)
 
             index = i.index
-            start = t
-            retry = True
-            while retry:
-                t = start
-                retry = False
-                current = []
-                try:
-                    while t != self._rr_bracket:
-                        if not current:
-                            current.append(t)
-                        else:
-                            current.extend(self.normal(t, i))
+            current = []
+            try:
+                while t != self._rr_bracket:
+                    if not current:
+                        current.append(t)
+                    else:
+                        current.extend(self.normal(t, i))
 
-                        t = next(i)
-                except RetryException:
-                    i.rewind(index)
-                    retry = True
-                except StopIteration:
-                    pass
+                    t = next(i)
+            except StopIteration:
+                pass
             self.verbose = verbose
 
             if t == self._rr_bracket:
@@ -673,6 +657,14 @@ if REGEX_SUPPORT:
 
             self.verbose = bool(self.re_verbose)
             self.version = self.re_version if self.re_version else regex.DEFAULT_VERSION
+            self.global_flag_swap = {
+                "version": self.re_version != 0,
+                "verbose": False
+            }
+            self.temp_global_flag_swap = {
+                "version": False,
+                "verbose": False
+            }
 
             new_pattern = []
             string = self.process_quotes(self.search.decode('latin-1') if self.binary else self.search)
@@ -680,15 +672,30 @@ if REGEX_SUPPORT:
             i = RegexSearchTokens(string, is_binary=self.binary)
             iter(i)
 
+            global_flags = 0
+
             retry = True
             while retry:
                 retry = False
                 try:
                     new_pattern = self.main_group(i)
-                except RetryException:
-                    i.rewind(0)
-                    retry = True
                 except GlobalRetryException:
+                    # Prevent a loop of retry over and over for a pattern like ((?V0)(?V1))
+                    # or on V0 (?-x:(?x))
+                    if self.temp_global_flag_swap['version']:
+                        if self.global_flag_swap['version']:
+                            raise RecursionException('Global version flag recursion.')
+                        else:
+                            self.global_flag_swap["version"] = True
+                    if self.temp_global_flag_swap['verbose']:
+                        if self.global_flag_swap['verbose']:
+                            raise RecursionException('Global verbose flag recursion.')
+                        else:
+                            self.global_flag_swap['verbose'] = True
+                    self.temp_global_flag_swap = {
+                        "version": False,
+                        "verbose": False
+                    }
                     i.rewind(0)
                     retry = True
 

--- a/backrefs/bregex.py
+++ b/backrefs/bregex.py
@@ -474,7 +474,6 @@ if REGEX_SUPPORT:
         def flags(self, text, scoped=False):
             """Analyze flags."""
 
-            retry = False
             global_retry = False
             if (self.version == VERSION1 or scoped) and self._verbose_off in text and self.verbose:
                 self.verbose = False
@@ -536,7 +535,6 @@ if REGEX_SUPPORT:
                 t = flags
                 self.flags(flags[2:-1], scoped=True)
 
-            index = i.index
             current = []
             try:
                 while t != self._rr_bracket:
@@ -671,8 +669,6 @@ if REGEX_SUPPORT:
 
             i = RegexSearchTokens(string, is_binary=self.binary)
             iter(i)
-
-            global_flags = 0
 
             retry = True
             while retry:

--- a/backrefs/compat.py
+++ b/backrefs/compat.py
@@ -8,6 +8,8 @@ import sys
 import struct
 
 PY3 = (3, 0) <= sys.version_info < (4, 0)
+PY36 = (3, 6) <= sys.version_info
+PY37 = (3, 7) <= sys.version_info
 
 if PY3:
     string_type = str

--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -13,6 +13,7 @@
 - **FIX**: Missing block properties on narrow systems when the property starts beyond the narrow limit.
 - **FIX**: Fix issue where an invalid general category could sometimes pass and return no characters.
 - **FIX**: Fix `\Q...\E` behavior so it is applied first as a separate step. No longer avoids `\Q...\E` in things like character groups or comments.
+- **FIX**: Flag related parsing issues in Regex and Re Python 3.6+.
 
 ## 2.2.0
 

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -31,6 +31,15 @@ class TestSearchTemplate(unittest.TestCase):
             with pytest.raises(bre.RecursionException):
                 bre.compile_search(r'(?-x:(?x))', re.VERBOSE)
 
+    def test_unicode_ascii_swap(self):
+        """Test Unicode ASCII swapping."""
+
+        if PY37_PLUS:
+            pattern = bre.compile_search(r'(?u:\C\w)(?a:\C\w)(?u:\C\w)')
+            self.assertTrue(pattern.match('ÀÀAAÀÀ') is not None)
+            self.assertTrue(pattern.match('ÀÀAÀÀÀ') is None)
+            self.assertTrue(pattern.match('ÀÀÀAÀÀ') is None)
+
     def test_comments_with_scoped_verbose(self):
         """Test scoped verbose with comments (PY36+)."""
 

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -21,6 +21,29 @@ else:
 class TestSearchTemplate(unittest.TestCase):
     """Search template tests."""
 
+    def test_comments_with_scoped_verbose(self):
+        """Test scoped verbose with comments (PY36+)."""
+
+        if PY36_PLUS:
+            pattern = bre.compile_search(
+                r'''(?u)Test # \e(?#\e\)(?x:
+                Test #\e(?#\e\)
+                (Test # \e
+                )Test #\e
+                )Test # \e'''
+            )
+
+            self.assertEqual(
+                pattern.pattern,
+                r'''(?u)Test # \x1b(?#\e\)(?x:
+                Test #\\e(?#\\e\)
+                (Test # \\e
+                )Test #\\e
+                )Test # \x1b'''
+            )
+
+            self.assertTrue(pattern.match('Test # \x16TestTestTestTest # \x1b') is not None)
+
     def test_byte_string_named_chars(self):
         """Test byte string named char."""
 

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -24,8 +24,12 @@ class TestSearchTemplate(unittest.TestCase):
     def test_infinite_loop_catch(self):
         """Test infinite loop catch."""
 
-        with pytest.raises(bre.RecursionException):
-            bre.compile_search(r'((?a)(?u))')
+        if PY3:
+            with pytest.raises(bre.RecursionException):
+                bre.compile_search(r'((?a)(?u))')
+        if PY36_PLUS:
+            with pytest.raises(bre.RecursionException):
+                bre.compile_search(r'(?-x:(?x))', re.VERBOSE)
 
     def test_comments_with_scoped_verbose(self):
         """Test scoped verbose with comments (PY36+)."""

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -21,6 +21,12 @@ else:
 class TestSearchTemplate(unittest.TestCase):
     """Search template tests."""
 
+    def test_infinite_loop_catch(self):
+        """Test infinite loop catch."""
+
+        with pytest.raises(bre.RecursionException):
+            bre.compile_search(r'((?a)(?u))')
+
     def test_comments_with_scoped_verbose(self):
         """Test scoped verbose with comments (PY36+)."""
 

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -52,7 +52,7 @@ class TestSearchTemplate(unittest.TestCase):
                 )Test # \x1b'''
             )
 
-            self.assertTrue(pattern.match('Test # \x16TestTestTestTest # \x1b') is not None)
+            self.assertTrue(pattern.match('Test # \x1bTestTestTestTest # \x1b') is not None)
 
     def test_byte_string_named_chars(self):
         """Test byte string named char."""

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -36,8 +36,8 @@ class TestSearchTemplate(unittest.TestCase):
 
         if PY36_PLUS:
             pattern = bre.compile_search(
-                r'''(?u)Test # \e(?#\e\)(?x:
-                Test #\e(?#\e\)
+                r'''(?u)Test # \e(?#\e)(?x:
+                Test #\e(?#\e)
                 (Test # \e
                 )Test #\e
                 )Test # \e'''
@@ -45,8 +45,8 @@ class TestSearchTemplate(unittest.TestCase):
 
             self.assertEqual(
                 pattern.pattern,
-                r'''(?u)Test # \x1b(?#\e\)(?x:
-                Test #\\e(?#\\e\)
+                r'''(?u)Test # \x1b(?#\e)(?x:
+                Test #\\e(?#\\e)
                 (Test # \\e
                 )Test #\\e
                 )Test # \x1b'''

--- a/tests/test_bregex.py
+++ b/tests/test_bregex.py
@@ -25,6 +25,9 @@ class TestSearchTemplate(unittest.TestCase):
         with pytest.raises(bregex.RecursionException):
             bregex.compile_search(r'(?-x:(?x))', regex.V0 | regex.VERBOSE)
 
+        with pytest.raises(bregex.RecursionException):
+            bregex.compile_search(r'(?V1)(?V0)')
+
     def test_escape_char(self):
         """Test escape char."""
 
@@ -60,6 +63,17 @@ class TestSearchTemplate(unittest.TestCase):
         )
 
         self.assertTrue(pattern.match('Test # \nTestTestTestTest # \n') is not None)
+
+    def test_mid_verbose(self):
+        """Test mid verbose."""
+
+        pattern = bregex.compile_search(r'(?V1)# \R (?x) # \R')
+        self.assertEqual(
+            pattern.pattern,
+            r'(?V1)# (?>\r\n|\n|\x0b|\f|\r|\x85|\u2028|\u2029) (?x) # \\R'
+        )
+
+        self.assertTrue(pattern.match('# \n '))
 
     def test_comments_v1(self):
         """Test comments v1."""

--- a/tests/test_bregex.py
+++ b/tests/test_bregex.py
@@ -19,6 +19,12 @@ else:
 class TestSearchTemplate(unittest.TestCase):
     """Search template tests."""
 
+    def test_infinite_loop_catch(self):
+        """Test infinite loop catch."""
+
+        with pytest.raises(bregex.RecursionException):
+            bregex.compile_search(r'(?-x:(?x))', regex.V0 | regex.VERBOSE)
+
     def test_escape_char(self):
         """Test escape char."""
 


### PR DESCRIPTION
- Regex should apply `(?flags)` at the the location of the flag to the end of the group in V1.
- Fix Regex related issues with processing `(?x)` in V0.
- Re processes `\)` in comments.
- Fix for infinite loop scenario when processing flags.
- Re PY3.6+ has scoped flags.
- Re PY3.7+ can scope `u` and `a`.
- Regex should allow scoping `u` and `a` if flags are not explicitly passed into the compiler.
- `LOCALE` should negate bre logic for Unicode.
- Global flags can also be defined in scoped notation, though they are still treated as global.