### PR TITLE
Add support for \R in Re

### DIFF
--- a/backrefs/_bre_parse.py
+++ b/backrefs/_bre_parse.py
@@ -57,6 +57,8 @@ class _SearchParser(object):
     _re_escape = r"\x1b"
     _re_start_wb = r"\b(?=\w)"
     _re_end_wb = r"\b(?<=\w)"
+    _line_break = r'(?:\r\n|(?!\r\n)[\n\v\f\r\x85\u2028\u2029])'
+    _binary_line_break = r'(?:\r\n|(?!\r\n)[\n\v\f\r\x85])'
 
     def __init__(self, search, re_verbose=False, re_unicode=None):
         """Initialize."""
@@ -66,6 +68,10 @@ class _SearchParser(object):
         else:
             self.binary = False
 
+        if self.binary:
+            self._re_line_break = self._binary_line_break
+        else:
+            self._re_line_break = self._line_break
         self.search = search
         self.re_verbose = re_verbose
         self.re_unicode = re_unicode
@@ -269,6 +275,8 @@ class _SearchParser(object):
             current.append(self._re_start_wb)
         elif not in_group and t == "M":
             current.append(self._re_end_wb)
+        elif not in_group and t == "R":
+            current.append(self._re_line_break)
         elif t == "e":
             current.append(self._re_escape)
         elif t == "l":

--- a/backrefs/_bregex_parse.py
+++ b/backrefs/_bregex_parse.py
@@ -49,8 +49,8 @@ class _SearchParser(object):
 
     _new_refs = ("e", "R", "Q", "E")
     _re_escape = r"\x1b"
-    _line_break = r'(?>\r\n|\n|\x0b|\f|\r|\x85|\u2028|\u2029)'
-    _binary_line_break = r'(?>\r\n|\n|\x0b|\f|\r|\x85)'
+    _line_break = r'(?>\r\n|[\n\v\f\r\x85\u2028\u2029])'
+    _binary_line_break = r'(?>\r\n|[\n\v\f\r\x85])'
 
     def __init__(self, search, re_verbose=False, re_version=0):
         """Initialize."""

--- a/backrefs/bre.py
+++ b/backrefs/bre.py
@@ -19,6 +19,7 @@ Add the ability to use the following backrefs with re:
  - `\e`                                                          - Escape character (search)
  - `\m`                                                          - Starting word boundary (search)
  - `\M`                                                          - Ending word boundary (search)
+ - `\R`                                                          - Generic line breaks (search)
 
 Licensed under MIT
 Copyright (c) 2011 - 2018 Isaac Muse <isaacmuse@gmail.com>

--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.5.0
+
+- **NEW**: Add support for generic line breaks (`\R`) to Re.
+
 ## 3.4.0
 
 - **NEW**: Add support for `Vertical_Orientation` property for Unicode 10.0.0 on Python 3.7.

--- a/docs/src/markdown/index.md
+++ b/docs/src/markdown/index.md
@@ -233,6 +233,8 @@ Back\ References      | Description
 `\N{UnicodeName}`     | Named characters are are normally ignored in Re, but Backrefs adds support for them.
 `\m`                  | Start word boundary. Translates to `\b(?=\w)`.
 `\M`                  | End word boundary. Translates to `\b(?<=\w)`.
+`\R`                  | Generic line breaks. When searching a Unicode string, this will use the *equivalent* of an atomic group and match `(?>\r\n|\n|\v|\f|\r|\x85|\u2028|\u2029)`, and when applied to byte strings, this will match the *equivalent* `(?>\r\n|\n|\v|\f|\r|\x85)`. Because it uses atomic groups, which Re does not support, this feature is only for Regex.
+
 
 ### Regex
 

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -1082,6 +1082,34 @@ class TestReplaceTemplate(unittest.TestCase):
         with pytest.raises(sre_constants.error):
             _bre_parse._ReplaceParser().parse(pattern, '\\1\\')
 
+    def test_line_break(self):
+        r"""Test line break \R."""
+
+        self.assertEqual(
+            bre.sub(r"\R", ' ', 'line\r\nline\nline\r'),
+            'line line line '
+        )
+
+    def test_binary_line_break(self):
+        r"""Test binary line break \R."""
+
+        self.assertEqual(
+            bre.sub(br"\R", b' ', b'line\r\nline\nline\r'),
+            b'line line line '
+        )
+
+    def test_line_break_in_group(self):
+        """Test that line break in group matches a normal R."""
+
+        if PY36_PLUS:
+            with pytest.raises(sre_constants.error):
+                bre.sub(r"[\R]", 'l', 'Rine\r\nRine\nRine\r')
+        else:
+            self.assertEqual(
+                bre.sub(r"[\R]", 'l', 'Rine\r\nRine\nRine\r'),
+                'line\r\nline\nline\r'
+            )
+
     def test_replace_unicode_name_ascii_range(self):
         """Test replacing Unicode names in the ASCII range."""
 

--- a/tests/test_bregex.py
+++ b/tests/test_bregex.py
@@ -159,11 +159,11 @@ class TestSearchTemplate(unittest.TestCase):
 
         self.assertEqual(
             pattern.pattern,
-            r'''(?uV0)Test # (?>\r\n|\n|\x0b|\f|\r|\x85|\u2028|\u2029)(?#\R\))(?x:
+            r'''(?uV0)Test # (?>\r\n|[\n\v\f\r\x85\u2028\u2029])(?#\R\))(?x:
             Test #\\R(?#\\R\)
             (Test # \\R
             )Test #\\R
-            )Test # (?>\r\n|\n|\x0b|\f|\r|\x85|\u2028|\u2029)'''
+            )Test # (?>\r\n|[\n\v\f\r\x85\u2028\u2029])'''
         )
 
         self.assertTrue(pattern.match('Test # \nTestTestTestTest # \n') is not None)
@@ -174,7 +174,7 @@ class TestSearchTemplate(unittest.TestCase):
         pattern = bregex.compile_search(r'(?V1)# \R (?x) # \R')
         self.assertEqual(
             pattern.pattern,
-            r'(?V1)# (?>\r\n|\n|\x0b|\f|\r|\x85|\u2028|\u2029) (?x) # \\R'
+            r'(?V1)# (?>\r\n|[\n\v\f\r\x85\u2028\u2029]) (?x) # \\R'
         )
 
         self.assertTrue(pattern.match('# \n '))
@@ -196,9 +196,9 @@ class TestSearchTemplate(unittest.TestCase):
             pattern.pattern,
             r'''(?xuV1)
             Test # \\R
-            (?-x:Test #(?>\r\n|\n|\x0b|\f|\r|\x85|\u2028|\u2029)(?#\R\))((?x)
+            (?-x:Test #(?>\r\n|[\n\v\f\r\x85\u2028\u2029])(?#\R\))((?x)
             Test # \\R
-            )Test #(?>\r\n|\n|\x0b|\f|\r|\x85|\u2028|\u2029))
+            )Test #(?>\r\n|[\n\v\f\r\x85\u2028\u2029]))
             Test # \\R
             '''
         )
@@ -230,16 +230,16 @@ class TestSearchTemplate(unittest.TestCase):
         """Test char group with nested opening [."""
 
         pattern = bregex.compile_search(r'test [[] \R', regex.UNICODE)
-        self.assertEqual(pattern.pattern, r'test [[] (?>\r\n|\n|\x0b|\f|\r|\x85|\u2028|\u2029)', regex.UNICODE)
+        self.assertEqual(pattern.pattern, r'test [[] (?>\r\n|[\n\v\f\r\x85\u2028\u2029])', regex.UNICODE)
 
     def test_posix_parse(self):
         """Test posix in a group."""
 
         pattern = bregex.compile_search(r'test [[:graph:]] \R', regex.V0)
-        self.assertEqual(pattern.pattern, r'test [[:graph:]] (?>\r\n|\n|\x0b|\f|\r|\x85|\u2028|\u2029)')
+        self.assertEqual(pattern.pattern, r'test [[:graph:]] (?>\r\n|[\n\v\f\r\x85\u2028\u2029])')
 
         pattern = bregex.compile_search(r'test [[:graph:]] \R', regex.V1)
-        self.assertEqual(pattern.pattern, r'test [[:graph:]] (?>\r\n|\n|\x0b|\f|\r|\x85|\u2028|\u2029)')
+        self.assertEqual(pattern.pattern, r'test [[:graph:]] (?>\r\n|[\n\v\f\r\x85\u2028\u2029])')
 
     def test_inline_comments(self):
         """Test that we properly find inline comments and avoid them."""


### PR DESCRIPTION
Simulate the equivalent of the generic lines in an atomic group. Also simplify the existing pattern for Regex. Ref #72