### PR TITLE
Table generation fixes

### DIFF
--- a/backrefs/__init__.py
+++ b/backrefs/__init__.py
@@ -1,7 +1,7 @@
 """Backrefs package."""
 
 #   (major, minor, micro, release type, pre-release build, post-release build)
-version_info = (3, 1, 1, 'final', 0, 0)
+version_info = (3, 1, 2, 'final', 0, 0)
 
 
 def _version():

--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -14,7 +14,7 @@ Feb 11, 2018
 
 ## 3.1.0
 
-Feb 12, 2018
+Feb 11, 2018
 
 - **NEW**: Start and end word boundary back references are now specified with `\m` and `\M` like Regex does.  `\<` and `\>` have been removed from Regex.
 - **FIX**: Escaped `\<` and `\>` are no longer processed as Re is known to escape these in versions less than Python 3.7.

--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -1,10 +1,20 @@
 # Changelog
 
+## 3.1.2
+
+Feb 12, 2018
+
+- **FIX**: Properly escape any problematic characters in Unicode tables.
+
 ## 3.1.1
+
+Feb 11, 2018
 
 - **FIX**: `bregex.compile` now supports additional keyword arguments for named lists like `bregex.compile_search` does.
 
 ## 3.1.0
+
+Feb 12, 2018
 
 - **NEW**: Start and end word boundary back references are now specified with `\m` and `\M` like Regex does.  `\<` and `\>` have been removed from Regex.
 - **FIX**: Escaped `\<` and `\>` are no longer processed as Re is known to escape these in versions less than Python 3.7.

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -428,10 +428,10 @@ class TestSearchTemplate(unittest.TestCase):
         """Test posix in a group for ASCII."""
         if PY3:
             pattern = bre.compile_search(r'Test [[:graph:]]', re.ASCII)
-            pattern2 = bre.compile_search('Test [\u0021-\u007E]', re.ASCII)
+            pattern2 = bre.compile_search('Test [!-\\~]', re.ASCII)
         else:
             pattern = bre.compile_search(r'Test [[:graph:]]')
-            pattern2 = bre.compile_search(r'Test [\u0021-\u007E]')
+            pattern2 = bre.compile_search(r'Test [!-\~]')
         self.assertEqual(pattern.pattern, pattern2.pattern)
 
     def test_not_posix_at_start_group(self):

--- a/tools/unipropgen.py
+++ b/tools/unipropgen.py
@@ -19,6 +19,7 @@ HOME = os.path.dirname(os.path.abspath(__file__))
 MAXUNICODE = sys.maxunicode
 MAXASCII = 0xFF
 NARROW = sys.maxunicode == 0xFFFF
+GROUP_ESCAPES = frozenset([ord(x) for x in '-&[\\]^|~'])
 
 # Compatibility
 PY3 = sys.version_info >= (3, 0) and sys.version_info[0:2] < (4, 0)
@@ -53,9 +54,11 @@ def uchr(i):
 def uniformat(value):
     """Convert a Unicode char."""
 
-    # Escape #^-\]
-    if value in (0x55, 0x5c, 0x5d):
-        c = "\\u%04x\\u%04x" % (0x5c, value)
+    if value in GROUP_ESCAPES:
+        # Escape characters that are (or will be in the future) problematic
+        c = "\\x%02x\\x%02x" % (0x5c, value)
+    elif value <= 0xFF:
+        c = "\\x%02x" % value
     elif value <= 0xFFFF:
         c = "\\u%04x" % value
     else:
@@ -71,8 +74,8 @@ def format_name(text):
 def binaryformat(value):
     """Convert a binary value."""
 
-    # Escape #^-\]
-    if value in (0x55, 0x5c, 0x5d):
+    if value in GROUP_ESCAPES:
+        # Escape characters that are (or will be in the future) problematic
         c = "\\x%02x\\x%02x" % (0x5c, value)
     else:
         c = "\\x%02x" % value


### PR DESCRIPTION
Escape `-&[\]^|~` in our Unicode tables so that when they are inserted into groups, they won't create issues.

Also use the smallest char escape notation that is possible.