### PR TITLE
Wide unicode fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ backrefs/uniprops/unidata/*
 *-sdist/*
 
 .~c9*
+.pytest_cache/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,6 @@ matrix:
       env: TOXENV=lint
     - python: 3.6
       env: TOXENV=documents
-  allow_failures:
-    - python: 3.7-dev
-    # - python: 3.3
-    #   env: TOXENV=py33-unittests
 
 addons:
   apt:

--- a/backrefs/__init__.py
+++ b/backrefs/__init__.py
@@ -1,7 +1,7 @@
 """Backrefs package."""
 
 #   (major, minor, micro, release type, pre-release build, post-release build)
-version_info = (3, 0, 3, 'final', 0, 0)
+version_info = (3, 0, 4, 'final', 0, 0)
 
 
 def _version():

--- a/backrefs/_bre_parse.py
+++ b/backrefs/_bre_parse.py
@@ -5,7 +5,6 @@ Licensed under MIT
 Copyright (c) 2011 - 2018 Isaac Muse <isaacmuse@gmail.com>
 """
 from __future__ import unicode_literals
-import sys as _sys
 import re as _re
 from . import util as _util
 import sre_parse as _sre_parse

--- a/backrefs/_bre_parse.py
+++ b/backrefs/_bre_parse.py
@@ -849,12 +849,14 @@ class _ReplaceParser(object):
 
         text = self.get_wide_unicode(i) if wide else self.get_narrow_unicode(i)
         value = int(text, 16)
+        skip_case = wide and _NARROW and value > _MAXUNICODE
         single = self.get_single_stack()
-        if self.span_stack:
-            text = self.convert_case(_util.uchr(value), self.span_stack[-1])
-            value = ord(self.convert_case(text, single)) if single is not None else ord(text)
-        elif single:
-            value = ord(self.convert_case(_util.uchr(value), single))
+        if not skip_case:
+            if self.span_stack:
+                text = self.convert_case(_util.uchr(value), self.span_stack[-1])
+                value = ord(self.convert_case(text, single)) if single is not None else ord(text)
+            elif single:
+                value = ord(self.convert_case(_util.uchr(value), single))
         if value <= 0xFF:
             self.result.append('\\%03o' % value)
         else:
@@ -959,7 +961,7 @@ class _ReplaceParser(object):
             self.span_case(i, _UPPER)
         elif t == "E":
             self.end_found = True
-        elif not self.binary and not _NARROW and t == "U":
+        elif not self.binary and t == "U":
             self.parse_unicode(i, True)
         elif not self.binary and t == "u":
             self.parse_unicode(i)

--- a/backrefs/_bregex_parse.py
+++ b/backrefs/_bregex_parse.py
@@ -5,7 +5,6 @@ Licensed under MIT
 Copyright (c) 2011 - 2018 Isaac Muse <isaacmuse@gmail.com>
 """
 from __future__ import unicode_literals
-import sys as _sys
 import unicodedata as _unicodedata
 from . import util as _util
 import regex as _regex

--- a/backrefs/_bregex_parse.py
+++ b/backrefs/_bregex_parse.py
@@ -12,9 +12,6 @@ import regex as _regex
 
 _REGEX_COMMENT_FIX = tuple([int(x) for x in _regex.__version__.split('.')]) > (2, 4, 136)
 
-_MAXUNICODE = _sys.maxunicode
-_NARROW = _sys.maxunicode == 0xFFFF
-
 _ASCII_LETTERS = frozenset(
     (
         'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
@@ -607,9 +604,9 @@ class _ReplaceParser(object):
             single = self.get_single_stack()
             if self.span_stack:
                 text = self.convert_case(_util.uchr(value), self.span_stack[-1])
-                value = ord(self.convert_case(text, single)) if single is not None else ord(text)
+                value = _util.uord(self.convert_case(text, single)) if single is not None else _util.uord(text)
             elif single:
-                value = ord(self.convert_case(_util.uchr(value), single))
+                value = _util.uord(self.convert_case(_util.uchr(value), single))
             if value <= 0xFF:
                 self.result.append('\\%03o' % value)
             else:
@@ -637,13 +634,13 @@ class _ReplaceParser(object):
     def parse_named_unicode(self, i):
         """Parse named Unicode."""
 
-        value = ord(_unicodedata.lookup(self.get_named_unicode(i)))
+        value = _util.uord(_unicodedata.lookup(self.get_named_unicode(i)))
         single = self.get_single_stack()
         if self.span_stack:
             text = self.convert_case(_util.uchr(value), self.span_stack[-1])
-            value = ord(self.convert_case(text, single)) if single is not None else ord(text)
+            value = _util.uord(self.convert_case(text, single)) if single is not None else _util.uord(text)
         elif single:
-            value = ord(self.convert_case(_util.uchr(value), single))
+            value = _util.uord(self.convert_case(_util.uchr(value), single))
         if value <= 0xFF:
             self.result.append('\\%03o' % value)
         else:
@@ -691,14 +688,12 @@ class _ReplaceParser(object):
 
         text = self.get_wide_unicode(i) if wide else self.get_narrow_unicode(i)
         value = int(text, 16)
-        skip_case = wide and _NARROW and value > _MAXUNICODE
         single = self.get_single_stack()
-        if not skip_case:
-            if self.span_stack:
-                text = self.convert_case(_util.uchr(value), self.span_stack[-1])
-                value = ord(self.convert_case(text, single)) if single is not None else ord(text)
-            elif single:
-                value = ord(self.convert_case(_util.uchr(value), single))
+        if self.span_stack:
+            text = self.convert_case(_util.uchr(value), self.span_stack[-1])
+            value = _util.uord(self.convert_case(text, single)) if single is not None else _util.uord(text)
+        elif single:
+            value = _util.uord(self.convert_case(_util.uchr(value), single))
         if value <= 0xFF:
             self.result.append('\\%03o' % value)
         else:
@@ -723,9 +718,9 @@ class _ReplaceParser(object):
         single = self.get_single_stack()
         if self.span_stack:
             text = self.convert_case(chr(value), self.span_stack[-1])
-            value = ord(self.convert_case(text, single)) if single is not None else ord(text)
+            value = _util.uord(self.convert_case(text, single)) if single is not None else _util.uord(text)
         elif single:
-            value = ord(self.convert_case(chr(value), single))
+            value = _util.uord(self.convert_case(chr(value), single))
         self.result.append('\\%03o' % value)
 
     def get_named_group(self, t, i):

--- a/backrefs/_bregex_parse.py
+++ b/backrefs/_bregex_parse.py
@@ -230,7 +230,7 @@ class _SearchParser(object):
             value.append(c)
             c = next(i)
             while c != ')' or escaped is True:
-                if _REGEX_COMMENT_FIX:  # pragma: no cover
+                if _REGEX_COMMENT_FIX:
                     if escaped:
                         escaped = False
                     elif c == '\\':

--- a/backrefs/_bregex_parse.py
+++ b/backrefs/_bregex_parse.py
@@ -690,12 +690,14 @@ class _ReplaceParser(object):
 
         text = self.get_wide_unicode(i) if wide else self.get_narrow_unicode(i)
         value = int(text, 16)
+        skip_case = wide and _NARROW and value > _MAXUNICODE
         single = self.get_single_stack()
-        if self.span_stack:
-            text = self.convert_case(_util.uchr(value), self.span_stack[-1])
-            value = ord(self.convert_case(text, single)) if single is not None else ord(text)
-        elif single:
-            value = ord(self.convert_case(_util.uchr(value), single))
+        if not skip_case:
+            if self.span_stack:
+                text = self.convert_case(_util.uchr(value), self.span_stack[-1])
+                value = ord(self.convert_case(text, single)) if single is not None else ord(text)
+            elif single:
+                value = ord(self.convert_case(_util.uchr(value), single))
         if value <= 0xFF:
             self.result.append('\\%03o' % value)
         else:
@@ -800,7 +802,7 @@ class _ReplaceParser(object):
             self.span_case(i, _UPPER)
         elif t == "E":
             self.end_found = True
-        elif not self.binary and not _NARROW and t == "U":
+        elif not self.binary and t == "U":
             self.parse_unicode(i, True)
         elif not self.binary and t == "u":
             self.parse_unicode(i)

--- a/backrefs/_bregex_parse.py
+++ b/backrefs/_bregex_parse.py
@@ -12,6 +12,7 @@ import regex as _regex
 
 _REGEX_COMMENT_FIX = tuple([int(x) for x in _regex.__version__.split('.')]) > (2, 4, 136)
 
+_MAXUNICODE = _sys.maxunicode
 _NARROW = _sys.maxunicode == 0xFFFF
 
 _ASCII_LETTERS = frozenset(

--- a/backrefs/util.py
+++ b/backrefs/util.py
@@ -74,8 +74,20 @@ def uchr(i):
 
     try:
         return unichar(i)
-    except ValueError:  # pragma: no cover
+    except ValueError:
         return struct.pack('i', i).decode('utf-32')
+
+
+def uord(c):
+    """Get Unicode ord."""
+
+    if len(c) == 2:
+        high, low = [ord(p) for p in c]
+        ordinal = (high - 0xD800) * 0x400 + low - 0xDC00 + 0x10000
+    else:
+        ordinal = ord(c)
+
+    return ordinal
 
 
 class Immutable(object):
@@ -91,4 +103,5 @@ class Immutable(object):
 
     def __setattr__(self, name, value):
         """Prevent mutability."""
+
         raise AttributeError('Class is immutable!')

--- a/backrefs/util.py
+++ b/backrefs/util.py
@@ -79,7 +79,7 @@ def uchr(i):
 
 
 def uord(c):
-    """Get Unicode ord."""
+    """Get Unicode ordinal."""
 
     if len(c) == 2:
         high, low = [ord(p) for p in c]

--- a/docs/src/dictionary/en-custom.txt
+++ b/docs/src/dictionary/en-custom.txt
@@ -4,6 +4,7 @@ Bre
 Bregex
 Changelog
 EmojiOne
+Feb
 GitHub
 Jan
 MERCHANTABILITY

--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -5,7 +5,7 @@
 Feb 8, 2018
 
 - **FIX**: Formally enable Python 3.7 support.
-- **FIX**: Tweak to Unicode wide character hadling.
+- **FIX**: Tweak to Unicode wide character handling.
 
 ## 3.0.3
 

--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 3.0.4
+
+Feb 8, 2018
+
+- **FIX**: Formally enable Python 3.7 support.
+- **FIX**: Tweak to Unicode wide character hadling.
+
 ## 3.0.3
 
 Jan 28, 2018

--- a/setup.py
+++ b/setup.py
@@ -128,10 +128,10 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ]
 )

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -182,7 +182,7 @@ class TestSearchTemplate(unittest.TestCase):
         """Test Unicode ASCII swapping."""
 
         if PY37_PLUS:
-            pattern = bre.compile_search(r'(?u:\C\w)(?a:\C\w)(?u:\C\w)')
+            pattern = bre.compile_search(r'(?u:\w{2})(?a:\w{2})(?u:\w{2})')
             self.assertTrue(pattern.match('ÀÀAAÀÀ') is not None)
             self.assertTrue(pattern.match('ÀÀAÀÀÀ') is None)
             self.assertTrue(pattern.match('ÀÀÀAÀÀ') is None)
@@ -2337,4 +2337,9 @@ class TestConvenienceFunctions(unittest.TestCase):
         replace = p.compile(r'{1}', bre.FORMAT)
         self.assertEqual(p.subf(replace, 'tests'), 'test')
 
-        self.assertEqual(p.sub(r'\ltest', 'tests'), r'\ltest')
+        if PY37_PLUS:
+            # Fail due to `\l` being an invalid escape.
+            with pytest.raises(re.error):
+                p.sub(r'\ltest', 'tests')
+        else:
+            self.assertEqual(p.sub(r'\ltest', 'tests'), r'\ltest')

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -1733,6 +1733,13 @@ class TestReplaceTemplate(unittest.TestCase):
             results
         )
 
+    def test_normal_string_escaped_unicode(self):
+        """Test normal string escaped Unicode."""
+
+        pattern = bre.compile('Test')
+        result = pattern.sub('\\C\\U00000070\\U0001F360\\E', 'Test')
+        self.assertEqual(result, 'P\U0001F360')
+
     def test_dont_case_special_refs(self):
         """Test that we don't case Unicode and bytes tokens, but case the character."""
 

--- a/tests/test_bregex.py
+++ b/tests/test_bregex.py
@@ -1401,6 +1401,13 @@ class TestReplaceTemplate(unittest.TestCase):
             results
         )
 
+    def test_normal_string_escaped_unicode(self):
+        """Test normal string escaped Unicode."""
+
+        pattern = bregex.compile('Test')
+        result = pattern.sub('\\C\\U00000070\\U0001F360\\E', 'Test')
+        self.assertEqual(result, 'P\U0001F360')
+
     def test_dont_case_special_refs(self):
         """Test that we don't case Unicode and bytes tokens, but case the character."""
 

--- a/tests/test_bregex.py
+++ b/tests/test_bregex.py
@@ -152,7 +152,7 @@ class TestSearchTemplate(unittest.TestCase):
         """Test comments v0."""
 
         pattern = bregex.compile_search(
-            r'''(?uV0)Test # \R(?#\R\)(?x:
+            r'''(?uV0)Test # \R(?#\R\))(?x:
             Test #\R(?#\R\)
             (Test # \R
             )Test #\R
@@ -161,7 +161,7 @@ class TestSearchTemplate(unittest.TestCase):
 
         self.assertEqual(
             pattern.pattern,
-            r'''(?uV0)Test # (?>\r\n|\n|\x0b|\f|\r|\x85|\u2028|\u2029)(?#\R\)(?x:
+            r'''(?uV0)Test # (?>\r\n|\n|\x0b|\f|\r|\x85|\u2028|\u2029)(?#\R\))(?x:
             Test #\\R(?#\\R\)
             (Test # \\R
             )Test #\\R
@@ -187,7 +187,7 @@ class TestSearchTemplate(unittest.TestCase):
         pattern = bregex.compile_search(
             r'''(?xuV1)
             Test # \R
-            (?-x:Test #\R(?#\R\)((?x)
+            (?-x:Test #\R(?#\R\))((?x)
             Test # \R
             )Test #\R)
             Test # \R
@@ -198,7 +198,7 @@ class TestSearchTemplate(unittest.TestCase):
             pattern.pattern,
             r'''(?xuV1)
             Test # \\R
-            (?-x:Test #(?>\r\n|\n|\x0b|\f|\r|\x85|\u2028|\u2029)(?#\R\)((?x)
+            (?-x:Test #(?>\r\n|\n|\x0b|\f|\r|\x85|\u2028|\u2029)(?#\R\))((?x)
             Test # \\R
             )Test #(?>\r\n|\n|\x0b|\f|\r|\x85|\u2028|\u2029))
             Test # \\R


### PR DESCRIPTION
Allow processing of wide Unicode in replace Py2.7 narrow builds.  Most cases, you'll never actually hit the code, but it is there just in case for consistency.

Formally enable Python 3.7 support as tests are now passing for latest beta.