### PR TITLE
Real format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,5 @@ backrefs/uniprops/unidata/*
 
 .~c9*
 .pytest_cache/*
+
+*.patch

--- a/backrefs/__init__.py
+++ b/backrefs/__init__.py
@@ -1,7 +1,7 @@
 """Backrefs package."""
 
 #   (major, minor, micro, release type, pre-release build, post-release build)
-version_info = (3, 4, 0, 'final', 0, 0)
+version_info = (3, 5, 0, 'final', 0, 0)
 
 
 def _version():

--- a/backrefs/_bre_parse.py
+++ b/backrefs/_bre_parse.py
@@ -749,7 +749,7 @@ class _ReplaceParser(object):
                     # Handle name
                     value.append(c)
                     c = next(i)
-                    while c not in ('}', '['):
+                    while c not in ('}', '[', ':', '!', '.'):
                         if c not in _WORD:
                             raise SyntaxError('Invalid character at %d!' % (i.index - 1))
                         value.append(c)
@@ -758,7 +758,7 @@ class _ReplaceParser(object):
                     # Handle group number
                     value.append(c)
                     c = next(i)
-                    while c not in ('}', '['):
+                    while c not in ('}', '[', ':', '!', '.'):
                         if c not in _DIGIT:
                             raise SyntaxError('Invalid character! at %d' % (i.index - 1))
                         value.append(c)
@@ -812,7 +812,7 @@ class _ReplaceParser(object):
         except StopIteration:
             raise SyntaxError("Unmatched '{' at %d!" % (index - 1))
 
-        return field, tuple(value)
+        return field, value
 
     def get_format(self, c, i):
         """Get format group."""
@@ -830,7 +830,7 @@ class _ReplaceParser(object):
                     # Handle name
                     value.append(c)
                     c = next(i)
-                    while c not in ('}', '['):
+                    while c not in ('}', '[', ':', '!', '.'):
                         if c not in _WORD:
                             raise SyntaxError('Invalid character at %d!' % (i.index - 1))
                         value.append(c)
@@ -839,7 +839,7 @@ class _ReplaceParser(object):
                     # Handle group number
                     value.append(c)
                     c = next(i)
-                    while c not in ('}', '['):
+                    while c not in ('}', '[', ':', '!', '.'):
                         if c not in _DIGIT:
                             raise SyntaxError('Invalid character! at %d' % (i.index - 1))
                         value.append(c)
@@ -1311,7 +1311,7 @@ class _ReplaceParser(object):
         elif not self.manual:
             raise ValueError("Cannot switch to manual format during auto format!")
 
-        self.handle_group(field, ('{%s}' % text) if not self.binary else text, True)
+        self.handle_group(field, ('{%s}' % text) if not self.binary else tuple(text), True)
 
     def handle_group(self, text, capture=None, is_format=False):
         """Handle groups."""

--- a/backrefs/_bre_parse.py
+++ b/backrefs/_bre_parse.py
@@ -79,14 +79,14 @@ class _SearchParser(object):
         self.re_verbose = re_verbose
         self.re_unicode = re_unicode
 
-    def process_quotes(self, string):
+    def process_quotes(self, text):
         """Process quotes."""
 
         escaped = False
         in_quotes = False
         current = []
         quoted = []
-        i = _util.StringIter(string)
+        i = _util.StringIter(text)
         iter(i)
         for t in i:
             if not escaped and t == "\\":
@@ -664,9 +664,9 @@ class _SearchParser(object):
             self.unicode = True
 
         new_pattern = []
-        string = self.process_quotes(self.search.decode('latin-1') if self.binary else self.search)
+        text = self.process_quotes(self.search.decode('latin-1') if self.binary else self.search)
 
-        i = _util.StringIter(string)
+        i = _util.StringIter(text)
         iter(i)
 
         retry = True
@@ -724,13 +724,14 @@ class _ReplaceParser(object):
             if c == '}':
                 value.append('')
             else:
-                if c in _ASCII_LETTERS:
+                # Field
+                if c in _LETTERS_UNDERSCORE:
                     # Handle name
                     value.append(c)
                     c = next(i)
                     while c not in ('}', '['):
                         if c not in _WORD:
-                            raise SyntaxError('Invalid format character at %d!' % (i.index - 1))
+                            raise SyntaxError('Invalid character at %d!' % (i.index - 1))
                         value.append(c)
                         c = next(i)
                 elif c in _DIGIT:
@@ -739,22 +740,45 @@ class _ReplaceParser(object):
                     c = next(i)
                     while c not in ('}', '['):
                         if c not in _DIGIT:
-                            raise SyntaxError('Invalid format character at %d' % (i.index - 1))
+                            raise SyntaxError('Invalid character! at %d' % (i.index - 1))
                         value.append(c)
                         c = next(i)
-                if c == '[':
-                    sindex = i.index - 1
-                    value.append(c)
-                    c = next(i)
-                    while c not in (']', '}'):
+                # Attributes and indexes
+                while c in ('[', '.'):
+                    if c == '[':
+                        sindex = i.index - 1
                         value.append(c)
                         c = next(i)
-                    if c != ']':
-                        raise SyntaxError("Unmatched '[' at %d!" % (sindex - 1))
+                        while c not in (']', '}'):
+                            value.append(c)
+                            c = next(i)
+                        if c != ']':
+                            raise SyntaxError("Unmatched '[' at %d" % (sindex - 1))
+                        value.append(c)
+                        c = next(i)
+                    else:
+                        value.append(c)
+                        c = next(i)
+                        while c in _WORD:
+                            value.append(c)
+                            c = next(i)
+                # Conversion
+                if c == '!':
                     value.append(c)
                     c = next(i)
+                    if c not in ('s', 'r', 'a'):
+                        raise SyntaxError("Invalid conversion type at %d!" % (i.index - 1))
+                    value.append(c)
+                    c = next(i)
+                # Format spec
+                if c == ':':
+                    value.append(c)
+                    c = next(i)
+                    while c != '}':
+                        value.append(c)
+                        c = next(i)
             if c != '}':
-                raise SyntaxError("Unmatched '{' at %d!" % (index - 1))
+                raise SyntaxError("Unmatched '{' at %d" % (index - 1))
         except StopIteration:
             raise SyntaxError("Unmatched '{' at %d!" % (index - 1))
 
@@ -1145,58 +1169,82 @@ class _ReplaceParser(object):
             single = self.single_stack.pop()
         return single
 
-    def get_capture(self, text):
-        """Get the capture."""
-
-        capture = -1
-        base = 10
-        try:
-            index = text.index("[")
-            capture = text[index + 1:-1]
-            text = text[:index]
-            prefix = capture[1:3] if capture[0] == "-" else capture[:2]
-            if prefix[0:1] == "0":
-                char = prefix[-1]
-                if char == "b":
-                    base = 2
-                elif char == "o":
-                    base = 8
-                elif char == "x":
-                    base = 16
-        except ValueError:
-            pass
-
-        if not isinstance(capture, int):
-            try:
-                capture = int(capture, base)
-            except ValueError:
-                raise ValueError("Capture index must be an integer!")
-        return text, capture
-
     def handle_format_group(self, text):
-        """Handle groups."""
+        """Handle format group."""
 
-        text, capture = self.get_capture(text)
+        group = ''
+        fields, spec, convert = next(_util._string.formatter_parser('{%s}' % text))[1:]
+        value, rest = _util._string.formatter_field_name_split(fields)
+        extra = [
+            ((":" + spec) if spec else spec),
+            ('' if convert is None else '!' + convert)
+        ]
 
-        # Handle auto or manual format
-        if text == "":
+        # Format the group name/index
+        if not isinstance(value, int):
+            try:
+                value = _util.string_type(int(value, 10))
+            except ValueError:
+                pass
+        else:
+            value = _util.string_type(value)
+        capture = [_util.string_type(value)]
+
+        # Format integer indexes inside []
+        for is_attr, i in rest:
+            # We don't care about attributes, so just add it back
+            if is_attr:
+                capture.append('.' + i)
+
+            # Parse various integer formats
+            elif not isinstance(i, int):
+                base = 10
+                prefix = i[1:3] if i[0] == "-" else i[:2]
+                if prefix[0:1] == "0":
+                    char = prefix[-1]
+                    if char == "b":
+                        base = 2
+                    elif char == "o":
+                        base = 8
+                    elif char == "x":
+                        base = 16
+                try:
+                    i = int(i, base)
+                except Exception:
+                    pass
+                capture.append('[%s]' % _util.string_type(i))
+
+            # Index is already an integer
+            else:
+                capture.append('[%s]' % _util.string_type(i))
+
+        # Rebuild format string
+        text = ''.join(capture + extra)
+
+        # Handle auot incrementing group indexes
+        if value == '':
             if self.auto:
-                text = _util.string_type(self.auto_index)
+                group = _util.string_type(self.auto_index)
+                text = group + text
                 self.auto_index += 1
             elif not self.manual and not self.auto:
                 self.auto = True
-                text = _util.string_type(self.auto_index)
+                group = _util.string_type(self.auto_index)
+                text = group + text
                 self.auto_index += 1
             else:
                 raise ValueError("Cannot switch to auto format during manual format!")
         elif not self.manual and not self.auto:
+            group = value
             self.manual = True
         elif not self.manual:
             raise ValueError("Cannot switch to manual format during auto format!")
+        else:
+            group = value
 
-        self.handle_group(text, capture, True)
+        self.handle_group(group, '{%s}' % text, True)
 
-    def handle_group(self, text, capture=-1, is_format=False):
+    def handle_group(self, text, capture='', is_format=False):
         """Handle groups."""
 
         if len(self.result) > 1:
@@ -1217,9 +1265,9 @@ class _ReplaceParser(object):
             (
                 self.slot,
                 (
-                    self.span_stack[-1] if self.span_stack else None,
+                    (self.span_stack[-1] if self.span_stack else None),
                     self.get_single_stack(),
-                    capture
+                    (capture.encode('latin-1') if self.binary else capture)
                 )
             )
         )
@@ -1343,6 +1391,8 @@ class ReplaceTemplate(_util.Immutable):
             raise ValueError("Match is None!")
 
         sep = m.string[:0]
+        if isinstance(sep, _util.binary_type) and self.use_format:
+            raise TypeError('Cannot format byte strings!')
         text = []
         # Expand string
         for x in range(0, len(self.literals)):
@@ -1351,9 +1401,15 @@ class ReplaceTemplate(_util.Immutable):
             if l is None:
                 g_index = self.get_group_index(index)
                 span_case, single_case, capture = self.get_group_attributes(index)
-                if capture not in (0, -1):
-                    raise IndexError("'%d' is out of range!" % capture)
-                l = m.group(g_index)
+                if not self.use_format:
+                    # Non format replace
+                    try:
+                        l = m.group(g_index)
+                    except IndexError:
+                        raise IndexError("'%d' is out of range!" % g_index)
+                else:
+                    # Format replace
+                    l = _util.Formatter().format(capture, m.group(0), *m.groups(), **m.groupdict())
                 if span_case is not None:
                     if span_case == _LOWER:
                         l = l.lower()

--- a/backrefs/_bre_parse.py
+++ b/backrefs/_bre_parse.py
@@ -1471,6 +1471,10 @@ class ReplaceTemplate(_util.Immutable):
         sep = m.string[:0]
         if isinstance(sep, _util.binary_type) != self._binary:
             raise TypeError('Match string type does not match expander string type!')
+        if self.use_format and not self._binary:
+            capture_args = [m.group(0)]
+            capture_args.extend(m.groups())
+            capture_dict = m.groupdict()
         text = []
         # Expand string
         for x in range(0, len(self.literals)):
@@ -1517,7 +1521,7 @@ class ReplaceTemplate(_util.Immutable):
                         l = repr(l).encode('ascii', 'backslashreplace')
                 else:
                     # Format replace
-                    l = _util.Formatter().format(capture, m.group(0), *m.groups(), **m.groupdict())
+                    l = _util.Formatter().vformat(capture, capture_args, capture_dict)
                 if span_case is not None:
                     if span_case == _LOWER:
                         l = l.lower()

--- a/backrefs/_bre_parse.py
+++ b/backrefs/_bre_parse.py
@@ -731,7 +731,88 @@ class _ReplaceParser(object):
             text = int(text, base)
         except Exception:
             pass
-        return _util.string_type(text)
+        return text
+
+    def get_byte_format(self, c, i):
+        """Get byte format group."""
+
+        index = i.index
+        field = ''
+        value = []
+
+        try:
+            if c == '}':
+                value.append('')
+            else:
+                # Field
+                if c in _LETTERS_UNDERSCORE:
+                    # Handle name
+                    value.append(c)
+                    c = next(i)
+                    while c not in ('}', '['):
+                        if c not in _WORD:
+                            raise SyntaxError('Invalid character at %d!' % (i.index - 1))
+                        value.append(c)
+                        c = next(i)
+                elif c in _DIGIT:
+                    # Handle group number
+                    value.append(c)
+                    c = next(i)
+                    while c not in ('}', '['):
+                        if c not in _DIGIT:
+                            raise SyntaxError('Invalid character! at %d' % (i.index - 1))
+                        value.append(c)
+                        c = next(i)
+
+                # Try and covert to integer index
+                field = ''.join(value).strip()
+                try:
+                    value = [_util.string_type(int(field, 10))]
+                except ValueError:
+                    value = [field]
+                    pass
+
+                # Attributes and indexes
+                while c in ('[', '.'):
+                    if c == '[':
+                        findex = []
+                        sindex = i.index - 1
+                        c = next(i)
+                        while c not in (']', '}'):
+                            findex.append(c)
+                            c = next(i)
+                        if c != ']':
+                            raise SyntaxError("Unmatched '[' at %d" % (sindex - 1))
+                        idx = self.parse_format_index(''.join(findex))
+                        if isinstance(idx, int):
+                            value.append((False, idx))
+                        else:
+                            value.append((False, idx))
+                        c = next(i)
+                    else:
+                        findex = []
+                        c = next(i)
+                        while c in _WORD:
+                            findex.append(c)
+                            c = next(i)
+                        value.append((True, ''.join(findex)))
+
+                # Conversion
+                if c == '!':
+                    c = next(i)
+                    if c not in ('s', 'r', 'a'):
+                        raise SyntaxError("Invalid conversion type at %d!" % (i.index - 1))
+                    value.append(('!' + c))
+                    c = next(i)
+
+                # Format spec is not currently supported in byte strings.
+
+            if c != '}':
+                raise SyntaxError("Unmatched '{' at %d" % (index - 1))
+        except StopIteration:
+            raise SyntaxError("Unmatched '{' at %d!" % (index - 1))
+
+        return field, tuple(value)
 
     def get_format(self, c, i):
         """Get format group."""
@@ -784,7 +865,7 @@ class _ReplaceParser(object):
                             c = next(i)
                         if c != ']':
                             raise SyntaxError("Unmatched '[' at %d" % (sindex - 1))
-                        value.append(self.parse_format_index(''.join(findex)))
+                        value.append(_util.string_type(self.parse_format_index(''.join(findex))))
                         value.append(c)
                         c = next(i)
                     else:
@@ -824,7 +905,10 @@ class _ReplaceParser(object):
                 self.get_single_stack()
                 self.result.append(t)
             else:
-                field, text = self.get_format(t, i)
+                if self.binary:
+                    field, text = self.get_byte_format(t, i)
+                else:
+                    field, text = self.get_format(t, i)
                 self.handle_format_group(field, text)
         else:
             t = next(i)
@@ -1207,12 +1291,18 @@ class _ReplaceParser(object):
         if field == '':
             if self.auto:
                 field = _util.string_type(self.auto_index)
-                text = field + text
+                if not self.binary:
+                    text = field + text
+                else:
+                    text[0] = field
                 self.auto_index += 1
             elif not self.manual and not self.auto:
                 self.auto = True
                 field = _util.string_type(self.auto_index)
-                text = field + text
+                if not self.binary:
+                    text = field + text
+                else:
+                    text[0] = field
                 self.auto_index += 1
             else:
                 raise ValueError("Cannot switch to auto format during manual format!")
@@ -1221,10 +1311,13 @@ class _ReplaceParser(object):
         elif not self.manual:
             raise ValueError("Cannot switch to manual format during auto format!")
 
-        self.handle_group(field, '{%s}' % text, True)
+        self.handle_group(field, ('{%s}' % text) if not self.binary else text, True)
 
-    def handle_group(self, text, capture='', is_format=False):
+    def handle_group(self, text, capture=None, is_format=False):
         """Handle groups."""
+
+        if capture is None:
+            capture = tuple() if self.binary else ''
 
         if len(self.result) > 1:
             self.literal_slots.append("".join(self.result))
@@ -1246,7 +1339,7 @@ class _ReplaceParser(object):
                 (
                     (self.span_stack[-1] if self.span_stack else None),
                     self.get_single_stack(),
-                    (capture.encode('latin-1') if self.binary else capture)
+                    capture
                 )
             )
         )
@@ -1370,8 +1463,7 @@ class ReplaceTemplate(_util.Immutable):
             raise ValueError("Match is None!")
 
         sep = m.string[:0]
-        if isinstance(sep, _util.binary_type) and self.use_format:
-            raise TypeError('Cannot format byte strings!')
+        is_binary = isinstance(sep, _util.binary_type)
         text = []
         # Expand string
         for x in range(0, len(self.literals)):
@@ -1386,6 +1478,36 @@ class ReplaceTemplate(_util.Immutable):
                         l = m.group(g_index)
                     except IndexError:
                         raise IndexError("'%d' is out of range!" % g_index)
+                elif is_binary:
+                    try:
+                        l = m.group(g_index)
+                    except IndexError:
+                        raise IndexError("'%d' is out of range!" % g_index)
+
+                    for x in capture[1:]:
+                        if isinstance(x, tuple):
+                            if x[0]:
+                                # Attribute
+                                l = getattr(l, x[1])
+                            else:
+                                # Index
+                                l = l[x[1]]
+                        elif x.startswith('!'):
+                            # Conversion
+                            conversion = x[1]
+                            if conversion in ('r', 'a'):
+                                l = repr(l).encode('ascii', 'backslashreplace')
+                            elif conversion == 's':
+                                # If the object is not string or byte string already
+                                if not isinstance(l, (_util.string_type, _util.binary_type)):
+                                    l = _util.string_type(l).encode('ascii', 'backslashreplace')
+                                elif isinstance(l, _util.string_type):
+                                    l = l.encode('ascii', 'backslashreplace')
+                    # Make sure the final object is a byte string
+                    if isinstance(l, _util.string_type):
+                        l = l.encode('ascii', 'backslashreplace')
+                    elif not isinstance(l, _util.binary_type):
+                        l = repr(l).encode('ascii', 'backslashreplace')
                 else:
                     # Format replace
                     l = _util.Formatter().format(capture, m.group(0), *m.groups(), **m.groupdict())

--- a/backrefs/_bre_parse.py
+++ b/backrefs/_bre_parse.py
@@ -1366,16 +1366,17 @@ class _ReplaceParser(object):
             tuple(self.group_slots),
             tuple(self.literals),
             hash(pattern),
-            self.use_format
+            self.use_format,
+            self.binary
         )
 
 
 class ReplaceTemplate(_util.Immutable):
     """Replacement template expander."""
 
-    __slots__ = ("groups", "group_slots", "literals", "pattern_hash", "use_format", "_hash")
+    __slots__ = ("groups", "group_slots", "literals", "pattern_hash", "use_format", "_hash", "_binary")
 
-    def __init__(self, groups, group_slots, literals, pattern_hash, use_format):
+    def __init__(self, groups, group_slots, literals, pattern_hash, use_format, binary):
         """Initialize."""
 
         super(ReplaceTemplate, self).__init__(
@@ -1384,11 +1385,12 @@ class ReplaceTemplate(_util.Immutable):
             group_slots=group_slots,
             literals=literals,
             pattern_hash=pattern_hash,
+            _binary=binary,
             _hash=hash(
                 (
                     type(self),
                     groups, group_slots, literals,
-                    pattern_hash, use_format
+                    pattern_hash, use_format, binary
                 )
             )
         )
@@ -1412,7 +1414,8 @@ class ReplaceTemplate(_util.Immutable):
             self.group_slots == other.group_slots and
             self.literals == other.literals and
             self.pattern_hash == other.pattern_hash and
-            self.use_format == other.use_format
+            self.use_format == other.use_format and
+            self._binary == other._binary
         )
 
     def __ne__(self, other):
@@ -1424,7 +1427,8 @@ class ReplaceTemplate(_util.Immutable):
             self.group_slots != other.group_slots or
             self.literals != other.literals or
             self.pattern_hash != other.pattern_hash or
-            self.use_format != other.use_format
+            self.use_format != other.use_format or
+            self._binary != self._binary
         )
 
     def __repr__(self):  # pragma: no cover
@@ -1529,7 +1533,7 @@ class ReplaceTemplate(_util.Immutable):
 def _pickle(r):
     """Pickle."""
 
-    return ReplaceTemplate, (r.groups, r.group_slots, r.literals, r.pattern_hash, r.use_format)
+    return ReplaceTemplate, (r.groups, r.group_slots, r.literals, r.pattern_hash, r.use_format, r._binary)
 
 
 _util.copyreg.pickle(ReplaceTemplate, _pickle)

--- a/backrefs/_bre_parse.py
+++ b/backrefs/_bre_parse.py
@@ -1483,12 +1483,12 @@ class ReplaceTemplate(_util.Immutable):
                     # Non format replace
                     try:
                         l = m.group(g_index)
-                    except IndexError:
+                    except IndexError:  # pragma: no cover
                         raise IndexError("'%d' is out of range!" % g_index)
                 elif self._binary:
                     try:
                         l = m.group(g_index)
-                    except IndexError:
+                    except IndexError:  # pragma: no cover
                         raise IndexError("'%d' is out of range!" % g_index)
 
                     for x in capture[1:]:

--- a/backrefs/_bre_parse.py
+++ b/backrefs/_bre_parse.py
@@ -1357,6 +1357,8 @@ class _ReplaceParser(object):
             self.binary = True
         else:
             self.binary = False
+        if isinstance(pattern.pattern, _util.binary_type) != self.binary:
+            raise TypeError('Pattern string type must match replace template string type!')
         self._original = template
         self.use_format = use_format
         self.parse_template(pattern)
@@ -1467,7 +1469,8 @@ class ReplaceTemplate(_util.Immutable):
             raise ValueError("Match is None!")
 
         sep = m.string[:0]
-        is_binary = isinstance(sep, _util.binary_type)
+        if isinstance(sep, _util.binary_type) != self._binary:
+            raise TypeError('Match string type does not match expander string type!')
         text = []
         # Expand string
         for x in range(0, len(self.literals)):
@@ -1482,7 +1485,7 @@ class ReplaceTemplate(_util.Immutable):
                         l = m.group(g_index)
                     except IndexError:
                         raise IndexError("'%d' is out of range!" % g_index)
-                elif is_binary:
+                elif self._binary:
                     try:
                         l = m.group(g_index)
                     except IndexError:

--- a/backrefs/_bre_parse.py
+++ b/backrefs/_bre_parse.py
@@ -56,12 +56,6 @@ _BACK_SLASH_TRANSLATION = {
     "\\\\": '\\'
 }
 
-_FMT_FIELD = 0
-_FMT_INDEX = 1
-_FMT_ATTR = 2
-_FMT_CONV = 3
-_FMT_SPEC = 4
-
 _FMT_CONV_TYPE = ('a', 'r', 's') if _util.PY3 else ('r', 's')
 
 
@@ -764,7 +758,7 @@ class _ReplaceParser(object):
 
         try:
             if c == '}':
-                value.append((_FMT_FIELD, ''))
+                value.append((_util.FMT_FIELD, ''))
             else:
                 # Field
                 if c in _LETTERS_UNDERSCORE:
@@ -785,9 +779,9 @@ class _ReplaceParser(object):
                 # Try and covert to integer index
                 field = ''.join(value).strip()
                 try:
-                    value = [(_FMT_FIELD, _util.string_type(int(field, 10)))]
+                    value = [(_util.FMT_FIELD, _util.string_type(int(field, 10)))]
                 except ValueError:
-                    value = [(_FMT_FIELD, field)]
+                    value = [(_util.FMT_FIELD, field)]
                     pass
 
                 # Attributes and indexes
@@ -804,9 +798,9 @@ class _ReplaceParser(object):
                             raise SyntaxError("Unmatched '[' at %d" % (sindex - 1))
                         idx = self.parse_format_index(''.join(findex))
                         if isinstance(idx, int):
-                            value.append((_FMT_INDEX, idx))
+                            value.append((_util.FMT_INDEX, idx))
                         else:
-                            value.append((_FMT_INDEX, idx))
+                            value.append((_util.FMT_INDEX, idx))
                         c = self.format_next(i)
                     else:
                         findex = []
@@ -814,14 +808,14 @@ class _ReplaceParser(object):
                         while c in _WORD:
                             findex.append(c)
                             c = self.format_next(i)
-                        value.append((_FMT_ATTR, ''.join(findex)))
+                        value.append((_util.FMT_ATTR, ''.join(findex)))
 
                 # Conversion
                 if c == '!':
                     c = self.format_next(i)
-                    if c not in ('s', 'r', 'a'):
+                    if c not in _FMT_CONV_TYPE:
                         raise SyntaxError("Invalid conversion type at %d!" % (i.index - 1))
-                    value.append((_FMT_CONV, c))
+                    value.append((_util.FMT_CONV, c))
                     c = self.format_next(i)
 
                 # Format spec
@@ -880,10 +874,9 @@ class _ReplaceParser(object):
                     elif not fill:
                         fill = b' ' if self.binary else ' '
 
-                    value.append((_FMT_SPEC, (fill, align, (int(''.join(width)) if width else 0), convert)))
+                    value.append((_util.FMT_SPEC, (fill, align, (int(''.join(width)) if width else 0), convert)))
 
             if c != '}':
-                print(c)
                 raise SyntaxError("Unmatched '{' at %d" % (index - 1))
         except StopIteration:
             raise SyntaxError("Unmatched '{' at %d!" % (index - 1))
@@ -1320,12 +1313,12 @@ class _ReplaceParser(object):
         if field == '':
             if self.auto:
                 field = _util.string_type(self.auto_index)
-                text[0] = (_FMT_FIELD, field)
+                text[0] = (_util.FMT_FIELD, field)
                 self.auto_index += 1
             elif not self.manual and not self.auto:
                 self.auto = True
                 field = _util.string_type(self.auto_index)
-                text[0] = (_FMT_FIELD, field)
+                text[0] = (_util.FMT_FIELD, field)
                 self.auto_index += 1
             else:
                 raise ValueError("Cannot switch to auto format during manual format!")
@@ -1394,71 +1387,6 @@ class _ReplaceParser(object):
             self.use_format,
             self.binary
         )
-
-
-def _to_bstr(l):
-    """Convert to byte string."""
-
-    if isinstance(l, _util.string_type):
-        l = l.encode('ascii', 'backslashreplace')
-    elif not isinstance(l, _util.binary_type):
-        l = _util.string_type(l).encode('ascii', 'backslashreplace')
-    return l
-
-
-def _format(m, group_index, capture, binary):
-    """Perform a string format."""
-
-    try:
-        l = m.group(group_index)
-    except IndexError:  # pragma: no cover
-        raise IndexError("'%d' is out of range!" % group_index)
-
-    for fmt_type, value in capture[1:]:
-        if fmt_type == _FMT_ATTR:
-            # Attribute
-            l = getattr(l, value)
-        elif fmt_type == _FMT_INDEX:
-            # Index
-            l = l[value]
-        elif fmt_type == _FMT_CONV:
-            if binary:
-                # Conversion
-                if value in ('r', 'a'):
-                    l = repr(l).encode('ascii', 'backslashreplace')
-                elif value == 's':
-                    # If the object is not string or byte string already
-                    l = _to_bstr(l)
-            else:
-                # Conversion
-                if value == 'a':
-                    l = ascii(l)
-                elif value == 'r':
-                    l = repr(l)
-                elif value == 's':
-                    # If the object is not string or byte string already
-                    l = _util.string_type(l)
-        elif fmt_type == _FMT_SPEC:
-            # Integers and floats don't have an explicit 's' format type.
-            if value[3] and value[3] == 's':
-                if isinstance(l, int):  # pragma: no cover
-                    raise ValueError("Unknown format code 's' for object of type 'int'")
-                if isinstance(l, float):  # pragma: no cover
-                    raise ValueError("Unknown format code 's' for object of type 'float'")
-
-            # Ensure object is a byte string
-            l = _to_bstr(l) if binary else _util.string_type(l)
-
-            spec_type = value[1]
-            if spec_type == '^':
-                l = l.center(value[2], value[0])
-            elif spec_type == ">":
-                l = l.rjust(value[2], value[0])
-            else:
-                l = l.ljust(value[2], value[0])
-
-    # Make sure the final object is a byte string
-    return _to_bstr(l) if binary else _util.string_type(l)
 
 
 class ReplaceTemplate(_util.Immutable):
@@ -1575,7 +1503,11 @@ class ReplaceTemplate(_util.Immutable):
                         raise IndexError("'%d' is out of range!" % g_index)
                 else:
                     # String format replace
-                    l = _format(m, g_index, capture, self._binary)
+                    try:
+                        obj = m.group(g_index)
+                    except IndexError:  # pragma: no cover
+                        raise IndexError("'%d' is out of range!" % g_index)
+                    l = _util.format(m, obj, capture, self._binary)
                 if span_case is not None:
                     if span_case == _LOWER:
                         l = l.lower()

--- a/backrefs/_bregex_parse.py
+++ b/backrefs/_bregex_parse.py
@@ -1160,6 +1160,8 @@ class _ReplaceParser(object):
             self.binary = True
         else:
             self.binary = False
+        if isinstance(pattern.pattern, _util.binary_type) != self.binary:
+            raise TypeError('Pattern string type must match replace template string type!')
         self._original = template
         self.use_format = use_format
         self.parse_template(pattern)
@@ -1270,7 +1272,8 @@ class ReplaceTemplate(_util.Immutable):
             raise ValueError("Match is None!")
 
         sep = m.string[:0]
-        is_binary = isinstance(sep, _util.binary_type)
+        if isinstance(sep, _util.binary_type) != self._binary:
+            raise TypeError('Match string type does not match expander string type!')
         text = []
         # Expand string
         for x in range(0, len(self.literals)):
@@ -1285,7 +1288,7 @@ class ReplaceTemplate(_util.Immutable):
                         l = m.group(g_index)
                     except IndexError:
                         raise IndexError("'%d' is out of range!" % capture)
-                elif is_binary:
+                elif self._binary:
                     try:
                         l = m.captures(g_index)
                     except IndexError:

--- a/backrefs/_bregex_parse.py
+++ b/backrefs/_bregex_parse.py
@@ -513,7 +513,7 @@ class _ReplaceParser(object):
                     # Handle name
                     value.append(c)
                     c = next(i)
-                    while c not in ('}', '['):
+                    while c not in ('}', '[', ':', '!', '.'):
                         if c not in _WORD:
                             raise SyntaxError('Invalid character at %d!' % (i.index - 1))
                         value.append(c)
@@ -522,7 +522,7 @@ class _ReplaceParser(object):
                     # Handle group number
                     value.append(c)
                     c = next(i)
-                    while c not in ('}', '['):
+                    while c not in ('}', '[', ':', '!', '.'):
                         if c not in _DIGIT:
                             raise SyntaxError('Invalid character! at %d' % (i.index - 1))
                         value.append(c)
@@ -583,7 +583,7 @@ class _ReplaceParser(object):
         except StopIteration:
             raise SyntaxError("Unmatched '{' at %d!" % (index - 1))
 
-        return field, tuple(value)
+        return field, value
 
     def get_format(self, c, i):
         """Get format group."""
@@ -601,7 +601,7 @@ class _ReplaceParser(object):
                     # Handle name
                     value.append(c)
                     c = next(i)
-                    while c not in ('}', '['):
+                    while c not in ('}', '[', ':', '!', '.'):
                         if c not in _WORD:
                             raise SyntaxError('Invalid character at %d!' % (i.index - 1))
                         value.append(c)
@@ -610,7 +610,7 @@ class _ReplaceParser(object):
                     # Handle group number
                     value.append(c)
                     c = next(i)
-                    while c not in ('}', '['):
+                    while c not in ('}', '[', ':', '!', '.'):
                         if c not in _DIGIT:
                             raise SyntaxError('Invalid character! at %d' % (i.index - 1))
                         value.append(c)
@@ -1114,7 +1114,7 @@ class _ReplaceParser(object):
         elif not self.manual:
             raise ValueError("Cannot switch to manual format during auto format!")
 
-        self.handle_group(field, ('{%s}' % text) if not self.binary else text, True)
+        self.handle_group(field, ('{%s}' % text) if not self.binary else tuple(text), True)
 
     def handle_group(self, text, capture=None, is_format=False):
         """Handle groups."""

--- a/backrefs/_bregex_parse.py
+++ b/backrefs/_bregex_parse.py
@@ -1169,16 +1169,17 @@ class _ReplaceParser(object):
             tuple(self.group_slots),
             tuple(self.literals),
             hash(pattern),
-            self.use_format
+            self.use_format,
+            self.binary
         )
 
 
 class ReplaceTemplate(_util.Immutable):
     """Replacement template expander."""
 
-    __slots__ = ("groups", "group_slots", "literals", "pattern_hash", "use_format", "_hash")
+    __slots__ = ("groups", "group_slots", "literals", "pattern_hash", "use_format", "_hash", "_binary")
 
-    def __init__(self, groups, group_slots, literals, pattern_hash, use_format):
+    def __init__(self, groups, group_slots, literals, pattern_hash, use_format, binary):
         """Initialize."""
 
         super(ReplaceTemplate, self).__init__(
@@ -1187,11 +1188,12 @@ class ReplaceTemplate(_util.Immutable):
             group_slots=group_slots,
             literals=literals,
             pattern_hash=pattern_hash,
+            _binary=binary,
             _hash=hash(
                 (
                     type(self),
                     groups, group_slots, literals,
-                    pattern_hash, use_format
+                    pattern_hash, use_format, binary
                 )
             )
         )
@@ -1215,7 +1217,8 @@ class ReplaceTemplate(_util.Immutable):
             self.group_slots == other.group_slots and
             self.literals == other.literals and
             self.pattern_hash == other.pattern_hash and
-            self.use_format == other.use_format
+            self.use_format == other.use_format and
+            self._binary == other._binary
         )
 
     def __ne__(self, other):
@@ -1227,7 +1230,8 @@ class ReplaceTemplate(_util.Immutable):
             self.group_slots != other.group_slots or
             self.literals != other.literals or
             self.pattern_hash != other.pattern_hash or
-            self.use_format != other.use_format
+            self.use_format != other.use_format or
+            self._binary != other._binary
         )
 
     def __repr__(self):  # pragma: no cover
@@ -1332,7 +1336,7 @@ class ReplaceTemplate(_util.Immutable):
 def _pickle(r):
     """Pickle."""
 
-    return ReplaceTemplate, (r.groups, r.group_slots, r.literals, r.pattern_hash, r.use_format)
+    return ReplaceTemplate, (r.groups, r.group_slots, r.literals, r.pattern_hash, r.use_format, r._binary)
 
 
 _util.copyreg.pickle(ReplaceTemplate, _pickle)

--- a/backrefs/_bregex_parse.py
+++ b/backrefs/_bregex_parse.py
@@ -1286,12 +1286,12 @@ class ReplaceTemplate(_util.Immutable):
                     # Non format replace
                     try:
                         l = m.group(g_index)
-                    except IndexError:
+                    except IndexError:  # pragma: no cover
                         raise IndexError("'%d' is out of range!" % capture)
                 elif self._binary:
                     try:
                         l = m.captures(g_index)
-                    except IndexError:
+                    except IndexError:  # pragma: no cover
                         raise IndexError("'%d' is out of range!" % g_index)
 
                     for x in capture[1:]:

--- a/backrefs/_bregex_parse.py
+++ b/backrefs/_bregex_parse.py
@@ -1274,6 +1274,9 @@ class ReplaceTemplate(_util.Immutable):
         sep = m.string[:0]
         if isinstance(sep, _util.binary_type) != self._binary:
             raise TypeError('Match string type does not match expander string type!')
+        if self.use_format and not self._binary:
+            capture_args = m.captures(*_util.iter_range(len(m)))
+            capture_dict = m.capturesdict()
         text = []
         # Expand string
         for x in range(0, len(self.literals)):
@@ -1320,7 +1323,7 @@ class ReplaceTemplate(_util.Immutable):
                         l = repr(l).encode('ascii', 'backslashreplace')
                 else:
                     # Format replace
-                    l = _util.Formatter().format(capture, *m.captures(*range(len(m))), **m.capturesdict())
+                    l = _util.Formatter().vformat(capture, capture_args, capture_dict)
                 if span_case is not None:
                     if span_case == _LOWER:
                         l = l.lower()

--- a/backrefs/_bregex_parse.py
+++ b/backrefs/_bregex_parse.py
@@ -32,9 +32,31 @@ _GLOBAL_FLAGS = frozenset(('L', 'a', 'b', 'e', 'r', 'u', 'p'))
 _SCOPED_FLAGS = frozenset(('i', 'm', 's', 'f', 'w', 'x'))
 _VERSIONS = frozenset(('0', '1'))
 
+_CURLY_BRACKETS_ORD = frozenset((0x7b, 0x7d))
+
 # Case upper or lower
 _UPPER = 1
 _LOWER = 2
+
+# Format Constants
+_BACK_SLASH_TRANSLATION = {
+    "\\a": '\a',
+    "\\b": '\b',
+    "\\f": '\f',
+    "\\r": '\r',
+    "\\t": '\t',
+    "\\n": '\n',
+    "\\v": '\v',
+    "\\\\": '\\'
+}
+
+_FMT_FIELD = 0
+_FMT_INDEX = 1
+_FMT_ATTR = 2
+_FMT_CONV = 3
+_FMT_SPEC = 4
+
+_FMT_CONV_TYPE = ('a', 'r', 's') if _util.PY3 else ('r', 's')
 
 
 class LoopException(Exception):
@@ -496,95 +518,6 @@ class _ReplaceParser(object):
             pass
         return text
 
-    def get_byte_format(self, c, i):
-        """Get byte format group."""
-
-        index = i.index
-        field = ''
-        value = []
-
-        try:
-            if c == '}':
-                value.append('')
-                value.append((False, -1))
-            else:
-                # Field
-                if c in _LETTERS_UNDERSCORE:
-                    # Handle name
-                    value.append(c)
-                    c = next(i)
-                    while c not in ('}', '[', ':', '!', '.'):
-                        if c not in _WORD:
-                            raise SyntaxError('Invalid character at %d!' % (i.index - 1))
-                        value.append(c)
-                        c = next(i)
-                elif c in _DIGIT:
-                    # Handle group number
-                    value.append(c)
-                    c = next(i)
-                    while c not in ('}', '[', ':', '!', '.'):
-                        if c not in _DIGIT:
-                            raise SyntaxError('Invalid character! at %d' % (i.index - 1))
-                        value.append(c)
-                        c = next(i)
-
-                # Try and covert to integer index
-                field = ''.join(value).strip()
-                try:
-                    value = [_util.string_type(int(field, 10))]
-                except ValueError:
-                    value = [field]
-                    pass
-
-                # Attributes and indexes
-                count = 0
-                while c in ('[', '.'):
-                    if c == '[':
-                        findex = []
-                        sindex = i.index - 1
-                        c = next(i)
-                        while c not in (']', '}'):
-                            findex.append(c)
-                            c = next(i)
-                        if c != ']':
-                            raise SyntaxError("Unmatched '[' at %d" % (sindex - 1))
-                        idx = self.parse_format_index(''.join(findex))
-                        if isinstance(idx, int):
-                            value.append((False, idx))
-                        else:
-                            value.append((False, idx))
-                        c = next(i)
-                    else:
-                        if count == 0:
-                            value.append((False, -1))
-                        findex = []
-                        c = next(i)
-                        while c in _WORD:
-                            findex.append(c)
-                            c = next(i)
-                        value.append((True, ''.join(findex)))
-                    count += 1
-
-                if count == 0:
-                    value.append((False, -1))
-
-                # Conversion
-                if c == '!':
-                    c = next(i)
-                    if c not in ('s', 'r', 'a'):
-                        raise SyntaxError("Invalid conversion type at %d!" % (i.index - 1))
-                    value.append(('!' + c))
-                    c = next(i)
-
-                # Format spec is not currently supported in byte strings.
-
-            if c != '}':
-                raise SyntaxError("Unmatched '{' at %d" % (index - 1))
-        except StopIteration:
-            raise SyntaxError("Unmatched '{' at %d!" % (index - 1))
-
-        return field, value
-
     def get_format(self, c, i):
         """Get format group."""
 
@@ -594,34 +527,31 @@ class _ReplaceParser(object):
 
         try:
             if c == '}':
-                value.append('[-1]')
+                value.append((_FMT_FIELD, ''))
+                value.append((_FMT_INDEX, -1))
             else:
                 # Field
                 if c in _LETTERS_UNDERSCORE:
                     # Handle name
                     value.append(c)
-                    c = next(i)
-                    while c not in ('}', '[', ':', '!', '.'):
-                        if c not in _WORD:
-                            raise SyntaxError('Invalid character at %d!' % (i.index - 1))
+                    c = self.format_next(i)
+                    while c in _WORD:
                         value.append(c)
-                        c = next(i)
+                        c = self.format_next(i)
                 elif c in _DIGIT:
                     # Handle group number
                     value.append(c)
-                    c = next(i)
-                    while c not in ('}', '[', ':', '!', '.'):
-                        if c not in _DIGIT:
-                            raise SyntaxError('Invalid character! at %d' % (i.index - 1))
+                    c = self.format_next(i)
+                    while c in _DIGIT:
                         value.append(c)
-                        c = next(i)
+                        c = self.format_next(i)
 
                 # Try and covert to integer index
                 field = ''.join(value).strip()
                 try:
-                    value = [_util.string_type(int(field, 10))]
+                    value = [(_FMT_FIELD, _util.string_type(int(field, 10)))]
                 except ValueError:
-                    value = [field]
+                    value = [(_FMT_FIELD, field)]
                     pass
 
                 # Attributes and indexes
@@ -630,68 +560,119 @@ class _ReplaceParser(object):
                     if c == '[':
                         findex = []
                         sindex = i.index - 1
-                        value.append(c)
-                        c = next(i)
-                        while c not in (']', '}'):
-                            findex.append(c)
-                            c = next(i)
-                        if c != ']':
+                        c = self.format_next(i)
+                        try:
+                            while c != ']':
+                                findex.append(c)
+                                c = self.format_next(i)
+                        except StopIteration:
                             raise SyntaxError("Unmatched '[' at %d" % (sindex - 1))
-                        value.append(_util.string_type(self.parse_format_index(''.join(findex))))
-                        value.append(c)
-                        c = next(i)
+                        idx = self.parse_format_index(''.join(findex))
+                        if isinstance(idx, int):
+                            value.append((_FMT_INDEX, idx))
+                        else:
+                            value.append((_FMT_INDEX, idx))
+                        c = self.format_next(i)
                     else:
                         if count == 0:
-                            value.append('[-1]')
-                        value.append(c)
-                        c = next(i)
+                            value.append((_FMT_INDEX, -1))
+                        findex = []
+                        c = self.format_next(i)
                         while c in _WORD:
-                            value.append(c)
-                            c = next(i)
+                            findex.append(c)
+                            c = self.format_next(i)
+                        value.append((_FMT_ATTR, ''.join(findex)))
                     count += 1
 
                 if count == 0:
-                    value.append('[-1]')
+                    value.append((_FMT_INDEX, -1))
 
                 # Conversion
                 if c == '!':
-                    value.append(c)
-                    c = next(i)
+                    c = self.format_next(i)
                     if c not in ('s', 'r', 'a'):
                         raise SyntaxError("Invalid conversion type at %d!" % (i.index - 1))
-                    value.append(c)
-                    c = next(i)
+                    value.append((_FMT_CONV, c))
+                    c = self.format_next(i)
 
                 # Format spec
                 if c == ':':
-                    value.append(c)
-                    c = next(i)
-                    while c != '}':
-                        value.append(c)
-                        c = next(i)
+                    fill = None
+                    width = []
+                    align = None
+                    convert = None
+                    c = self.format_next(i)
+
+                    if c in ('<', '>', '^'):
+                        # Get fill and alignment
+                        align = c
+                        c = self.format_next(i)
+                        if c in ('<', '>', '^'):
+                            fill = align
+                            align = c
+                            c = self.format_next(i)
+                    elif c in _DIGIT:
+                        # Get Width
+                        fill = c
+                        c = self.format_next(i)
+                        if c in ('<', '>', '^'):
+                            align = c
+                            c = self.format_next(i)
+                        else:
+                            width.append(fill)
+                            fill = None
+                    else:
+                        fill = c
+                        c = self.format_next(i)
+                        if fill == 's' and c == '}':
+                            convert = fill
+                            fill = None
+                        if fill is not None:
+                            if c not in ('<', '>', '^'):
+                                raise SyntaxError('Invalid format spec char at %d!' % (i.index - 1))
+                            align = c
+                            c = self.format_next(i)
+
+                    while c in _DIGIT:
+                        width.append(c)
+                        c = self.format_next(i)
+
+                    if not align and len(width) and width[0] == '0':
+                        raise ValueError("'=' alignment is not supported!")
+                    if align and not fill and len(width) and width[0] == '0':
+                        fill = '0'
+
+                    if c == 's':
+                        convert = c
+                        c = self.format_next(i)
+
+                    if fill and self.binary:
+                        fill = fill.encode('latin-1')
+                    elif not fill:
+                        fill = b' ' if self.binary else ' '
+
+                    value.append((_FMT_SPEC, (fill, align, (int(''.join(width)) if width else 0), convert)))
+
             if c != '}':
                 raise SyntaxError("Unmatched '{' at %d" % (index - 1))
         except StopIteration:
             raise SyntaxError("Unmatched '{' at %d!" % (index - 1))
 
-        return field, ''.join(value).strip()
+        return field, value
 
     def handle_format(self, t, i):
         """Handle format."""
 
         if t == '{':
-            t = next(i)
+            t = self.format_next(i)
             if t == '{':
                 self.get_single_stack()
                 self.result.append(t)
             else:
-                if self.binary:
-                    field, text = self.get_byte_format(t, i)
-                else:
-                    field, text = self.get_format(t, i)
+                field, text = self.get_format(t, i)
                 self.handle_format_group(field, text)
         else:
-            t = next(i)
+            t = self.format_next(i)
             if t == '}':
                 self.get_single_stack()
                 self.result.append(t)
@@ -723,13 +704,13 @@ class _ReplaceParser(object):
             pass
 
         octal_count = len(value)
-        if not (zero_count and octal_count < 3) and octal_count != 3:
+        if not (self.use_format and octal_count) and not (zero_count and octal_count < 3) and octal_count != 3:
             i.rewind(i.index - index)
             value = []
 
         return ''.join(value) if value else None
 
-    def parse_octal(self, text):
+    def parse_octal(self, text, i):
         """Parse octal value."""
 
         value = int(text, 8)
@@ -743,7 +724,9 @@ class _ReplaceParser(object):
                 value = _util.uord(self.convert_case(text, single)) if single is not None else _util.uord(text)
             elif single:
                 value = _util.uord(self.convert_case(_util.uchr(value), single))
-            if value <= 0xFF:
+            if self.use_format and value in _CURLY_BRACKETS_ORD:
+                self.handle_format(_util.uchr(value), i)
+            elif value <= 0xFF:
                 self.result.append('\\%03o' % value)
             else:
                 self.result.append(_util.uchr(value))
@@ -775,7 +758,9 @@ class _ReplaceParser(object):
             value = _util.uord(self.convert_case(text, single)) if single is not None else _util.uord(text)
         elif single:
             value = _util.uord(self.convert_case(_util.uchr(value), single))
-        if value <= 0xFF:
+        if self.use_format and value in _CURLY_BRACKETS_ORD:
+            self.handle_format(_util.uchr(value), i)
+        elif value <= 0xFF:
             self.result.append('\\%03o' % value)
         else:
             self.result.append(_util.uchr(value))
@@ -828,7 +813,9 @@ class _ReplaceParser(object):
             value = _util.uord(self.convert_case(text, single)) if single is not None else _util.uord(text)
         elif single:
             value = _util.uord(self.convert_case(_util.uchr(value), single))
-        if value <= 0xFF:
+        if self.use_format and value in _CURLY_BRACKETS_ORD:
+            self.handle_format(_util.uchr(value), i)
+        elif value <= 0xFF:
             self.result.append('\\%03o' % value)
         else:
             self.result.append(_util.uchr(value))
@@ -855,7 +842,10 @@ class _ReplaceParser(object):
             value = _util.uord(self.convert_case(text, single)) if single is not None else _util.uord(text)
         elif single:
             value = _util.uord(self.convert_case(chr(value), single))
-        self.result.append('\\%03o' % value)
+        if self.use_format and value in _CURLY_BRACKETS_ORD:
+            self.handle_format(_util.uchr(value), i)
+        else:
+            self.result.append('\\%03o' % value)
 
     def get_named_group(self, t, i):
         """Get group number."""
@@ -907,13 +897,42 @@ class _ReplaceParser(object):
             pass
         return ''.join(value) if value else None
 
+    def format_next(self, i):
+        """Get next format char."""
+
+        c = next(i)
+        return self.format_references(next(i), i) if c == '\\' else c
+
+    def format_references(self, t, i):
+        """Handle format references."""
+
+        octal = self.get_octal(t, i)
+        if octal:
+            value = int(octal, 8)
+            if value > 0xFF and self.binary:
+                # Re fails on octal greater than 0o377 or 0xFF
+                raise ValueError("octal escape value outside of range 0-0o377!")
+            value = _util.uchr(value)
+        elif t in _STANDARD_ESCAPES or t == '\\':
+            value = _BACK_SLASH_TRANSLATION['\\' + t]
+        elif not self.binary and t == "U":
+            value = _util.uchr(int(self.get_wide_unicode(i), 16))
+        elif not self.binary and t == "u":
+            value = _util.uchr(int(self.get_narrow_unicode(i), 16))
+        elif not self.binary and t == "N":
+            value = _unicodedata.lookup(self.get_named_unicode(i))
+        elif t == "x":
+            value = _util.uchr(int(self.get_byte(i), 16))
+        else:
+            i.rewind(1)
+            value = '\\'
+        return value
+
     def reference(self, t, i):
         """Handle references."""
         octal = self.get_octal(t, i)
-        if t in _OCTAL and (self.use_format or octal):
-            if not octal:
-                octal = self.get_group(t, i)
-            self.parse_octal(octal)
+        if t in _OCTAL and octal:
+            self.parse_octal(octal, i)
         elif (t in _DIGIT or t == 'g') and not self.use_format:
             group = self.get_group(t, i)
             if not group:
@@ -1094,18 +1113,12 @@ class _ReplaceParser(object):
         if field == '':
             if self.auto:
                 field = _util.string_type(self.auto_index)
-                if not self.binary:
-                    text = field + text
-                else:
-                    text[0] = field
+                text[0] = (_FMT_FIELD, field)
                 self.auto_index += 1
             elif not self.manual and not self.auto:
                 self.auto = True
                 field = _util.string_type(self.auto_index)
-                if not self.binary:
-                    text = field + text
-                else:
-                    text[0] = field
+                text[0] = (_FMT_FIELD, field)
                 self.auto_index += 1
             else:
                 raise ValueError("Cannot switch to auto format during manual format!")
@@ -1114,7 +1127,7 @@ class _ReplaceParser(object):
         elif not self.manual:
             raise ValueError("Cannot switch to manual format during auto format!")
 
-        self.handle_group(field, ('{%s}' % text) if not self.binary else tuple(text), True)
+        self.handle_group(field, tuple(text), True)
 
     def handle_group(self, text, capture=None, is_format=False):
         """Handle groups."""
@@ -1174,6 +1187,71 @@ class _ReplaceParser(object):
             self.use_format,
             self.binary
         )
+
+
+def _to_bstr(l):
+    """Convert to byte string."""
+
+    if isinstance(l, _util.string_type):
+        l = l.encode('ascii', 'backslashreplace')
+    elif not isinstance(l, _util.binary_type):
+        l = _util.string_type(l).encode('ascii', 'backslashreplace')
+    return l
+
+
+def _format(m, group_index, capture, binary):
+    """Perform a string format."""
+
+    try:
+        l = m.captures(group_index)
+    except IndexError:  # pragma: no cover
+        raise IndexError("'%d' is out of range!" % group_index)
+
+    for fmt_type, value in capture[1:]:
+        if fmt_type == _FMT_ATTR:
+            # Attribute
+            l = getattr(l, value)
+        elif fmt_type == _FMT_INDEX:
+            # Index
+            l = l[value]
+        elif fmt_type == _FMT_CONV:
+            if binary:
+                # Conversion
+                if value in ('r', 'a'):
+                    l = repr(l).encode('ascii', 'backslashreplace')
+                elif value == 's':
+                    # If the object is not string or byte string already
+                    l = _to_bstr(l)
+            else:
+                # Conversion
+                if value == 'a':
+                    l = ascii(l)
+                elif value == 'r':
+                    l = repr(l)
+                elif value == 's':
+                    # If the object is not string or byte string already
+                    l = _util.string_type(l)
+        elif fmt_type == _FMT_SPEC:
+            # Integers and floats don't have an explicit 's' format type.
+            if value[3] and value[3] == 's':
+                if isinstance(l, int):  # pragma: no cover
+                    raise ValueError("Unknown format code 's' for object of type 'int'")
+                if isinstance(l, float):  # pragma: no cover
+                    raise ValueError("Unknown format code 's' for object of type 'float'")
+
+            # Ensure object is a byte string
+            l = _to_bstr(l) if binary else _util.string_type(l)
+
+            spec_type = value[1]
+            if spec_type == '^':
+                l = l.center(value[2], value[0])
+            elif spec_type == ">":
+                l = l.rjust(value[2], value[0])
+            else:
+                l = l.ljust(value[2], value[0])
+
+    # Make sure the final object is a byte string
+    return _to_bstr(l) if binary else _util.string_type(l)
 
 
 class ReplaceTemplate(_util.Immutable):
@@ -1245,7 +1323,7 @@ class ReplaceTemplate(_util.Immutable):
             self.pattern_hash, self.use_format
         )
 
-    def get_group_index(self, index):
+    def _get_group_index(self, index):
         """Find and return the appropriate group index."""
 
         g_index = None
@@ -1255,7 +1333,7 @@ class ReplaceTemplate(_util.Immutable):
                 break
         return g_index
 
-    def get_group_attributes(self, index):
+    def _get_group_attributes(self, index):
         """Find and return the appropriate group case."""
 
         g_case = (None, None, -1)
@@ -1274,56 +1352,23 @@ class ReplaceTemplate(_util.Immutable):
         sep = m.string[:0]
         if isinstance(sep, _util.binary_type) != self._binary:
             raise TypeError('Match string type does not match expander string type!')
-        if self.use_format and not self._binary:
-            capture_args = m.captures(*_util.iter_range(len(m)))
-            capture_dict = m.capturesdict()
         text = []
         # Expand string
         for x in range(0, len(self.literals)):
             index = x
             l = self.literals[x]
             if l is None:
-                g_index = self.get_group_index(index)
-                span_case, single_case, capture = self.get_group_attributes(index)
+                g_index = self._get_group_index(index)
+                span_case, single_case, capture = self._get_group_attributes(index)
                 if not self.use_format:
                     # Non format replace
                     try:
                         l = m.group(g_index)
                     except IndexError:  # pragma: no cover
                         raise IndexError("'%d' is out of range!" % capture)
-                elif self._binary:
-                    try:
-                        l = m.captures(g_index)
-                    except IndexError:  # pragma: no cover
-                        raise IndexError("'%d' is out of range!" % g_index)
-
-                    for x in capture[1:]:
-                        if isinstance(x, tuple):
-                            if x[0]:
-                                # Attribute
-                                l = getattr(l, x[1])
-                            else:
-                                # Index
-                                l = l[x[1]]
-                        elif x.startswith('!'):
-                            # Conversion
-                            conversion = x[1]
-                            if conversion in ('r', 'a'):
-                                l = repr(l).encode('ascii', 'backslashreplace')
-                            elif conversion == 's':
-                                # If the object is not string or byte string already
-                                if not isinstance(l, (_util.string_type, _util.binary_type)):
-                                    l = _util.string_type(l).encode('ascii', 'backslashreplace')
-                                elif isinstance(l, _util.string_type):
-                                    l = l.encode('ascii', 'backslashreplace')
-                    # Make sure the final object is a byte string
-                    if isinstance(l, _util.string_type):
-                        l = l.encode('ascii', 'backslashreplace')
-                    elif not isinstance(l, _util.binary_type):
-                        l = repr(l).encode('ascii', 'backslashreplace')
                 else:
-                    # Format replace
-                    l = _util.Formatter().vformat(capture, capture_args, capture_dict)
+                    # String format replace
+                    l = _format(m, g_index, capture, self._binary)
                 if span_case is not None:
                     if span_case == _LOWER:
                         l = l.lower()

--- a/backrefs/_bregex_parse.py
+++ b/backrefs/_bregex_parse.py
@@ -477,15 +477,35 @@ class _ReplaceParser(object):
         self.auto = False
         self.auto_index = 0
 
+    def parse_format_index(self, text):
+        """Parse format index."""
+
+        base = 10
+        prefix = text[1:3] if text[0] == "-" else text[:2]
+        if prefix[0:1] == "0":
+            char = prefix[-1]
+            if char == "b":
+                base = 2
+            elif char == "o":
+                base = 8
+            elif char == "x":
+                base = 16
+        try:
+            text = int(text, base)
+        except Exception:
+            pass
+        return _util.string_type(text)
+
     def get_format(self, c, i):
         """Get format group."""
 
         index = i.index
-
+        field = ''
         value = []
+
         try:
             if c == '}':
-                value.append('')
+                value.append('[-1]')
             else:
                 # Field
                 if c in _LETTERS_UNDERSCORE:
@@ -506,25 +526,44 @@ class _ReplaceParser(object):
                             raise SyntaxError('Invalid character! at %d' % (i.index - 1))
                         value.append(c)
                         c = next(i)
+
+                # Try and covert to integer index
+                field = ''.join(value).strip()
+                try:
+                    value = [_util.string_type(int(field, 10))]
+                except ValueError:
+                    value = [field]
+                    pass
+
                 # Attributes and indexes
+                count = 0
                 while c in ('[', '.'):
                     if c == '[':
+                        findex = []
                         sindex = i.index - 1
                         value.append(c)
                         c = next(i)
                         while c not in (']', '}'):
-                            value.append(c)
+                            findex.append(c)
                             c = next(i)
                         if c != ']':
                             raise SyntaxError("Unmatched '[' at %d" % (sindex - 1))
+                        value.append(self.parse_format_index(''.join(findex)))
                         value.append(c)
                         c = next(i)
                     else:
+                        if count == 0:
+                            value.append('[-1]')
                         value.append(c)
                         c = next(i)
                         while c in _WORD:
                             value.append(c)
                             c = next(i)
+                    count += 1
+
+                if count == 0:
+                    value.append('[-1]')
+
                 # Conversion
                 if c == '!':
                     value.append(c)
@@ -533,6 +572,7 @@ class _ReplaceParser(object):
                         raise SyntaxError("Invalid conversion type at %d!" % (i.index - 1))
                     value.append(c)
                     c = next(i)
+
                 # Format spec
                 if c == ':':
                     value.append(c)
@@ -545,7 +585,7 @@ class _ReplaceParser(object):
         except StopIteration:
             raise SyntaxError("Unmatched '{' at %d!" % (index - 1))
 
-        return ''.join(value)
+        return field, ''.join(value).strip()
 
     def handle_format(self, t, i):
         """Handle format."""
@@ -556,8 +596,8 @@ class _ReplaceParser(object):
                 self.get_single_stack()
                 self.result.append(t)
             else:
-                text = self.get_format(t, i)
-                self.handle_format_group(text.strip())
+                field, text = self.get_format(t, i)
+                self.handle_format_group(field, text)
         else:
             t = next(i)
             if t == '}':
@@ -955,91 +995,28 @@ class _ReplaceParser(object):
             single = self.single_stack.pop()
         return single
 
-    def handle_format_group(self, text):
+    def handle_format_group(self, field, text):
         """Handle format group."""
 
-        group = ''
-        fields, spec, convert = next(_util._string.formatter_parser('{%s}' % text))[1:]
-        value, rest = _util._string.formatter_field_name_split(fields)
-        extra = [
-            ((":" + spec) if spec else spec),
-            ('' if convert is None else '!' + convert)
-        ]
-
-        # Format the group name/index
-        if not isinstance(value, int):
-            try:
-                value = _util.string_type(int(value, 10))
-            except ValueError:
-                pass
-        else:
-            value = _util.string_type(value)
-        capture = [_util.string_type(value)]
-
-        # Format integer indexes inside []
-        found_first = False
-        for is_attr, i in rest:
-            # If we are missing the capture index, assume -1
-            if not found_first:
-                if is_attr:
-                    capture.append('[-1]')
-                found_first = True
-
-            # We don't care about attributes, so just add it back
-            if is_attr:
-                capture.append('.' + i)
-
-            # Parse various integer formats
-            elif not isinstance(i, int):
-                base = 10
-                prefix = i[1:3] if i[0] == "-" else i[:2]
-                if prefix[0:1] == "0":
-                    char = prefix[-1]
-                    if char == "b":
-                        base = 2
-                    elif char == "o":
-                        base = 8
-                    elif char == "x":
-                        base = 16
-                try:
-                    i = int(i, base)
-                except Exception:
-                    pass
-                capture.append('[%s]' % _util.string_type(i))
-
-            # Index is already an integer
-            else:
-                capture.append('[%s]' % _util.string_type(i))
-
-        # There were no additional attributes or indexes, so add capture index
-        if not found_first:
-            capture.append('[-1]')
-
-        # Rebuild format string
-        text = ''.join(capture + extra)
-
-        # Handle auot incrementing group indexes
-        if value == '':
+        # Handle auto incrementing group indexes
+        if field == '':
             if self.auto:
-                group = _util.string_type(self.auto_index)
-                text = group + text
+                field = _util.string_type(self.auto_index)
+                text = field + text
                 self.auto_index += 1
             elif not self.manual and not self.auto:
                 self.auto = True
-                group = _util.string_type(self.auto_index)
-                text = group + text
+                field = _util.string_type(self.auto_index)
+                text = field + text
                 self.auto_index += 1
             else:
                 raise ValueError("Cannot switch to auto format during manual format!")
         elif not self.manual and not self.auto:
-            group = value
             self.manual = True
         elif not self.manual:
             raise ValueError("Cannot switch to manual format during auto format!")
-        else:
-            group = value
 
-        self.handle_group(group, '{%s}' % text, True)
+        self.handle_group(field, '{%s}' % text, True)
 
     def handle_group(self, text, capture='', is_format=False):
         """Handle groups."""

--- a/backrefs/bre.py
+++ b/backrefs/bre.py
@@ -69,14 +69,14 @@ _RE_TYPE = type(_re.compile('', 0))
 
 
 @_util.lru_cache(maxsize=_MAXCACHE)
-def _cached_search_compile(pattern, re_verbose, re_version):
+def _cached_search_compile(pattern, re_verbose, re_version, pattern_type):
     """Cached search compile."""
 
     return _bre_parse._SearchParser(pattern, re_verbose, re_version).parse()
 
 
 @_util.lru_cache(maxsize=_MAXCACHE)
-def _cached_replace_compile(pattern, repl, flags):
+def _cached_replace_compile(pattern, repl, flags, pattern_type):
     """Cached replace compile."""
 
     return _bre_parse._ReplaceParser().parse(pattern, repl, bool(flags & FORMAT))
@@ -128,7 +128,7 @@ def _apply_search_backrefs(pattern, flags=0):
         elif bool(UNICODE & flags):
             re_unicode = True
         if not (flags & DEBUG):
-            pattern = _cached_search_compile(pattern, re_verbose, re_unicode)
+            pattern = _cached_search_compile(pattern, re_verbose, re_unicode, type(pattern))
         else:  # pragma: no cover
             pattern = _bre_parse._SearchParser(pattern, re_verbose, re_unicode).parse()
     elif isinstance(pattern, Bre):
@@ -170,7 +170,7 @@ class Bre(_util.Immutable):
         super(Bre, self).__init__(
             _pattern=pattern,
             auto_compile=auto_compile,
-            _hash=hash((type(self), pattern, auto_compile))
+            _hash=hash((type(self), type(pattern), pattern, auto_compile))
         )
 
     @property
@@ -336,7 +336,7 @@ def compile_replace(pattern, repl, flags=0):
     if pattern is not None and isinstance(pattern, _RE_TYPE):
         if isinstance(repl, (_util.string_type, _util.binary_type)):
             if not (pattern.flags & DEBUG):
-                call = _cached_replace_compile(pattern, repl, flags)
+                call = _cached_replace_compile(pattern, repl, flags, type(repl))
             else:  # pragma: no cover
                 call = _bre_parse._ReplaceParser().parse(pattern, repl, bool(flags & FORMAT))
         elif isinstance(repl, ReplaceTemplate):

--- a/backrefs/bregex.py
+++ b/backrefs/bregex.py
@@ -80,14 +80,14 @@ _REGEX_TYPE = type(_regex.compile('', 0))
 
 
 @_util.lru_cache(maxsize=_MAXCACHE)
-def _cached_search_compile(pattern, re_verbose, re_version):
+def _cached_search_compile(pattern, re_verbose, re_version, pattern_type):
     """Cached search compile."""
 
     return _bregex_parse._SearchParser(pattern, re_verbose, re_version).parse()
 
 
 @_util.lru_cache(maxsize=_MAXCACHE)
-def _cached_replace_compile(pattern, repl, flags):
+def _cached_replace_compile(pattern, repl, flags, pattern_type):
     """Cached replace compile."""
 
     return _bregex_parse._ReplaceParser().parse(pattern, repl, bool(flags & FORMAT))
@@ -140,7 +140,7 @@ def _apply_search_backrefs(pattern, flags=0):
         else:
             re_version = 0
         if not (flags & DEBUG):
-            pattern = _cached_search_compile(pattern, re_verbose, re_version)
+            pattern = _cached_search_compile(pattern, re_verbose, re_version, type(pattern))
         else:  # pragma: no cover
             pattern = _bregex_parse._SearchParser(pattern, re_verbose, re_version).parse()
     elif isinstance(pattern, Bregex):
@@ -197,7 +197,7 @@ def compile_replace(pattern, repl, flags=0):
     if pattern is not None and isinstance(pattern, _REGEX_TYPE):
         if isinstance(repl, (_util.string_type, _util.binary_type)):
             if not (pattern.flags & DEBUG):
-                call = _cached_replace_compile(pattern, repl, flags)
+                call = _cached_replace_compile(pattern, repl, flags, type(pattern))
             else:  # pragma: no cover
                 call = _bregex_parse._ReplaceParser().parse(pattern, repl, bool(flags & FORMAT))
         elif isinstance(repl, ReplaceTemplate):
@@ -227,7 +227,7 @@ class Bregex(_util.Immutable):
         super(Bregex, self).__init__(
             _pattern=pattern,
             auto_compile=auto_compile,
-            _hash=hash((type(self), pattern, auto_compile))
+            _hash=hash((type(self), type(pattern), pattern, auto_compile))
         )
 
     @property

--- a/backrefs/bregex.py
+++ b/backrefs/bregex.py
@@ -197,7 +197,7 @@ def compile_replace(pattern, repl, flags=0):
     if pattern is not None and isinstance(pattern, _REGEX_TYPE):
         if isinstance(repl, (_util.string_type, _util.binary_type)):
             if not (pattern.flags & DEBUG):
-                call = _cached_replace_compile(pattern, repl, flags, type(pattern))
+                call = _cached_replace_compile(pattern, repl, flags, type(repl))
             else:  # pragma: no cover
                 call = _bregex_parse._ReplaceParser().parse(pattern, repl, bool(flags & FORMAT))
         elif isinstance(repl, ReplaceTemplate):

--- a/backrefs/util.py
+++ b/backrefs/util.py
@@ -6,7 +6,6 @@ Copyright (c) 2015 - 2018 Isaac Muse <isaacmuse@gmail.com>
 """
 import sys
 import struct
-import string
 
 PY2 = (2, 0) <= sys.version_info < (3, 0)
 PY3 = (3, 0) <= sys.version_info < (4, 0)
@@ -118,31 +117,3 @@ class Immutable(object):
         """Prevent mutability."""
 
         raise AttributeError('Class is immutable!')
-
-
-class Formatter(string.Formatter):
-    """Formatter."""
-
-    def get_field(self, field_name, args, kwargs):
-        """Get field."""
-
-        if PY3:
-            first, rest = _string.formatter_field_name_split(field_name)
-        else:
-            first, rest = field_name._formatter_field_name_split()
-
-        obj = self.get_value(first, args, kwargs)
-
-        # loop through the rest of the field_name, doing
-        #  getattr or getitem as needed
-        for is_attr, i in rest:
-            if is_attr:
-                obj = getattr(obj, i)
-            else:
-                try:
-                    i = int(i, 10)
-                except Exception:
-                    pass
-                obj = obj[i]
-
-        return obj, first

--- a/backrefs/util.py
+++ b/backrefs/util.py
@@ -124,7 +124,10 @@ class Formatter(string.Formatter):
     def get_field(self, field_name, args, kwargs):
         """Get field."""
 
-        first, rest = _string.formatter_field_name_split(field_name)
+        if PY3:
+            first, rest = _string.formatter_field_name_split(field_name)
+        else:
+            first, rest = field_name._formatter_field_name_split()
 
         obj = self.get_value(first, args, kwargs)
 

--- a/backrefs/util.py
+++ b/backrefs/util.py
@@ -22,6 +22,7 @@ if PY3:
     string_type = str
     binary_type = bytes
     unichar = chr
+    iter_range = range  # noqa F821
 
 else:
     from backports.functools_lru_cache import lru_cache  # noqa F401
@@ -30,6 +31,7 @@ else:
     string_type = unicode  # noqa F821
     binary_type = str  # noqa F821
     unichar = unichr  # noqa F821
+    iter_range = xrange  # noqa F821
 
 
 class StringIter(object):

--- a/backrefs/util.py
+++ b/backrefs/util.py
@@ -16,7 +16,6 @@ PY37 = (3, 7) <= sys.version_info
 if PY3:
     from functools import lru_cache  # noqa F401
     import copyreg  # noqa F401
-    import _string
 
     string_type = str
     binary_type = bytes

--- a/backrefs/util.py
+++ b/backrefs/util.py
@@ -7,7 +7,6 @@ Copyright (c) 2015 - 2018 Isaac Muse <isaacmuse@gmail.com>
 import sys
 import struct
 import string
-import _string
 
 PY2 = (2, 0) <= sys.version_info < (3, 0)
 PY3 = (3, 0) <= sys.version_info < (4, 0)
@@ -18,6 +17,7 @@ PY37 = (3, 7) <= sys.version_info
 if PY3:
     from functools import lru_cache  # noqa F401
     import copyreg  # noqa F401
+    import _string
 
     string_type = str
     binary_type = bytes

--- a/backrefs/util.py
+++ b/backrefs/util.py
@@ -13,6 +13,12 @@ PY34 = (3, 4) <= sys.version_info
 PY36 = (3, 6) <= sys.version_info
 PY37 = (3, 7) <= sys.version_info
 
+FMT_FIELD = 0
+FMT_INDEX = 1
+FMT_ATTR = 2
+FMT_CONV = 3
+FMT_SPEC = 4
+
 if PY3:
     from functools import lru_cache  # noqa F401
     import copyreg  # noqa F401
@@ -99,6 +105,66 @@ def uord(c):
         ordinal = ord(c)
 
     return ordinal
+
+
+def _to_bstr(l):
+    """Convert to byte string."""
+
+    if isinstance(l, string_type):
+        l = l.encode('ascii', 'backslashreplace')
+    elif not isinstance(l, binary_type):
+        l = string_type(l).encode('ascii', 'backslashreplace')
+    return l
+
+
+def format(m, l, capture, binary):
+    """Perform a string format."""
+
+    for fmt_type, value in capture[1:]:
+        if fmt_type == FMT_ATTR:
+            # Attribute
+            l = getattr(l, value)
+        elif fmt_type == FMT_INDEX:
+            # Index
+            l = l[value]
+        elif fmt_type == FMT_CONV:
+            if binary:
+                # Conversion
+                if value in ('r', 'a'):
+                    l = repr(l).encode('ascii', 'backslashreplace')
+                elif value == 's':
+                    # If the object is not string or byte string already
+                    l = _to_bstr(l)
+            else:
+                # Conversion
+                if value == 'a':
+                    l = ascii(l)
+                elif value == 'r':
+                    l = repr(l)
+                elif value == 's':
+                    # If the object is not string or byte string already
+                    l = string_type(l)
+        elif fmt_type == FMT_SPEC:
+            # Integers and floats don't have an explicit 's' format type.
+            if value[3] and value[3] == 's':
+                if isinstance(l, int):  # pragma: no cover
+                    raise ValueError("Unknown format code 's' for object of type 'int'")
+                if isinstance(l, float):  # pragma: no cover
+                    raise ValueError("Unknown format code 's' for object of type 'float'")
+
+            # Ensure object is a byte string
+            l = _to_bstr(l) if binary else string_type(l)
+
+            spec_type = value[1]
+            if spec_type == '^':
+                l = l.center(value[2], value[0])
+            elif spec_type == ">":
+                l = l.rjust(value[2], value[0])
+            else:
+                l = l.ljust(value[2], value[0])
+
+    # Make sure the final object is a byte string
+    return _to_bstr(l) if binary else string_type(l)
 
 
 class Immutable(object):

--- a/backrefs/util.py
+++ b/backrefs/util.py
@@ -6,6 +6,8 @@ Copyright (c) 2015 - 2018 Isaac Muse <isaacmuse@gmail.com>
 """
 import sys
 import struct
+import string
+import _string
 
 PY2 = (2, 0) <= sys.version_info < (3, 0)
 PY3 = (3, 0) <= sys.version_info < (4, 0)
@@ -33,10 +35,10 @@ else:
 class StringIter(object):
     """Preprocess replace tokens."""
 
-    def __init__(self, string):
+    def __init__(self, text):
         """Initialize."""
 
-        self._string = string
+        self._string = text
         self._index = 0
 
     def __iter__(self):
@@ -114,3 +116,28 @@ class Immutable(object):
         """Prevent mutability."""
 
         raise AttributeError('Class is immutable!')
+
+
+class Formatter(string.Formatter):
+    """Formatter."""
+
+    def get_field(self, field_name, args, kwargs):
+        """Get field."""
+
+        first, rest = _string.formatter_field_name_split(field_name)
+
+        obj = self.get_value(first, args, kwargs)
+
+        # loop through the rest of the field_name, doing
+        #  getattr or getitem as needed
+        for is_attr, i in rest:
+            if is_attr:
+                obj = getattr(obj, i)
+            else:
+                try:
+                    i = int(i, 10)
+                except Exception:
+                    pass
+                obj = obj[i]
+
+        return obj, first

--- a/docs/src/dictionary/en-custom.txt
+++ b/docs/src/dictionary/en-custom.txt
@@ -5,6 +5,7 @@ Bregex
 Changelog
 EmojiOne
 Feb
+Formatter
 GitHub
 Jan
 MERCHANTABILITY

--- a/docs/src/markdown/_snippets/links.md
+++ b/docs/src/markdown/_snippets/links.md
@@ -1,3 +1,4 @@
+[format-spec]: https://docs.python.org/3/library/string.html#formatspec
 [grapheme-boundaries]: http://www.unicode.org/reports/tr29/#Grapheme_Cluster_Boundary_Rules
 [mkdocs]: https://github.com/mkdocs/mkdocs
 [mkdocs-material]: https://github.com/squidfunk/mkdocs-material

--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -2,8 +2,10 @@
 
 ## 3.5.0
 
+- **NEW**: Use true string format for format style replacements. Byte strings still use a simulated format replace, though slightly more advanced.
 - **FIX**: Relax validation so not exclude valid named Unicode values.
 - **FIX**: Caching issues where byte string patterns were confused with Unicode patterns.
+- **FIX**: More protection against using conflicting string type combinations with search and replace.
 
 ## 3.4.0
 

--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -2,8 +2,8 @@
 
 ## 3.5.0
 
-- **NEW**: Use true string format for format style replacements. Byte strings still use a simulated format replace, though slightly more advanced.
-- **FIX**: Relax validation so not exclude valid named Unicode values.
+- **NEW**: Use a more advanced format string implementation that implements all string features, included those found in `format_spec`.
+- **FIX**: Relax validation so not to exclude valid named Unicode values.
 - **FIX**: Caching issues where byte string patterns were confused with Unicode patterns.
 - **FIX**: More protection against using conflicting string type combinations with search and replace.
 

--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## 0.0.0
+## 3.5.0
 
 - **FIX**: Relax validation so not exclude valid named Unicode values.
+- **FIX**: Caching issues where byte string patterns were confused with Unicode patterns.
 
 ## 3.4.0
 

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -989,7 +989,7 @@ class TestReplaceTemplate(unittest.TestCase):
     def test_format_failures(self):
         """Test format parsing failures."""
 
-        with pytest.raises(sre_constants.error):
+        with pytest.raises(sre_constants.error if PY3 else IndexError):
             bre.subf('test', r'{1.}', 'test', bre.FORMAT)
 
         with pytest.raises(IndexError):
@@ -1806,7 +1806,7 @@ class TestReplaceTemplate(unittest.TestCase):
         """Test format features."""
 
         pattern = bre.compile(r'(Te)(st)(?P<group>ing)')
-        self.assertEqual(pattern.subf(r'{.__class__.__name__}', 'Testing'), 'str')
+        self.assertEqual(pattern.subf(r'{.__class__.__name__}', 'Testing'), ('str' if PY3 else 'unicode'))
 
         self.assertEqual(pattern.subf(r'{1:<30}', 'Testing'), 'Te                            ')
 

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -1041,13 +1041,22 @@ class TestReplaceTemplate(unittest.TestCase):
         with pytest.raises(TypeError):
             bre.subf(b'test', br'{[test]}', b'test', bre.FORMAT)
 
-    def test_byte_format_conversions(self):
-        """Test byte string format conversion paths."""
+    def test_format_conversions(self):
+        """Test string format conversion paths."""
+
+        self.assertTrue(bre.subf('test', r'{0.index}', 'test').startswith('<built-in method'))
+        self.assertEqual(bre.subf('test', r'{0.__class__.__name__}', 'test'), ('str' if PY3 else 'unicode'))
+        self.assertTrue(bre.subf('test', r'{0.index!s}', 'test').startswith('<built-in method'))
+        self.assertEqual(bre.subf('test', r'{0.__class__.__name__!s}', 'test'), ('str' if PY3 else 'unicode'))
+        if PY3:
+            self.assertTrue(bre.subf('test', r'{0.index!a}', 'test').startswith('<built-in method'))
 
         self.assertTrue(bre.subf(b'test', br'{0.index}', b'test').startswith(b'<built-in method'))
         self.assertEqual(bre.subf(b'test', br'{0.__class__.__name__}', b'test'), (b'bytes' if PY3 else b'str'))
         self.assertTrue(bre.subf(b'test', br'{0.index!s}', b'test').startswith(b'<built-in method'))
         self.assertEqual(bre.subf(b'test', br'{0.__class__.__name__!s}', b'test'), (b'bytes' if PY3 else b'str'))
+        if PY3:
+            self.assertTrue(bre.subf('test', r'{0.index!a}', 'test').startswith('<built-in method'))
 
     def test_incompatible_strings(self):
         """Test incompatible string types."""
@@ -1890,14 +1899,47 @@ class TestReplaceTemplate(unittest.TestCase):
         result = pattern.sub('\\C\\U00000070\\U0001F360\\E', 'Test')
         self.assertEqual(result, 'P\U0001F360')
 
+    def test_format_inter_escape(self):
+        """Test escaped characters inside format group."""
+
+        self.assertEqual(
+            bre.subf(
+                r'(Te)(st)(ing)(!)',
+                r'\x7b1\x7d-\u007b2\u007d-\U0000007b3\U0000007d-\N{LEFT CURLY BRACKET}4\N{RIGHT CURLY BRACKET}',
+                'Testing!'
+            ),
+            "Te-st-ing-!"
+        )
+        self.assertEqual(
+            bre.subf(
+                r'(Te)(st)(ing)(!)',
+                r'\1731\175-{2:\\^6}',
+                'Testing!'
+            ),
+            "Te-\\\\st\\\\"
+        )
+
+        with pytest.raises(SyntaxError):
+            bre.subf(r'(test)', r'{\g}', 'test')
+
+        with pytest.raises(ValueError):
+            bre.subf(br'(test)', br'{\777}', b'test')
+
     def test_format_features(self):
         """Test format features."""
 
         pattern = bre.compile(r'(Te)(st)(?P<group>ing)')
         self.assertEqual(pattern.subf(r'{.__class__.__name__}', 'Testing'), ('str' if PY3 else 'unicode'))
-
         self.assertEqual(pattern.subf(r'{1:<30}', 'Testing'), 'Te                            ')
-
+        self.assertEqual(pattern.subf(r'{1:30}', 'Testing'), 'Te                            ')
+        self.assertEqual(pattern.subf(r'{1:>30}', 'Testing'), '                            Te')
+        self.assertEqual(pattern.subf(r'{1:^30}', 'Testing'), '              Te              ')
+        self.assertEqual(pattern.subf(r'{1:*^30}', 'Testing'), '**************Te**************')
+        self.assertEqual(pattern.subf(r'{1:^030}', 'Testing'), '00000000000000Te00000000000000')
+        self.assertEqual(pattern.subf(r'{1:^^30}', 'Testing'), '^^^^^^^^^^^^^^Te^^^^^^^^^^^^^^')
+        self.assertEqual(pattern.subf(r'{1:1^30}', 'Testing'), '11111111111111Te11111111111111')
+        self.assertEqual(pattern.subf(r'{1:<30s}', 'Testing'), 'Te                            ')
+        self.assertEqual(pattern.subf(r'{1:s}', 'Testing'), 'Te')
         self.assertEqual(pattern.subf(r'{2!r}', 'Testing'), "'st'" if PY3 else "u'st'")
 
         with pytest.raises(SyntaxError):
@@ -1912,9 +1954,24 @@ class TestReplaceTemplate(unittest.TestCase):
         with pytest.raises(SyntaxError):
             pattern.subf(r'{a$}', 'Testing')
 
+        with pytest.raises(SyntaxError):
+            pattern.subf(r'{:ss}', 'Testing')
+
+        with pytest.raises(ValueError):
+            pattern.subf(r'{:030}', 'Testing')
+
         pattern = bre.compile(br'(Te)(st)(?P<group>ing)')
         self.assertEqual(pattern.subf(br'{.__class__.__name__}', b'Testing'), (b'bytes' if PY3 else b'str'))
-
+        self.assertEqual(pattern.subf(br'{1:<30}', b'Testing'), b'Te                            ')
+        self.assertEqual(pattern.subf(br'{1:30}', b'Testing'), b'Te                            ')
+        self.assertEqual(pattern.subf(br'{1:>30}', b'Testing'), b'                            Te')
+        self.assertEqual(pattern.subf(br'{1:^30}', b'Testing'), b'              Te              ')
+        self.assertEqual(pattern.subf(br'{1:*^30}', b'Testing'), b'**************Te**************')
+        self.assertEqual(pattern.subf(br'{1:^030}', b'Testing'), b'00000000000000Te00000000000000')
+        self.assertEqual(pattern.subf(br'{1:^^30}', b'Testing'), b'^^^^^^^^^^^^^^Te^^^^^^^^^^^^^^')
+        self.assertEqual(pattern.subf(br'{1:1^30}', b'Testing'), b'11111111111111Te11111111111111')
+        self.assertEqual(pattern.subf(br'{1:<30s}', b'Testing'), b'Te                            ')
+        self.assertEqual(pattern.subf(br'{1:s}', b'Testing'), b'Te')
         self.assertEqual(pattern.subf(br'{2!r}', b'Testing'), b"b'st'" if PY3 else b"'st'")
 
         with pytest.raises(SyntaxError):
@@ -1928,6 +1985,12 @@ class TestReplaceTemplate(unittest.TestCase):
 
         with pytest.raises(SyntaxError):
             pattern.subf(br'{a$}', b'Testing')
+
+        with pytest.raises(SyntaxError):
+            pattern.subf(br'{:ss}', b'Testing')
+
+        with pytest.raises(ValueError):
+            pattern.subf(br'{:030}', b'Testing')
 
     def test_dont_case_special_refs(self):
         """Test that we don't case Unicode and bytes tokens, but case the character."""

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -1810,7 +1810,7 @@ class TestReplaceTemplate(unittest.TestCase):
 
         self.assertEqual(pattern.subf(r'{1:<30}', 'Testing'), 'Te                            ')
 
-        self.assertEqual(pattern.subf(r'{2!r}', 'Testing'), "'st'" if PY3 else "b'st'")
+        self.assertEqual(pattern.subf(r'{2!r}', 'Testing'), "'st'" if PY3 else "u'st'")
 
         with pytest.raises(SyntaxError):
             pattern.subf(r'{2!x}', 'Testing')
@@ -1825,9 +1825,9 @@ class TestReplaceTemplate(unittest.TestCase):
             pattern.subf(r'{a$}', 'Testing')
 
         pattern = bre.compile(br'(Te)(st)(?P<group>ing)')
-        self.assertEqual(pattern.subf(br'{.__class__.__name__}', b'Testing'), b'bytes')
+        self.assertEqual(pattern.subf(br'{.__class__.__name__}', b'Testing'), (b'bytes' if PY3 else b'str'))
 
-        self.assertEqual(pattern.subf(br'{2!r}', b'Testing'), b"b'st'")
+        self.assertEqual(pattern.subf(br'{2!r}', b'Testing'), b"b'st'" if PY3 else b"'st'")
 
         with pytest.raises(SyntaxError):
             pattern.subf(br'{2!x}', b'Testing')

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -1758,16 +1758,10 @@ class TestReplaceTemplate(unittest.TestCase):
         )
 
         results = expand(pattern.match(text))
-        if PY27:
-            self.assertEqual(
-                b'bbb',
-                results
-            )
-        else:
-            self.assertEqual(
-                b'989898',
-                results
-            )
+        self.assertEqual(
+            (b'989898' if PY3 else b'bbb'),
+            results
+        )
 
     def test_format_escapes(self):
         """Test format escapes."""

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -18,8 +18,10 @@ PY37_PLUS = (3, 7) <= sys.version_info
 
 if PY3:
     binary_type = bytes  # noqa
+    string_type = str  # noqa
 else:
     binary_type = str  # noqa
+    string_type = unicode  # noqa
 
 
 class TestSearchTemplate(unittest.TestCase):
@@ -60,13 +62,15 @@ class TestSearchTemplate(unittest.TestCase):
         p1 = bre.compile('test')
         p2 = bre.compile('test')
         p3 = bre.compile('test', bre.X)
+        p4 = bre.compile(b'test')
 
         self.assertTrue(p1 == p2)
         self.assertTrue(p1 != p3)
+        self.assertTrue(p1 != p4)
 
-        p4 = copy.copy(p1)
-        self.assertTrue(p1 == p4)
-        self.assertTrue(p4 in {p1})
+        p5 = copy.copy(p1)
+        self.assertTrue(p1 == p5)
+        self.assertTrue(p5 in {p1})
 
     def test_not_flags(self):
         """Test invalid flags."""
@@ -167,7 +171,7 @@ class TestSearchTemplate(unittest.TestCase):
         self.assertEqual(bre._get_cache_size(), 0)
         self.assertEqual(bre._get_cache_size(True), 0)
         for x in range(1000):
-            value = str(random.randint(1, 10000))
+            value = string_type(random.randint(1, 10000))
             p = bre.compile(value)
             p.sub('', value)
             self.assertTrue(bre._get_cache_size() > 0)
@@ -973,18 +977,21 @@ class TestReplaceTemplate(unittest.TestCase):
 
         p1 = bre.compile('(test)')
         p2 = bre.compile('(test)')
+        p3 = bre.compile(b'(test)')
         r1 = p1.compile(r'\1')
         r2 = p1.compile(r'\1')
         r3 = p2.compile(r'\1')
         r4 = p2.compile(r'\1', bre.FORMAT)
+        r5 = p3.compile(br'\1')
 
         self.assertTrue(r1 == r2)
         self.assertTrue(r2 == r3)
         self.assertTrue(r1 != r4)
+        self.assertTrue(r1 != r5)
 
-        r5 = copy.copy(r1)
-        self.assertTrue(r1 == r5)
-        self.assertTrue(r5 in {r1})
+        r6 = copy.copy(r1)
+        self.assertTrue(r1 == r6)
+        self.assertTrue(r6 in {r1})
 
     def test_format_failures(self):
         """Test format parsing failures."""

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -1041,6 +1041,14 @@ class TestReplaceTemplate(unittest.TestCase):
         with pytest.raises(TypeError):
             bre.subf(b'test', br'{[test]}', b'test', bre.FORMAT)
 
+    def test_byte_format_conversions(self):
+        """Test byte string format conversion paths."""
+
+        self.assertTrue(bre.subf(b'test', br'{0.index}', b'test').startswith(b'<built-in method'))
+        self.assertEqual(bre.subf(b'test', br'{0.__class__.__name__}', b'test'), (b'bytes' if PY3 else b'str'))
+        self.assertTrue(bre.subf(b'test', br'{0.index!s}', b'test').startswith(b'<built-in method'))
+        self.assertEqual(bre.subf(b'test', br'{0.__class__.__name__!s}', b'test'), (b'bytes' if PY3 else b'str'))
+
     def test_incompatible_strings(self):
         """Test incompatible string types."""
 

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -989,10 +989,10 @@ class TestReplaceTemplate(unittest.TestCase):
     def test_format_failures(self):
         """Test format parsing failures."""
 
-        with pytest.raises(SyntaxError):
+        with pytest.raises(sre_constants.error):
             bre.subf('test', r'{1.}', 'test', bre.FORMAT)
 
-        with pytest.raises(SyntaxError):
+        with pytest.raises(IndexError):
             bre.subf('test', r'{a.}', 'test', bre.FORMAT)
 
         with pytest.raises(SyntaxError):
@@ -1801,6 +1801,45 @@ class TestReplaceTemplate(unittest.TestCase):
         pattern = bre.compile('Test')
         result = pattern.sub('\\C\\U00000070\\U0001F360\\E', 'Test')
         self.assertEqual(result, 'P\U0001F360')
+
+    def test_fromat_features(self):
+        """Test format features."""
+
+        pattern = bre.compile(r'(Te)(st)(?P<group>ing)')
+        self.assertEqual(pattern.subf(r'{.__class__.__name__}', 'Testing'), 'str')
+
+        self.assertEqual(pattern.subf(r'{1:<30}', 'Testing'), 'Te                            ')
+
+        self.assertEqual(pattern.subf(r'{2!r}', 'Testing'), "'st'")
+
+        with pytest.raises(SyntaxError):
+            pattern.subf(r'{2!x}', 'Testing')
+
+        with pytest.raises(SyntaxError):
+            pattern.subf(r'{2$}', 'Testing')
+
+        with pytest.raises(SyntaxError):
+            pattern.subf(r'{2$}', 'Testing')
+
+        with pytest.raises(SyntaxError):
+            pattern.subf(r'{a$}', 'Testing')
+
+        pattern = bre.compile(br'(Te)(st)(?P<group>ing)')
+        self.assertEqual(pattern.subf(br'{.__class__.__name__}', b'Testing'), b'bytes')
+
+        self.assertEqual(pattern.subf(br'{2!r}', b'Testing'), b"b'st'")
+
+        with pytest.raises(SyntaxError):
+            pattern.subf(br'{2!x}', b'Testing')
+
+        with pytest.raises(SyntaxError):
+            pattern.subf(br'{2$}', b'Testing')
+
+        with pytest.raises(SyntaxError):
+            pattern.subf(br'{2$}', b'Testing')
+
+        with pytest.raises(SyntaxError):
+            pattern.subf(br'{a$}', b'Testing')
 
     def test_dont_case_special_refs(self):
         """Test that we don't case Unicode and bytes tokens, but case the character."""

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -1757,8 +1757,11 @@ class TestReplaceTemplate(unittest.TestCase):
             pattern, br'{1[-0x1]}{1[-0o1]}{1[-0b1]}', bre.FORMAT
         )
 
-        with pytest.raises(TypeError):
-            expand(pattern.match(text))
+        results = expand(pattern.match(text))
+        self.assertEqual(
+            b'989898',
+            results
+        )
 
     def test_format_escapes(self):
         """Test format escapes."""
@@ -1832,8 +1835,8 @@ class TestReplaceTemplate(unittest.TestCase):
             self.assertEqual(b'\\U0109\nWw\\u0109', results)
 
             expandf = bre.compile_replace(pattern, br'\C\u0109\n\x77\E\l\x57\c\u0109', bre.FORMAT)
-            with pytest.raises(TypeError):
-                expandf(pattern.match(b'Test'))
+            results = expandf(pattern.match(b'Test'))
+            self.assertEqual(b'\\U0109\nWw\\u0109', results)
 
             pattern = re.compile(b'Test')
             expand = bre.compile_replace(pattern, br'\C\U00000109\n\x77\E\l\x57\c\U00000109')
@@ -1841,8 +1844,8 @@ class TestReplaceTemplate(unittest.TestCase):
             self.assertEqual(b'\U00000109\nWw\U00000109', results)
 
             expandf = bre.compile_replace(pattern, br'\C\U00000109\n\x77\E\l\x57\c\U00000109', bre.FORMAT)
-            with pytest.raises(TypeError):
-                expandf(pattern.match(b'Test'))
+            results = expandf(pattern.match(b'Test'))
+            self.assertEqual(b'\U00000109\nWw\U00000109', results)
 
         # Format doesn't care about groups
         pattern = re.compile('Test')
@@ -1852,8 +1855,8 @@ class TestReplaceTemplate(unittest.TestCase):
 
         pattern = re.compile(b'Test')
         expandf = bre.compile_replace(pattern, br'\127\C\167\n\E\l\127', bre.FORMAT)
-        with pytest.raises(TypeError):
-            expandf(pattern.match(b'Test'))
+        results = expandf(pattern.match(b'Test'))
+        self.assertEqual(b'WW\nw', results)
 
         # Octal behavior in regex grabs \127 before it evaluates \27, so we must match that behavior
         pattern = re.compile('Test')
@@ -1884,8 +1887,8 @@ class TestReplaceTemplate(unittest.TestCase):
 
         pattern = re.compile(b'Test')
         expand = bre.compile_replace(pattern, br'\0\00\000', bre.FORMAT)
-        with pytest.raises(TypeError):
-            expand(pattern.match(b'Test'))
+        results = expand(pattern.match(b'Test'))
+        self.assertEqual(b'\x00\x00\x00', results)
 
 
 class TestExceptions(unittest.TestCase):

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -1802,7 +1802,7 @@ class TestReplaceTemplate(unittest.TestCase):
         result = pattern.sub('\\C\\U00000070\\U0001F360\\E', 'Test')
         self.assertEqual(result, 'P\U0001F360')
 
-    def test_fromat_features(self):
+    def test_format_features(self):
         """Test format features."""
 
         pattern = bre.compile(r'(Te)(st)(?P<group>ing)')
@@ -1810,7 +1810,7 @@ class TestReplaceTemplate(unittest.TestCase):
 
         self.assertEqual(pattern.subf(r'{1:<30}', 'Testing'), 'Te                            ')
 
-        self.assertEqual(pattern.subf(r'{2!r}', 'Testing'), "'st'")
+        self.assertEqual(pattern.subf(r'{2!r}', 'Testing'), "'st'" if PY3 else "b'st'")
 
         with pytest.raises(SyntaxError):
             pattern.subf(r'{2!x}', 'Testing')

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -1758,10 +1758,16 @@ class TestReplaceTemplate(unittest.TestCase):
         )
 
         results = expand(pattern.match(text))
-        self.assertEqual(
-            b'989898',
-            results
-        )
+        if PY27:
+            self.assertEqual(
+                b'bbb',
+                results
+            )
+        else:
+            self.assertEqual(
+                b'989898',
+                results
+            )
 
     def test_format_escapes(self):
         """Test format escapes."""

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -989,7 +989,7 @@ class TestReplaceTemplate(unittest.TestCase):
     def test_format_failures(self):
         """Test format parsing failures."""
 
-        with pytest.raises(sre_constants.error if PY3 else IndexError):
+        with pytest.raises(sre_constants.error if PY36_PLUS else IndexError):
             bre.subf('test', r'{1.}', 'test', bre.FORMAT)
 
         with pytest.raises(IndexError):

--- a/tests/test_bregex.py
+++ b/tests/test_bregex.py
@@ -665,6 +665,14 @@ class TestReplaceTemplate(unittest.TestCase):
         with pytest.raises(TypeError):
             bregex.subf(b'test', br'{[test]}', b'test', bregex.FORMAT)
 
+    def test_byte_format_conversions(self):
+        """Test byte string format conversion paths."""
+
+        self.assertTrue(bregex.subf(b'test', br'{0.index}', b'test').startswith(b'<built-in method'))
+        self.assertEqual(bregex.subf(b'test', br'{0.__class__.__name__}', b'test'), (b'bytes' if PY3 else b'str'))
+        self.assertTrue(bregex.subf(b'test', br'{0.index!s}', b'test').startswith(b'<built-in method'))
+        self.assertEqual(bregex.subf(b'test', br'{0.__class__.__name__!s}', b'test'), (b'bytes' if PY3 else b'str'))
+
     def test_incompatible_strings(self):
         """Test incompatible string types."""
 

--- a/tests/test_bregex.py
+++ b/tests/test_bregex.py
@@ -1415,7 +1415,7 @@ class TestReplaceTemplate(unittest.TestCase):
 
         self.assertEqual(pattern.subf(r'{1:<30}', 'Testing'), 'Te                            ')
 
-        self.assertEqual(pattern.subf(r'{2!r}', 'Testing'), "'st'" if PY3 else "b'st'")
+        self.assertEqual(pattern.subf(r'{2!r}', 'Testing'), "'st'" if PY3 else "u'st'")
 
         with pytest.raises(SyntaxError):
             pattern.subf(r'{2!x}', 'Testing')
@@ -1430,9 +1430,9 @@ class TestReplaceTemplate(unittest.TestCase):
             pattern.subf(r'{a$}', 'Testing')
 
         pattern = bregex.compile(br'(Te)(st)(?P<group>ing)')
-        self.assertEqual(pattern.subf(br'{.__class__.__name__}', b'Testing'), b'bytes')
+        self.assertEqual(pattern.subf(br'{.__class__.__name__}', b'Testing'), (b'bytes' if PY3 else b'str'))
 
-        self.assertEqual(pattern.subf(br'{2!r}', b'Testing'), b"b'st'")
+        self.assertEqual(pattern.subf(br'{2!r}', b'Testing'), b"b'st'" if PY3 else b"'st'")
 
         with pytest.raises(SyntaxError):
             pattern.subf(br'{2!x}', b'Testing')

--- a/tests/test_bregex.py
+++ b/tests/test_bregex.py
@@ -613,7 +613,7 @@ class TestReplaceTemplate(unittest.TestCase):
     def test_format_failures(self):
         """Test format parsing failures."""
 
-        with pytest.raises(_regex_core.error):
+        with pytest.raises(_regex_core.error if PY3 else IndexError):
             bregex.subf('test', r'{1.}', 'test', bregex.FORMAT)
 
         with pytest.raises(IndexError):
@@ -1411,7 +1411,7 @@ class TestReplaceTemplate(unittest.TestCase):
         """Test format features."""
 
         pattern = bregex.compile(r'(Te)(st)(?P<group>ing)')
-        self.assertEqual(pattern.subf(r'{.__class__.__name__}', 'Testing'), 'str')
+        self.assertEqual(pattern.subf(r'{.__class__.__name__}', 'Testing'),  ('str' if PY3 else 'unicode'))
 
         self.assertEqual(pattern.subf(r'{1:<30}', 'Testing'), 'Te                            ')
 

--- a/tests/test_bregex.py
+++ b/tests/test_bregex.py
@@ -613,10 +613,10 @@ class TestReplaceTemplate(unittest.TestCase):
     def test_format_failures(self):
         """Test format parsing failures."""
 
-        with pytest.raises(SyntaxError):
+        with pytest.raises(_regex_core.error):
             bregex.subf('test', r'{1.}', 'test', bregex.FORMAT)
 
-        with pytest.raises(SyntaxError):
+        with pytest.raises(IndexError):
             bregex.subf('test', r'{a.}', 'test', bregex.FORMAT)
 
         with pytest.raises(SyntaxError):
@@ -1406,6 +1406,45 @@ class TestReplaceTemplate(unittest.TestCase):
         pattern = bregex.compile('Test')
         result = pattern.sub('\\C\\U00000070\\U0001F360\\E', 'Test')
         self.assertEqual(result, 'P\U0001F360')
+
+    def test_fromat_features(self):
+        """Test format features."""
+
+        pattern = bregex.compile(r'(Te)(st)(?P<group>ing)')
+        self.assertEqual(pattern.subf(r'{.__class__.__name__}', 'Testing'), 'str')
+
+        self.assertEqual(pattern.subf(r'{1:<30}', 'Testing'), 'Te                            ')
+
+        self.assertEqual(pattern.subf(r'{2!r}', 'Testing'), "'st'")
+
+        with pytest.raises(SyntaxError):
+            pattern.subf(r'{2!x}', 'Testing')
+
+        with pytest.raises(SyntaxError):
+            pattern.subf(r'{2$}', 'Testing')
+
+        with pytest.raises(SyntaxError):
+            pattern.subf(r'{2$}', 'Testing')
+
+        with pytest.raises(SyntaxError):
+            pattern.subf(r'{a$}', 'Testing')
+
+        pattern = bregex.compile(br'(Te)(st)(?P<group>ing)')
+        self.assertEqual(pattern.subf(br'{.__class__.__name__}', b'Testing'), b'bytes')
+
+        self.assertEqual(pattern.subf(br'{2!r}', b'Testing'), b"b'st'")
+
+        with pytest.raises(SyntaxError):
+            pattern.subf(br'{2!x}', b'Testing')
+
+        with pytest.raises(SyntaxError):
+            pattern.subf(br'{2$}', b'Testing')
+
+        with pytest.raises(SyntaxError):
+            pattern.subf(br'{2$}', b'Testing')
+
+        with pytest.raises(SyntaxError):
+            pattern.subf(br'{a$}', b'Testing')
 
     def test_dont_case_special_refs(self):
         """Test that we don't case Unicode and bytes tokens, but case the character."""

--- a/tests/test_bregex.py
+++ b/tests/test_bregex.py
@@ -15,8 +15,10 @@ PY3 = (3, 0) <= sys.version_info < (4, 0)
 
 if PY3:
     binary_type = bytes  # noqa
+    string_type = str  # noqa
 else:
     binary_type = str  # noqa
+    string_type = unicode  # noqa
 
 
 class TestSearchTemplate(unittest.TestCase):
@@ -68,13 +70,15 @@ class TestSearchTemplate(unittest.TestCase):
         p1 = bregex.compile('test')
         p2 = bregex.compile('test')
         p3 = bregex.compile('test', bregex.X)
+        p4 = bregex.compile(b'test')
 
         self.assertTrue(p1 == p2)
         self.assertTrue(p1 != p3)
+        self.assertTrue(p1 != p4)
 
-        p4 = copy.copy(p1)
-        self.assertTrue(p1 == p4)
-        self.assertTrue(p4 in {p1})
+        p5 = copy.copy(p1)
+        self.assertTrue(p1 == p5)
+        self.assertTrue(p5 in {p1})
 
     def test_not_flags(self):
         """Test invalid flags."""
@@ -111,7 +115,7 @@ class TestSearchTemplate(unittest.TestCase):
         self.assertEqual(bregex._get_cache_size(), 0)
         self.assertEqual(bregex._get_cache_size(True), 0)
         for x in range(1000):
-            value = str(random.randint(1, 10000))
+            value = string_type(random.randint(1, 10000))
             p = bregex.compile(value)
             p.sub('', value)
             self.assertTrue(bregex._get_cache_size() > 0)
@@ -597,14 +601,17 @@ class TestReplaceTemplate(unittest.TestCase):
 
         p1 = bregex.compile('(test)')
         p2 = bregex.compile('(test)')
+        p3 = bregex.compile(b'(test)')
         r1 = p1.compile(r'\1')
         r2 = p1.compile(r'\1')
         r3 = p2.compile(r'\1')
         r4 = p2.compile(r'\1', bregex.FORMAT)
+        r5 = p3.compile(br'\1')
 
         self.assertTrue(r1 == r2)
         self.assertTrue(r2 == r3)
         self.assertTrue(r1 != r4)
+        self.assertTrue(r1 != r5)
 
         r5 = copy.copy(r1)
         self.assertTrue(r1 == r5)
@@ -1411,7 +1418,7 @@ class TestReplaceTemplate(unittest.TestCase):
         """Test format features."""
 
         pattern = bregex.compile(r'(Te)(st)(?P<group>ing)')
-        self.assertEqual(pattern.subf(r'{.__class__.__name__}', 'Testing'),  ('str' if PY3 else 'unicode'))
+        self.assertEqual(pattern.subf(r'{.__class__.__name__}', 'Testing'), ('str' if PY3 else 'unicode'))
 
         self.assertEqual(pattern.subf(r'{1:<30}', 'Testing'), 'Te                            ')
 

--- a/tests/test_bregex.py
+++ b/tests/test_bregex.py
@@ -613,7 +613,7 @@ class TestReplaceTemplate(unittest.TestCase):
     def test_format_failures(self):
         """Test format parsing failures."""
 
-        with pytest.raises(_regex_core.error if PY3 else IndexError):
+        with pytest.raises(_regex_core.error):
             bregex.subf('test', r'{1.}', 'test', bregex.FORMAT)
 
         with pytest.raises(IndexError):
@@ -1407,7 +1407,7 @@ class TestReplaceTemplate(unittest.TestCase):
         result = pattern.sub('\\C\\U00000070\\U0001F360\\E', 'Test')
         self.assertEqual(result, 'P\U0001F360')
 
-    def test_fromat_features(self):
+    def test_format_features(self):
         """Test format features."""
 
         pattern = bregex.compile(r'(Te)(st)(?P<group>ing)')
@@ -1415,7 +1415,7 @@ class TestReplaceTemplate(unittest.TestCase):
 
         self.assertEqual(pattern.subf(r'{1:<30}', 'Testing'), 'Te                            ')
 
-        self.assertEqual(pattern.subf(r'{2!r}', 'Testing'), "'st'")
+        self.assertEqual(pattern.subf(r'{2!r}', 'Testing'), "'st'" if PY3 else "b'st'")
 
         with pytest.raises(SyntaxError):
             pattern.subf(r'{2!x}', 'Testing')

--- a/tests/test_bregex.py
+++ b/tests/test_bregex.py
@@ -641,6 +641,42 @@ class TestReplaceTemplate(unittest.TestCase):
         with pytest.raises(SyntaxError):
             bregex.subf('test', r'test { test', 'test', bregex.FORMAT)
 
+        with pytest.raises(_regex_core.error):
+            bregex.subf(b'test', br'{1.}', b'test', bregex.FORMAT)
+
+        with pytest.raises(IndexError):
+            bregex.subf(b'test', br'{a.}', b'test', bregex.FORMAT)
+
+        with pytest.raises(SyntaxError):
+            bregex.subf(b'test', br'{1[}', b'test', bregex.FORMAT)
+
+        with pytest.raises(SyntaxError):
+            bregex.subf(b'test', br'{a[}', b'test', bregex.FORMAT)
+
+        with pytest.raises(SyntaxError):
+            bregex.subf(b'test', br'test } test', b'test', bregex.FORMAT)
+
+        with pytest.raises(SyntaxError):
+            bregex.subf(b'test', br'test {test', b'test', bregex.FORMAT)
+
+        with pytest.raises(SyntaxError):
+            bregex.subf(b'test', br'test { test', b'test', bregex.FORMAT)
+
+        with pytest.raises(TypeError):
+            bregex.subf(b'test', br'{[test]}', b'test', bregex.FORMAT)
+
+    def test_incompatible_strings(self):
+        """Test incompatible string types."""
+
+        with pytest.raises(TypeError):
+            bregex.compile('test').compile(b'test')
+
+        p1 = bregex.compile('test')
+        repl = bregex.compile(b'test').compile(b'other')
+        m = p1.match('test')
+        with pytest.raises(TypeError):
+            repl(m)
+
     def test_named_unicode_failures(self):
         """Test named Unicode failures."""
 
@@ -1271,10 +1307,21 @@ class TestReplaceTemplate(unittest.TestCase):
         text_pattern = r"(this )(.+?)(numeric capture )(groups)(!)"
         pattern = regex.compile(text_pattern)
 
-        expand = bregex.compile_replace(pattern, r'\l\C{0001}\l{02}\L\c{03}\E{004}\E{5}\n\C{000}\E', bregex.FORMAT)
-        results = expand(pattern.match(text))
+        expandf = bregex.compile_replace(pattern, r'\l\C{0001}\l{02}\L\c{03}\E{004}\E{5}\n\C{000}\E', bregex.FORMAT)
+        results = expandf(pattern.match(text))
         self.assertEqual(
             'tHIS iS A TEST FOR Numeric capture GROUPS!\nTHIS IS A TEST FOR NUMERIC CAPTURE GROUPS!',
+            results
+        )
+
+        text = b"this is a test for numeric capture groups!"
+        text_pattern = br"(this )(.+?)(numeric capture )(groups)(!)"
+        pattern = regex.compile(text_pattern)
+
+        expandf = bregex.compile_replace(pattern, br'\l\C{0001}\l{02}\L\c{03}\E{004}\E{5}\n\C{000}\E', bregex.FORMAT)
+        results = expandf(pattern.match(text))
+        self.assertEqual(
+            b'tHIS iS A TEST FOR Numeric capture GROUPS!\nTHIS IS A TEST FOR NUMERIC CAPTURE GROUPS!',
             results
         )
 
@@ -1285,12 +1332,25 @@ class TestReplaceTemplate(unittest.TestCase):
         text_pattern = r"(this )(.+?)(format capture )(groups)(!)"
         pattern = regex.compile(text_pattern)
 
-        expand = bregex.compile_replace(
+        expandf = bregex.compile_replace(
             pattern, r'\l\C{{0001}}\l{{{02}}}\L\c{03}\E{004}\E{5}\n\C{000}\E', bregex.FORMAT
         )
-        results = expand(pattern.match(text))
+        results = expandf(pattern.match(text))
         self.assertEqual(
             '{0001}{IS A TEST FOR }Format capture GROUPS!\nTHIS IS A TEST FOR FORMAT CAPTURE GROUPS!',
+            results
+        )
+
+        text = b"this is a test for format capture groups!"
+        text_pattern = br"(this )(.+?)(format capture )(groups)(!)"
+        pattern = regex.compile(text_pattern)
+
+        expandf = bregex.compile_replace(
+            pattern, br'\l\C{{0001}}\l{{{02}}}\L\c{03}\E{004}\E{5}\n\C{000}\E', bregex.FORMAT
+        )
+        results = expandf(pattern.match(text))
+        self.assertEqual(
+            b'{0001}{IS A TEST FOR }Format capture GROUPS!\nTHIS IS A TEST FOR FORMAT CAPTURE GROUPS!',
             results
         )
 
@@ -1301,12 +1361,25 @@ class TestReplaceTemplate(unittest.TestCase):
         text_pattern = r"(this )(.+?)(format capture )(groups)(!)"
         pattern = regex.compile(text_pattern)
 
-        expand = bregex.compile_replace(
+        expandf = bregex.compile_replace(
             pattern, r'\C{}\E\n\l\C{}\l{}\L\c{}\E{}\E{}{{}}', bregex.FORMAT
         )
-        results = expand(pattern.match(text))
+        results = expandf(pattern.match(text))
         self.assertEqual(
             'THIS IS A TEST FOR FORMAT CAPTURE GROUPS!\ntHIS iS A TEST FOR Format capture GROUPS!{}',
+            results
+        )
+
+        text = b"this is a test for format capture groups!"
+        text_pattern = br"(this )(.+?)(format capture )(groups)(!)"
+        pattern = regex.compile(text_pattern)
+
+        expandf = bregex.compile_replace(
+            pattern, br'\C{}\E\n\l\C{}\l{}\L\c{}\E{}\E{}{{}}', bregex.FORMAT
+        )
+        results = expandf(pattern.match(text))
+        self.assertEqual(
+            b'THIS IS A TEST FOR FORMAT CAPTURE GROUPS!\ntHIS iS A TEST FOR Format capture GROUPS!{}',
             results
         )
 

--- a/tests/test_bregex.py
+++ b/tests/test_bregex.py
@@ -1361,11 +1361,9 @@ class TestReplaceTemplate(unittest.TestCase):
         expand = bregex.compile_replace(
             pattern, br'{1[-0x1]}{1[0o3]}{1[0b101]}', bregex.FORMAT
         )
-        results = expand(pattern.match(text))
-        self.assertEqual(
-            b'bbb',
-            results
-        )
+
+        with pytest.raises(TypeError):
+            expand(pattern.match(text))
 
     def test_format_escapes(self):
         """Test format escapes."""
@@ -1436,8 +1434,9 @@ class TestReplaceTemplate(unittest.TestCase):
         self.assertEqual(b'\\U0109\nWw\\u0109', results)
 
         expandf = bregex.compile_replace(pattern, br'\C\u0109\n\x77\E\l\x57\c\u0109', bregex.FORMAT)
-        results = expandf(pattern.match(b'Test'))
-        self.assertEqual(b'\\U0109\nWw\\u0109', results)
+        with pytest.raises(TypeError):
+            results = expandf(pattern.match(b'Test'))
+        # self.assertEqual(b'\\U0109\nWw\\u0109', results)
 
         pattern = regex.compile(b'Test')
         expand = bregex.compile_replace(pattern, br'\C\U00000109\n\x77\E\l\x57\c\U00000109')
@@ -1445,8 +1444,9 @@ class TestReplaceTemplate(unittest.TestCase):
         self.assertEqual(b'\U00000109\nWw\U00000109', results)
 
         expandf = bregex.compile_replace(pattern, br'\C\U00000109\n\x77\E\l\x57\c\U00000109', bregex.FORMAT)
-        results = expandf(pattern.match(b'Test'))
-        self.assertEqual(b'\U00000109\nWw\U00000109', results)
+        with pytest.raises(TypeError):
+            results = expandf(pattern.match(b'Test'))
+        # self.assertEqual(b'\U00000109\nWw\U00000109', results)
 
         # Format doesn't care about groups
         pattern = regex.compile('Test')
@@ -1456,8 +1456,8 @@ class TestReplaceTemplate(unittest.TestCase):
 
         pattern = regex.compile(b'Test')
         expandf = bregex.compile_replace(pattern, br'\127\C\167\n\E\l\127', bregex.FORMAT)
-        results = expandf(pattern.match(b'Test'))
-        self.assertEqual(b'WW\nw', results)
+        with pytest.raises(TypeError):
+            expandf(pattern.match(b'Test'))
 
         # Octal behavior in regex grabs \127 before it evaluates \27, so we must match that behavior
         pattern = regex.compile('Test')
@@ -1466,8 +1466,8 @@ class TestReplaceTemplate(unittest.TestCase):
         self.assertEqual('W\u01b6W\u01b5\nw\u01b5', results)
 
         pattern = regex.compile(b'Test')
-        expandf = bregex.compile_replace(pattern, br'\127\C\167\n\E\l\127\c')
-        results = expandf(pattern.match(b'Test'))
+        expand = bregex.compile_replace(pattern, br'\127\C\167\n\E\l\127\c')
+        results = expand(pattern.match(b'Test'))
         self.assertEqual(b'WW\nw', results)
 
         # Null should pass through
@@ -1482,14 +1482,14 @@ class TestReplaceTemplate(unittest.TestCase):
         self.assertEqual(b'\x00\x00\x00', results)
 
         pattern = regex.compile('Test')
-        expand = bregex.compile_replace(pattern, r'\0\00\000', bregex.FORMAT)
-        results = expand(pattern.match('Test'))
+        expandf = bregex.compile_replace(pattern, r'\0\00\000', bregex.FORMAT)
+        results = expandf(pattern.match('Test'))
         self.assertEqual('\x00\x00\x00', results)
 
         pattern = regex.compile(b'Test')
-        expand = bregex.compile_replace(pattern, br'\0\00\000', bregex.FORMAT)
-        results = expand(pattern.match(b'Test'))
-        self.assertEqual(b'\x00\x00\x00', results)
+        expandf = bregex.compile_replace(pattern, br'\0\00\000', bregex.FORMAT)
+        with pytest.raises(TypeError):
+            expandf(pattern.match(b'Test'))
 
 
 class TestExceptions(unittest.TestCase):
@@ -1558,12 +1558,10 @@ class TestExceptions(unittest.TestCase):
         text_pattern = r"(\w)+"
         pattern = regex.compile(text_pattern)
 
-        with pytest.raises(ValueError) as excinfo:
-            bregex.compile_replace(
-                pattern, r'{1[0o3f]}', bregex.FORMAT
+        with pytest.raises(TypeError):
+            bregex.subf(
+                pattern, r'{1[0o3f]}', 'test'
             )
-
-        assert "Capture index must be an integer!" in str(excinfo.value)
 
     def test_format_bad_capture_range(self):
         """Test a bad capture."""
@@ -1574,10 +1572,8 @@ class TestExceptions(unittest.TestCase):
             pattern, r'{1[37]}', bregex.FORMAT
         )
 
-        with pytest.raises(IndexError) as excinfo:
+        with pytest.raises(IndexError):
             expand(pattern.match('text'))
-
-        assert "is out of range!" in str(excinfo.value)
 
     def test_require_compiled_pattern(self):
         """Test a bad capture."""

--- a/tests/test_bregex.py
+++ b/tests/test_bregex.py
@@ -1362,8 +1362,11 @@ class TestReplaceTemplate(unittest.TestCase):
             pattern, br'{1[-0x1]}{1[0o3]}{1[0b101]}', bregex.FORMAT
         )
 
-        with pytest.raises(TypeError):
-            expand(pattern.match(text))
+        results = expand(pattern.match(text))
+        self.assertEqual(
+            b'bbb',
+            results
+        )
 
     def test_format_escapes(self):
         """Test format escapes."""
@@ -1434,9 +1437,8 @@ class TestReplaceTemplate(unittest.TestCase):
         self.assertEqual(b'\\U0109\nWw\\u0109', results)
 
         expandf = bregex.compile_replace(pattern, br'\C\u0109\n\x77\E\l\x57\c\u0109', bregex.FORMAT)
-        with pytest.raises(TypeError):
-            results = expandf(pattern.match(b'Test'))
-        # self.assertEqual(b'\\U0109\nWw\\u0109', results)
+        results = expandf(pattern.match(b'Test'))
+        self.assertEqual(b'\\U0109\nWw\\u0109', results)
 
         pattern = regex.compile(b'Test')
         expand = bregex.compile_replace(pattern, br'\C\U00000109\n\x77\E\l\x57\c\U00000109')
@@ -1444,9 +1446,8 @@ class TestReplaceTemplate(unittest.TestCase):
         self.assertEqual(b'\U00000109\nWw\U00000109', results)
 
         expandf = bregex.compile_replace(pattern, br'\C\U00000109\n\x77\E\l\x57\c\U00000109', bregex.FORMAT)
-        with pytest.raises(TypeError):
-            results = expandf(pattern.match(b'Test'))
-        # self.assertEqual(b'\U00000109\nWw\U00000109', results)
+        results = expandf(pattern.match(b'Test'))
+        self.assertEqual(b'\U00000109\nWw\U00000109', results)
 
         # Format doesn't care about groups
         pattern = regex.compile('Test')
@@ -1456,8 +1457,8 @@ class TestReplaceTemplate(unittest.TestCase):
 
         pattern = regex.compile(b'Test')
         expandf = bregex.compile_replace(pattern, br'\127\C\167\n\E\l\127', bregex.FORMAT)
-        with pytest.raises(TypeError):
-            expandf(pattern.match(b'Test'))
+        results = expandf(pattern.match(b'Test'))
+        self.assertEqual(b'WW\nw', results)
 
         # Octal behavior in regex grabs \127 before it evaluates \27, so we must match that behavior
         pattern = regex.compile('Test')
@@ -1488,8 +1489,8 @@ class TestReplaceTemplate(unittest.TestCase):
 
         pattern = regex.compile(b'Test')
         expandf = bregex.compile_replace(pattern, br'\0\00\000', bregex.FORMAT)
-        with pytest.raises(TypeError):
-            expandf(pattern.match(b'Test'))
+        results = expand(pattern.match(b'Test'))
+        self.assertEqual(b'\x00\x00\x00', results)
 
 
 class TestExceptions(unittest.TestCase):


### PR DESCRIPTION
Process format templates with real Python formatting.  This enables all format features for format replacements (along with indexing tweaks for negative indexing etc.). Though byte strings still simulate formatting as they are not really supported with the `.format` method.

This is still being evaluated, so this may or may not be the final solution.

Ref #75 