### PR TITLE
use bytes when referring to byte strings

### DIFF
--- a/backrefs/_bre_parse.py
+++ b/backrefs/_bre_parse.py
@@ -75,20 +75,20 @@ class _SearchParser(object):
     _re_start_wb = r"\b(?=\w)"
     _re_end_wb = r"\b(?<=\w)"
     _line_break = r'(?:\r\n|(?!\r\n)[\n\v\f\r\x85\u2028\u2029])'
-    _binary_line_break = r'(?:\r\n|(?!\r\n)[\n\v\f\r\x85])'
+    _bytes_line_break = r'(?:\r\n|(?!\r\n)[\n\v\f\r\x85])'
     # (?:\PM\pM*(?!\pM)) ~= (?>\PM\pM*)
     _grapheme_cluster = r'(?:%s%s*(?!%s))'
 
     def __init__(self, search, re_verbose=False, re_unicode=None):
         """Initialize."""
 
-        if isinstance(search, _util.binary_type):
+        if isinstance(search, _util.bytes_type):
             self.binary = True
         else:
             self.binary = False
 
         if self.binary:
-            self._re_line_break = self._binary_line_break
+            self._re_line_break = self._bytes_line_break
         else:
             self._re_line_break = self._line_break
         self.search = search
@@ -568,7 +568,7 @@ class _SearchParser(object):
         try:
             if self.binary or not self.unicode:
                 pattern = _uniprops.get_posix_property(
-                    prop, (_uniprops.POSIX_BINARY if self.binary else _uniprops.POSIX)
+                    prop, (_uniprops.POSIX_BYTES if self.binary else _uniprops.POSIX)
                 )
             else:
                 pattern = _uniprops.get_posix_property(prop, _uniprops.POSIX_UNICODE)
@@ -1369,11 +1369,11 @@ class _ReplaceParser(object):
     def parse(self, pattern, template, use_format=False):
         """Parse template."""
 
-        if isinstance(template, _util.binary_type):
+        if isinstance(template, _util.bytes_type):
             self.binary = True
         else:
             self.binary = False
-        if isinstance(pattern.pattern, _util.binary_type) != self.binary:
+        if isinstance(pattern.pattern, _util.bytes_type) != self.binary:
             raise TypeError('Pattern string type must match replace template string type!')
         self._original = template
         self.use_format = use_format
@@ -1392,7 +1392,7 @@ class _ReplaceParser(object):
 class ReplaceTemplate(_util.Immutable):
     """Replacement template expander."""
 
-    __slots__ = ("groups", "group_slots", "literals", "pattern_hash", "use_format", "_hash", "_binary")
+    __slots__ = ("groups", "group_slots", "literals", "pattern_hash", "use_format", "_hash", "_bytes")
 
     def __init__(self, groups, group_slots, literals, pattern_hash, use_format, binary):
         """Initialize."""
@@ -1403,7 +1403,7 @@ class ReplaceTemplate(_util.Immutable):
             group_slots=group_slots,
             literals=literals,
             pattern_hash=pattern_hash,
-            _binary=binary,
+            _bytes=binary,
             _hash=hash(
                 (
                     type(self),
@@ -1433,7 +1433,7 @@ class ReplaceTemplate(_util.Immutable):
             self.literals == other.literals and
             self.pattern_hash == other.pattern_hash and
             self.use_format == other.use_format and
-            self._binary == other._binary
+            self._bytes == other._bytes
         )
 
     def __ne__(self, other):
@@ -1446,7 +1446,7 @@ class ReplaceTemplate(_util.Immutable):
             self.literals != other.literals or
             self.pattern_hash != other.pattern_hash or
             self.use_format != other.use_format or
-            self._binary != self._binary
+            self._bytes != self._bytes
         )
 
     def __repr__(self):  # pragma: no cover
@@ -1485,7 +1485,7 @@ class ReplaceTemplate(_util.Immutable):
             raise ValueError("Match is None!")
 
         sep = m.string[:0]
-        if isinstance(sep, _util.binary_type) != self._binary:
+        if isinstance(sep, _util.bytes_type) != self._bytes:
             raise TypeError('Match string type does not match expander string type!')
         text = []
         # Expand string
@@ -1507,7 +1507,7 @@ class ReplaceTemplate(_util.Immutable):
                         obj = m.group(g_index)
                     except IndexError:  # pragma: no cover
                         raise IndexError("'%d' is out of range!" % g_index)
-                    l = _util.format_string(m, obj, capture, self._binary)
+                    l = _util.format_string(m, obj, capture, self._bytes)
                 if span_case is not None:
                     if span_case == _LOWER:
                         l = l.lower()
@@ -1526,7 +1526,7 @@ class ReplaceTemplate(_util.Immutable):
 def _pickle(r):
     """Pickle."""
 
-    return ReplaceTemplate, (r.groups, r.group_slots, r.literals, r.pattern_hash, r.use_format, r._binary)
+    return ReplaceTemplate, (r.groups, r.group_slots, r.literals, r.pattern_hash, r.use_format, r._bytes)
 
 
 _util.copyreg.pickle(ReplaceTemplate, _pickle)

--- a/backrefs/_bregex_parse.py
+++ b/backrefs/_bregex_parse.py
@@ -67,18 +67,18 @@ class _SearchParser(object):
     _new_refs = ("e", "R", "Q", "E")
     _re_escape = r"\x1b"
     _line_break = r'(?>\r\n|[\n\v\f\r\x85\u2028\u2029])'
-    _binary_line_break = r'(?>\r\n|[\n\v\f\r\x85])'
+    _bytes_line_break = r'(?>\r\n|[\n\v\f\r\x85])'
 
     def __init__(self, search, re_verbose=False, re_version=0):
         """Initialize."""
 
-        if isinstance(search, _util.binary_type):
+        if isinstance(search, _util.bytes_type):
             self.binary = True
         else:
             self.binary = False
 
         if self.binary:
-            self._re_line_break = self._binary_line_break
+            self._re_line_break = self._bytes_line_break
         else:
             self._re_line_break = self._line_break
         self.re_verbose = re_verbose
@@ -1163,11 +1163,11 @@ class _ReplaceParser(object):
     def parse(self, pattern, template, use_format=False):
         """Parse template."""
 
-        if isinstance(template, _util.binary_type):
+        if isinstance(template, _util.bytes_type):
             self.binary = True
         else:
             self.binary = False
-        if isinstance(pattern.pattern, _util.binary_type) != self.binary:
+        if isinstance(pattern.pattern, _util.bytes_type) != self.binary:
             raise TypeError('Pattern string type must match replace template string type!')
         self._original = template
         self.use_format = use_format
@@ -1186,7 +1186,7 @@ class _ReplaceParser(object):
 class ReplaceTemplate(_util.Immutable):
     """Replacement template expander."""
 
-    __slots__ = ("groups", "group_slots", "literals", "pattern_hash", "use_format", "_hash", "_binary")
+    __slots__ = ("groups", "group_slots", "literals", "pattern_hash", "use_format", "_hash", "_bytes")
 
     def __init__(self, groups, group_slots, literals, pattern_hash, use_format, binary):
         """Initialize."""
@@ -1197,7 +1197,7 @@ class ReplaceTemplate(_util.Immutable):
             group_slots=group_slots,
             literals=literals,
             pattern_hash=pattern_hash,
-            _binary=binary,
+            _bytes=binary,
             _hash=hash(
                 (
                     type(self),
@@ -1227,7 +1227,7 @@ class ReplaceTemplate(_util.Immutable):
             self.literals == other.literals and
             self.pattern_hash == other.pattern_hash and
             self.use_format == other.use_format and
-            self._binary == other._binary
+            self._bytes == other._bytes
         )
 
     def __ne__(self, other):
@@ -1240,7 +1240,7 @@ class ReplaceTemplate(_util.Immutable):
             self.literals != other.literals or
             self.pattern_hash != other.pattern_hash or
             self.use_format != other.use_format or
-            self._binary != other._binary
+            self._bytes != other._bytes
         )
 
     def __repr__(self):  # pragma: no cover
@@ -1279,7 +1279,7 @@ class ReplaceTemplate(_util.Immutable):
             raise ValueError("Match is None!")
 
         sep = m.string[:0]
-        if isinstance(sep, _util.binary_type) != self._binary:
+        if isinstance(sep, _util.bytes_type) != self._bytes:
             raise TypeError('Match string type does not match expander string type!')
         text = []
         # Expand string
@@ -1301,7 +1301,7 @@ class ReplaceTemplate(_util.Immutable):
                         obj = m.captures(g_index)
                     except IndexError:  # pragma: no cover
                         raise IndexError("'%d' is out of range!" % g_index)
-                    l = _util.format_string(m, obj, capture, self._binary)
+                    l = _util.format_string(m, obj, capture, self._bytes)
                 if span_case is not None:
                     if span_case == _LOWER:
                         l = l.lower()
@@ -1320,7 +1320,7 @@ class ReplaceTemplate(_util.Immutable):
 def _pickle(r):
     """Pickle."""
 
-    return ReplaceTemplate, (r.groups, r.group_slots, r.literals, r.pattern_hash, r.use_format, r._binary)
+    return ReplaceTemplate, (r.groups, r.group_slots, r.literals, r.pattern_hash, r.use_format, r._bytes)
 
 
 _util.copyreg.pickle(ReplaceTemplate, _pickle)

--- a/backrefs/bre.py
+++ b/backrefs/bre.py
@@ -113,14 +113,14 @@ def _apply_replace_backrefs(m, repl=None, flags=0):
     else:
         if isinstance(repl, ReplaceTemplate):
             return repl.expand(m)
-        elif isinstance(repl, (_util.string_type, _util.binary_type)):
+        elif isinstance(repl, (_util.string_type, _util.bytes_type)):
             return _bre_parse._ReplaceParser().parse(m.re, repl, bool(flags & FORMAT)).expand(m)
 
 
 def _apply_search_backrefs(pattern, flags=0):
     """Apply the search backrefs to the search pattern."""
 
-    if isinstance(pattern, (_util.string_type, _util.binary_type)):
+    if isinstance(pattern, (_util.string_type, _util.bytes_type)):
         re_verbose = bool(VERBOSE & flags)
         re_unicode = None
         if _util.PY3 and bool((ASCII | LOCALE) & flags):
@@ -152,7 +152,7 @@ def _assert_expandable(repl, use_format=False):
                 raise ValueError("Replace not compiled as a format replace")
             else:
                 raise ValueError("Replace should not be compiled as a format replace!")
-    elif not isinstance(repl, (_util.string_type, _util.binary_type)):
+    elif not isinstance(repl, (_util.string_type, _util.bytes_type)):
         raise TypeError("Expected string, buffer, or compiled replace!")
 
 
@@ -237,7 +237,7 @@ class Bre(_util.Immutable):
         """Compile replacements."""
 
         is_replace = _is_replace(template)
-        is_string = isinstance(template, (_util.string_type, _util.binary_type))
+        is_string = isinstance(template, (_util.string_type, _util.bytes_type))
         if is_replace and use_format != template.use_format:
             raise ValueError("Compiled replace cannot be a format object!")
         if is_replace or (is_string and self.auto_compile):
@@ -334,7 +334,7 @@ def compile_replace(pattern, repl, flags=0):
 
     call = None
     if pattern is not None and isinstance(pattern, _RE_TYPE):
-        if isinstance(repl, (_util.string_type, _util.binary_type)):
+        if isinstance(repl, (_util.string_type, _util.bytes_type)):
             if not (pattern.flags & DEBUG):
                 call = _cached_replace_compile(pattern, repl, flags, type(repl))
             else:  # pragma: no cover
@@ -414,7 +414,7 @@ def sub(pattern, repl, string, count=0, flags=0):
     """Apply `sub` after applying backrefs."""
 
     is_replace = _is_replace(repl)
-    is_string = isinstance(repl, (_util.string_type, _util.binary_type))
+    is_string = isinstance(repl, (_util.string_type, _util.bytes_type))
     if is_replace and repl.use_format:
         raise ValueError("Compiled replace cannot be a format object!")
 
@@ -428,7 +428,7 @@ def subf(pattern, format, string, count=0, flags=0):  # noqa A002
     """Apply `sub` with format style replace."""
 
     is_replace = _is_replace(format)
-    is_string = isinstance(format, (_util.string_type, _util.binary_type))
+    is_string = isinstance(format, (_util.string_type, _util.bytes_type))
     if is_replace and not format.use_format:
         raise ValueError("Compiled replace is not a format object!")
 
@@ -444,7 +444,7 @@ def subn(pattern, repl, string, count=0, flags=0):
     """Apply `subn` with format style replace."""
 
     is_replace = _is_replace(repl)
-    is_string = isinstance(repl, (_util.string_type, _util.binary_type))
+    is_string = isinstance(repl, (_util.string_type, _util.bytes_type))
     if is_replace and repl.use_format:
         raise ValueError("Compiled replace cannot be a format object!")
 
@@ -458,7 +458,7 @@ def subfn(pattern, format, string, count=0, flags=0):  # noqa A002
     """Apply `subn` after applying backrefs."""
 
     is_replace = _is_replace(format)
-    is_string = isinstance(format, (_util.string_type, _util.binary_type))
+    is_string = isinstance(format, (_util.string_type, _util.bytes_type))
     if is_replace and not format.use_format:
         raise ValueError("Compiled replace is not a format object!")
 

--- a/backrefs/bregex.py
+++ b/backrefs/bregex.py
@@ -124,14 +124,14 @@ def _apply_replace_backrefs(m, repl=None, flags=0):
         else:
             if isinstance(repl, ReplaceTemplate):
                 return repl.expand(m)
-            elif isinstance(repl, (_util.string_type, _util.binary_type)):
+            elif isinstance(repl, (_util.string_type, _util.bytes_type)):
                 return _bregex_parse._ReplaceParser().parse(m.re, repl, bool(flags & FORMAT)).expand(m)
 
 
 def _apply_search_backrefs(pattern, flags=0):
     """Apply the search backrefs to the search pattern."""
 
-    if isinstance(pattern, (_util.string_type, _util.binary_type)):
+    if isinstance(pattern, (_util.string_type, _util.bytes_type)):
         re_verbose = VERBOSE & flags
         if flags & V0:
             re_version = V0
@@ -164,7 +164,7 @@ def _assert_expandable(repl, use_format=False):
                 raise ValueError("Replace not compiled as a format replace")
             else:
                 raise ValueError("Replace should not be compiled as a format replace!")
-    elif not isinstance(repl, (_util.string_type, _util.binary_type)):
+    elif not isinstance(repl, (_util.string_type, _util.bytes_type)):
         raise TypeError("Expected string, buffer, or compiled replace!")
 
 
@@ -195,7 +195,7 @@ def compile_replace(pattern, repl, flags=0):
 
     call = None
     if pattern is not None and isinstance(pattern, _REGEX_TYPE):
-        if isinstance(repl, (_util.string_type, _util.binary_type)):
+        if isinstance(repl, (_util.string_type, _util.bytes_type)):
             if not (pattern.flags & DEBUG):
                 call = _cached_replace_compile(pattern, repl, flags, type(repl))
             else:  # pragma: no cover
@@ -294,7 +294,7 @@ class Bregex(_util.Immutable):
         """Compile replacements."""
 
         is_replace = _is_replace(template)
-        is_string = isinstance(template, (_util.string_type, _util.binary_type))
+        is_string = isinstance(template, (_util.string_type, _util.bytes_type))
         if is_replace and use_format != template.use_format:
             raise ValueError("Compiled replace cannot be a format object!")
         if is_replace or (is_string and self.auto_compile):
@@ -420,7 +420,7 @@ def sub(pattern, repl, string, count=0, flags=0, pos=None, endpos=None, concurre
     """Wrapper for `sub`."""
 
     is_replace = _is_replace(repl)
-    is_string = isinstance(repl, (_util.string_type, _util.binary_type))
+    is_string = isinstance(repl, (_util.string_type, _util.bytes_type))
     if is_replace and repl.use_format:
         raise ValueError("Compiled replace cannot be a format object!")
 
@@ -435,7 +435,7 @@ def subf(pattern, format, string, count=0, flags=0, pos=None, endpos=None, concu
     """Wrapper for `subf`."""
 
     is_replace = _is_replace(format)
-    is_string = isinstance(format, (_util.string_type, _util.binary_type))
+    is_string = isinstance(format, (_util.string_type, _util.bytes_type))
     if is_replace and not format.use_format:
         raise ValueError("Compiled replace is not a format object!")
 
@@ -451,7 +451,7 @@ def subn(pattern, repl, string, count=0, flags=0, pos=None, endpos=None, concurr
     """Wrapper for `subn`."""
 
     is_replace = _is_replace(repl)
-    is_string = isinstance(repl, (_util.string_type, _util.binary_type))
+    is_string = isinstance(repl, (_util.string_type, _util.bytes_type))
     if is_replace and repl.use_format:
         raise ValueError("Compiled replace cannot be a format object!")
 
@@ -466,7 +466,7 @@ def subfn(pattern, format, string, count=0, flags=0, pos=None, endpos=None, conc
     """Wrapper for `subfn`."""
 
     is_replace = _is_replace(format)
-    is_string = isinstance(format, (_util.string_type, _util.binary_type))
+    is_string = isinstance(format, (_util.string_type, _util.bytes_type))
     if is_replace and not format.use_format:
         raise ValueError("Compiled replace is not a format object!")
 

--- a/backrefs/uniprops/__init__.py
+++ b/backrefs/uniprops/__init__.py
@@ -13,19 +13,19 @@ PY3 = sys.version_info >= (3, 0) and sys.version_info[0:2] < (4, 0)
 PY35 = sys.version_info >= (3, 5)
 PY37 = sys.version_info >= (3, 7)
 if PY3:
-    binary_type = bytes  # noqa
+    bytes_type = bytes  # noqa
 else:
-    binary_type = str  # noqa
+    bytes_type = str  # noqa
 
 POSIX = 0
-POSIX_BINARY = 1
+POSIX_BYTES = 1
 POSIX_UNICODE = 2
 
 
 def get_posix_property(value, mode=POSIX):
     """Retrieve the posix category."""
 
-    if mode == POSIX_BINARY:
+    if mode == POSIX_BYTES:
         return unidata.ascii_posix_properties[value]
     elif mode == POSIX_UNICODE:
         return unidata.unicode_binary[
@@ -35,10 +35,10 @@ def get_posix_property(value, mode=POSIX):
         return unidata.unicode_posix_properties[value]
 
 
-def get_gc_property(value, binary=False):
+def get_gc_property(value, is_bytes=False):
     """Get `GC` property."""
 
-    obj = unidata.ascii_properties if binary else unidata.unicode_properties
+    obj = unidata.ascii_properties if is_bytes else unidata.unicode_properties
 
     if value.startswith('^'):
         negate = True
@@ -62,10 +62,10 @@ def get_gc_property(value, binary=False):
     return value
 
 
-def get_binary_property(value, binary=False):
+def get_binary_property(value, is_bytes=False):
     """Get `BINARY` property."""
 
-    obj = unidata.ascii_binary if binary else unidata.unicode_binary
+    obj = unidata.ascii_binary if is_bytes else unidata.unicode_binary
 
     if value.startswith('^'):
         negated = value[1:]
@@ -76,10 +76,10 @@ def get_binary_property(value, binary=False):
     return obj[value]
 
 
-def get_canonical_combining_class_property(value, binary=False):
+def get_canonical_combining_class_property(value, is_bytes=False):
     """Get `CANONICAL COMBINING CLASS` property."""
 
-    obj = unidata.ascii_canonical_combining_class if binary else unidata.unicode_canonical_combining_class
+    obj = unidata.ascii_canonical_combining_class if is_bytes else unidata.unicode_canonical_combining_class
 
     if value.startswith('^'):
         negated = value[1:]
@@ -90,10 +90,10 @@ def get_canonical_combining_class_property(value, binary=False):
     return obj[value]
 
 
-def get_east_asian_width_property(value, binary=False):
+def get_east_asian_width_property(value, is_bytes=False):
     """Get `EAST ASIAN WIDTH` property."""
 
-    obj = unidata.ascii_east_asian_width if binary else unidata.unicode_east_asian_width
+    obj = unidata.ascii_east_asian_width if is_bytes else unidata.unicode_east_asian_width
 
     if value.startswith('^'):
         negated = value[1:]
@@ -104,10 +104,10 @@ def get_east_asian_width_property(value, binary=False):
     return obj[value]
 
 
-def get_grapheme_cluster_break_property(value, binary=False):
+def get_grapheme_cluster_break_property(value, is_bytes=False):
     """Get `GRAPHEME CLUSTER BREAK` property."""
 
-    obj = unidata.ascii_grapheme_cluster_break if binary else unidata.unicode_grapheme_cluster_break
+    obj = unidata.ascii_grapheme_cluster_break if is_bytes else unidata.unicode_grapheme_cluster_break
 
     if value.startswith('^'):
         negated = value[1:]
@@ -118,10 +118,10 @@ def get_grapheme_cluster_break_property(value, binary=False):
     return obj[value]
 
 
-def get_line_break_property(value, binary=False):
+def get_line_break_property(value, is_bytes=False):
     """Get `LINE BREAK` property."""
 
-    obj = unidata.ascii_line_break if binary else unidata.unicode_line_break
+    obj = unidata.ascii_line_break if is_bytes else unidata.unicode_line_break
 
     if value.startswith('^'):
         negated = value[1:]
@@ -132,10 +132,10 @@ def get_line_break_property(value, binary=False):
     return obj[value]
 
 
-def get_sentence_break_property(value, binary=False):
+def get_sentence_break_property(value, is_bytes=False):
     """Get `SENTENCE BREAK` property."""
 
-    obj = unidata.ascii_sentence_break if binary else unidata.unicode_sentence_break
+    obj = unidata.ascii_sentence_break if is_bytes else unidata.unicode_sentence_break
 
     if value.startswith('^'):
         negated = value[1:]
@@ -146,10 +146,10 @@ def get_sentence_break_property(value, binary=False):
     return obj[value]
 
 
-def get_word_break_property(value, binary=False):
+def get_word_break_property(value, is_bytes=False):
     """Get `WORD BREAK` property."""
 
-    obj = unidata.ascii_word_break if binary else unidata.unicode_word_break
+    obj = unidata.ascii_word_break if is_bytes else unidata.unicode_word_break
 
     if value.startswith('^'):
         negated = value[1:]
@@ -160,10 +160,10 @@ def get_word_break_property(value, binary=False):
     return obj[value]
 
 
-def get_hangul_syllable_type_property(value, binary=False):
+def get_hangul_syllable_type_property(value, is_bytes=False):
     """Get `HANGUL SYLLABLE TYPE` property."""
 
-    obj = unidata.ascii_hangul_syllable_type if binary else unidata.unicode_hangul_syllable_type
+    obj = unidata.ascii_hangul_syllable_type if is_bytes else unidata.unicode_hangul_syllable_type
 
     if value.startswith('^'):
         negated = value[1:]
@@ -174,14 +174,14 @@ def get_hangul_syllable_type_property(value, binary=False):
     return obj[value]
 
 
-def get_indic_positional_category_property(value, binary=False):
+def get_indic_positional_category_property(value, is_bytes=False):
     """Get `INDIC POSITIONAL/MATRA CATEGORY` property."""
 
     if PY35:
-        obj = unidata.ascii_indic_positional_category if binary else unidata.unicode_indic_positional_category
+        obj = unidata.ascii_indic_positional_category if is_bytes else unidata.unicode_indic_positional_category
         alias_key = 'indicpositionalcategory'
     else:
-        obj = unidata.ascii_indic_matra_category if binary else unidata.unicode_indic_matra_category
+        obj = unidata.ascii_indic_matra_category if is_bytes else unidata.unicode_indic_matra_category
         alias_key = 'indicmatracategory'
 
     if value.startswith('^'):
@@ -193,10 +193,10 @@ def get_indic_positional_category_property(value, binary=False):
     return obj[value]
 
 
-def get_indic_syllabic_category_property(value, binary=False):
+def get_indic_syllabic_category_property(value, is_bytes=False):
     """Get `INDIC SYLLABIC CATEGORY` property."""
 
-    obj = unidata.ascii_indic_syllabic_category if binary else unidata.unicode_indic_syllabic_category
+    obj = unidata.ascii_indic_syllabic_category if is_bytes else unidata.unicode_indic_syllabic_category
 
     if value.startswith('^'):
         negated = value[1:]
@@ -207,10 +207,10 @@ def get_indic_syllabic_category_property(value, binary=False):
     return obj[value]
 
 
-def get_decomposition_type_property(value, binary=False):
+def get_decomposition_type_property(value, is_bytes=False):
     """Get `DECOMPOSITION TYPE` property."""
 
-    obj = unidata.ascii_decomposition_type if binary else unidata.unicode_decomposition_type
+    obj = unidata.ascii_decomposition_type if is_bytes else unidata.unicode_decomposition_type
 
     if value.startswith('^'):
         negated = value[1:]
@@ -221,10 +221,10 @@ def get_decomposition_type_property(value, binary=False):
     return obj[value]
 
 
-def get_nfc_quick_check_property(value, binary=False):
+def get_nfc_quick_check_property(value, is_bytes=False):
     """Get `NFC QUICK CHECK` property."""
 
-    obj = unidata.ascii_nfc_quick_check if binary else unidata.unicode_nfc_quick_check
+    obj = unidata.ascii_nfc_quick_check if is_bytes else unidata.unicode_nfc_quick_check
 
     if value.startswith('^'):
         negated = value[1:]
@@ -235,10 +235,10 @@ def get_nfc_quick_check_property(value, binary=False):
     return obj[value]
 
 
-def get_nfd_quick_check_property(value, binary=False):
+def get_nfd_quick_check_property(value, is_bytes=False):
     """Get `NFD QUICK CHECK` property."""
 
-    obj = unidata.ascii_nfd_quick_check if binary else unidata.unicode_nfd_quick_check
+    obj = unidata.ascii_nfd_quick_check if is_bytes else unidata.unicode_nfd_quick_check
 
     if value.startswith('^'):
         negated = value[1:]
@@ -249,10 +249,10 @@ def get_nfd_quick_check_property(value, binary=False):
     return obj[value]
 
 
-def get_nfkc_quick_check_property(value, binary=False):
+def get_nfkc_quick_check_property(value, is_bytes=False):
     """Get `NFKC QUICK CHECK` property."""
 
-    obj = unidata.ascii_nfkc_quick_check if binary else unidata.unicode_nfkc_quick_check
+    obj = unidata.ascii_nfkc_quick_check if is_bytes else unidata.unicode_nfkc_quick_check
 
     if value.startswith('^'):
         negated = value[1:]
@@ -263,10 +263,10 @@ def get_nfkc_quick_check_property(value, binary=False):
     return obj[value]
 
 
-def get_nfkd_quick_check_property(value, binary=False):
+def get_nfkd_quick_check_property(value, is_bytes=False):
     """Get `NFKD QUICK CHECK` property."""
 
-    obj = unidata.ascii_nfkd_quick_check if binary else unidata.unicode_nfkd_quick_check
+    obj = unidata.ascii_nfkd_quick_check if is_bytes else unidata.unicode_nfkd_quick_check
 
     if value.startswith('^'):
         negated = value[1:]
@@ -277,10 +277,10 @@ def get_nfkd_quick_check_property(value, binary=False):
     return obj[value]
 
 
-def get_numeric_type_property(value, binary=False):
+def get_numeric_type_property(value, is_bytes=False):
     """Get `NUMERIC TYPE` property."""
 
-    obj = unidata.ascii_numeric_type if binary else unidata.unicode_numeric_type
+    obj = unidata.ascii_numeric_type if is_bytes else unidata.unicode_numeric_type
 
     if value.startswith('^'):
         negated = value[1:]
@@ -291,10 +291,10 @@ def get_numeric_type_property(value, binary=False):
     return obj[value]
 
 
-def get_numeric_value_property(value, binary=False):
+def get_numeric_value_property(value, is_bytes=False):
     """Get `NUMERIC VALUE` property."""
 
-    obj = unidata.ascii_numeric_values if binary else unidata.unicode_numeric_values
+    obj = unidata.ascii_numeric_values if is_bytes else unidata.unicode_numeric_values
 
     if value.startswith('^'):
         negated = value[1:]
@@ -305,10 +305,10 @@ def get_numeric_value_property(value, binary=False):
     return obj[value]
 
 
-def get_age_property(value, binary=False):
+def get_age_property(value, is_bytes=False):
     """Get `AGE` property."""
 
-    obj = unidata.ascii_age if binary else unidata.unicode_age
+    obj = unidata.ascii_age if is_bytes else unidata.unicode_age
 
     if value.startswith('^'):
         negated = value[1:]
@@ -319,10 +319,10 @@ def get_age_property(value, binary=False):
     return obj[value]
 
 
-def get_joining_type_property(value, binary=False):
+def get_joining_type_property(value, is_bytes=False):
     """Get `JOINING TYPE` property."""
 
-    obj = unidata.ascii_joining_type if binary else unidata.unicode_joining_type
+    obj = unidata.ascii_joining_type if is_bytes else unidata.unicode_joining_type
 
     if value.startswith('^'):
         negated = value[1:]
@@ -333,10 +333,10 @@ def get_joining_type_property(value, binary=False):
     return obj[value]
 
 
-def get_joining_group_property(value, binary=False):
+def get_joining_group_property(value, is_bytes=False):
     """Get `JOINING GROUP` property."""
 
-    obj = unidata.ascii_joining_group if binary else unidata.unicode_joining_group
+    obj = unidata.ascii_joining_group if is_bytes else unidata.unicode_joining_group
 
     if value.startswith('^'):
         negated = value[1:]
@@ -347,10 +347,10 @@ def get_joining_group_property(value, binary=False):
     return obj[value]
 
 
-def get_script_property(value, binary=False):
+def get_script_property(value, is_bytes=False):
     """Get `SC` property."""
 
-    obj = unidata.ascii_scripts if binary else unidata.unicode_scripts
+    obj = unidata.ascii_scripts if is_bytes else unidata.unicode_scripts
 
     if value.startswith('^'):
         negated = value[1:]
@@ -361,10 +361,10 @@ def get_script_property(value, binary=False):
     return obj[value]
 
 
-def get_script_extension_property(value, binary=False):
+def get_script_extension_property(value, is_bytes=False):
     """Get `SCX` property."""
 
-    obj = unidata.ascii_script_extensions if binary else unidata.unicode_script_extensions
+    obj = unidata.ascii_script_extensions if is_bytes else unidata.unicode_script_extensions
 
     if value.startswith('^'):
         negated = value[1:]
@@ -375,10 +375,10 @@ def get_script_extension_property(value, binary=False):
     return obj[value]
 
 
-def get_block_property(value, binary=False):
+def get_block_property(value, is_bytes=False):
     """Get `BLK` property."""
 
-    obj = unidata.ascii_blocks if binary else unidata.unicode_blocks
+    obj = unidata.ascii_blocks if is_bytes else unidata.unicode_blocks
 
     if value.startswith('^'):
         negated = value[1:]
@@ -389,10 +389,10 @@ def get_block_property(value, binary=False):
     return obj[value]
 
 
-def get_bidi_property(value, binary=False):
+def get_bidi_property(value, is_bytes=False):
     """Get `BC` property."""
 
-    obj = unidata.ascii_bidi_classes if binary else unidata.unicode_bidi_classes
+    obj = unidata.ascii_bidi_classes if is_bytes else unidata.unicode_bidi_classes
 
     if value.startswith('^'):
         negated = value[1:]
@@ -403,10 +403,10 @@ def get_bidi_property(value, binary=False):
     return obj[value]
 
 
-def get_bidi_paired_bracket_type_property(value, binary=False):
+def get_bidi_paired_bracket_type_property(value, is_bytes=False):
     """Get `BPT` property."""
 
-    obj = unidata.ascii_bidi_paired_bracket_type if binary else unidata.unicode_bidi_paired_bracket_type
+    obj = unidata.ascii_bidi_paired_bracket_type if is_bytes else unidata.unicode_bidi_paired_bracket_type
 
     if value.startswith('^'):
         negated = value[1:]
@@ -417,10 +417,10 @@ def get_bidi_paired_bracket_type_property(value, binary=False):
     return obj[value]
 
 
-def get_vertical_orientation_property(value, binary=False):
+def get_vertical_orientation_property(value, is_bytes=False):
     """Get `VO` property."""
 
-    obj = unidata.ascii_vertical_orientation if binary else unidata.unicode_vertical_orientation
+    obj = unidata.ascii_vertical_orientation if is_bytes else unidata.unicode_vertical_orientation
 
     if value.startswith('^'):
         negated = value[1:]
@@ -431,7 +431,7 @@ def get_vertical_orientation_property(value, binary=False):
     return obj[value]
 
 
-def get_is_property(value, binary=False):
+def get_is_property(value, is_bytes=False):
     """Get shortcut for `SC` or `Binary` property."""
 
     if value.startswith('^'):
@@ -447,10 +447,10 @@ def get_is_property(value, binary=False):
         raise ValueError("Does not start with 'is'!")
 
     if PY3:
-        script_obj = unidata.ascii_script_extensions if binary else unidata.unicode_script_extensions
+        script_obj = unidata.ascii_script_extensions if is_bytes else unidata.unicode_script_extensions
     else:
-        script_obj = unidata.ascii_scripts if binary else unidata.unicode_scripts
-    bin_obj = unidata.ascii_binary if binary else unidata.unicode_binary
+        script_obj = unidata.ascii_scripts if is_bytes else unidata.unicode_scripts
+    bin_obj = unidata.ascii_binary if is_bytes else unidata.unicode_binary
 
     value = negate + unidata.unicode_alias['script'].get(temp, temp)
 
@@ -463,7 +463,7 @@ def get_is_property(value, binary=False):
     return obj[value]
 
 
-def get_in_property(value, binary=False):
+def get_in_property(value, is_bytes=False):
     """Get shortcut for `Block` property."""
 
     if value.startswith('^'):
@@ -479,7 +479,7 @@ def get_in_property(value, binary=False):
         raise ValueError("Does not start with 'in'!")
 
     value = negate + unidata.unicode_alias['block'].get(temp, temp)
-    obj = unidata.ascii_blocks if binary else unidata.unicode_blocks
+    obj = unidata.ascii_blocks if is_bytes else unidata.unicode_blocks
 
     return obj[value]
 
@@ -490,103 +490,103 @@ def is_enum(name):
     return name in unidata.enum_names
 
 
-def get_unicode_property(value, prop=None, binary=False):
+def get_unicode_property(value, prop=None, is_bytes=False):
     """Retrieve the Unicode category from the table."""
 
     if prop is not None:
         prop = unidata.unicode_alias['_'].get(prop, prop)
         try:
             if prop == 'generalcategory':
-                return get_gc_property(value, binary)
+                return get_gc_property(value, is_bytes)
             elif prop == 'script':
-                return get_script_property(value, binary)
+                return get_script_property(value, is_bytes)
             elif PY3 and prop == 'scriptextensions':
-                return get_script_extension_property(value, binary)
+                return get_script_extension_property(value, is_bytes)
             elif prop == 'block':
-                return get_block_property(value, binary)
+                return get_block_property(value, is_bytes)
             elif prop == 'binary':
-                return get_binary_property(value, binary)
+                return get_binary_property(value, is_bytes)
             elif prop == 'bidiclass':
-                return get_bidi_property(value, binary)
+                return get_bidi_property(value, is_bytes)
             elif prop == 'bidipairedbrackettype':
-                return get_bidi_paired_bracket_type_property(value, binary)
+                return get_bidi_paired_bracket_type_property(value, is_bytes)
             elif prop == 'age':
-                return get_age_property(value, binary)
+                return get_age_property(value, is_bytes)
             elif prop == 'eastasianwidth':
-                return get_east_asian_width_property(value, binary)
+                return get_east_asian_width_property(value, is_bytes)
             elif PY35 and prop == 'indicpositionalcategory':
-                return get_indic_positional_category_property(value, binary)
+                return get_indic_positional_category_property(value, is_bytes)
             elif PY3 and not PY35 and prop == 'indicmatracategory':
-                return get_indic_positional_category_property(value, binary)
+                return get_indic_positional_category_property(value, is_bytes)
             elif PY3 and prop == 'indicsyllabiccategory':
-                return get_indic_syllabic_category_property(value, binary)
+                return get_indic_syllabic_category_property(value, is_bytes)
             elif prop == 'hangulsyllabletype':
-                return get_hangul_syllable_type_property(value, binary)
+                return get_hangul_syllable_type_property(value, is_bytes)
             elif prop == 'decompositiontype':
-                return get_decomposition_type_property(value, binary)
+                return get_decomposition_type_property(value, is_bytes)
             elif prop == 'canonicalcombiningclass':
-                return get_canonical_combining_class_property(value, binary)
+                return get_canonical_combining_class_property(value, is_bytes)
             elif prop == 'numerictype':
-                return get_numeric_type_property(value, binary)
+                return get_numeric_type_property(value, is_bytes)
             elif prop == 'numericvalue':
-                return get_numeric_value_property(value, binary)
+                return get_numeric_value_property(value, is_bytes)
             elif prop == 'joiningtype':
-                return get_joining_type_property(value, binary)
+                return get_joining_type_property(value, is_bytes)
             elif prop == 'joininggroup':
-                return get_joining_group_property(value, binary)
+                return get_joining_group_property(value, is_bytes)
             elif prop == 'graphemeclusterbreak':
-                return get_grapheme_cluster_break_property(value, binary)
+                return get_grapheme_cluster_break_property(value, is_bytes)
             elif prop == 'linebreak':
-                return get_line_break_property(value, binary)
+                return get_line_break_property(value, is_bytes)
             elif prop == 'sentencebreak':
-                return get_sentence_break_property(value, binary)
+                return get_sentence_break_property(value, is_bytes)
             elif prop == 'wordbreak':
-                return get_word_break_property(value, binary)
+                return get_word_break_property(value, is_bytes)
             elif prop == 'nfcquickcheck':
-                return get_nfc_quick_check_property(value, binary)
+                return get_nfc_quick_check_property(value, is_bytes)
             elif prop == 'nfdquickcheck':
-                return get_nfd_quick_check_property(value, binary)
+                return get_nfd_quick_check_property(value, is_bytes)
             elif prop == 'nfkcquickcheck':
-                return get_nfkc_quick_check_property(value, binary)
+                return get_nfkc_quick_check_property(value, is_bytes)
             elif prop == 'nfkdquickcheck':
-                return get_nfkd_quick_check_property(value, binary)
+                return get_nfkd_quick_check_property(value, is_bytes)
             elif PY37 and prop == 'verticalorientation':
-                return get_vertical_orientation_property(value, binary)
+                return get_vertical_orientation_property(value, is_bytes)
             else:
                 raise ValueError('Invalid Unicode property!')
         except Exception:
             raise ValueError('Invalid Unicode property!')
 
     try:
-        return get_gc_property(value, binary)
+        return get_gc_property(value, is_bytes)
     except Exception:
         pass
 
     try:
         if PY3:
-            return get_script_extension_property(value, binary)
+            return get_script_extension_property(value, is_bytes)
         else:
-            return get_script_property(value, binary)
+            return get_script_property(value, is_bytes)
     except Exception:
         pass
 
     try:
-        return get_block_property(value, binary)
+        return get_block_property(value, is_bytes)
     except Exception:
         pass
 
     try:
-        return get_binary_property(value, binary)
+        return get_binary_property(value, is_bytes)
     except Exception:
         pass
 
     try:
-        return get_is_property(value, binary)
+        return get_is_property(value, is_bytes)
     except Exception:
         pass
 
     try:
-        return get_in_property(value, binary)
+        return get_in_property(value, is_bytes)
     except Exception:
         pass
 

--- a/backrefs/util.py
+++ b/backrefs/util.py
@@ -24,7 +24,7 @@ if PY3:
     import copyreg  # noqa F401
 
     string_type = str
-    binary_type = bytes
+    bytes_type = bytes
     unichar = chr
     iter_range = range  # noqa F821
 
@@ -33,7 +33,7 @@ else:
     import copy_reg as copyreg  # noqa F401
 
     string_type = unicode  # noqa F821
-    binary_type = str  # noqa F821
+    bytes_type = str  # noqa F821
     unichar = unichr  # noqa F821
     iter_range = xrange  # noqa F821
 
@@ -112,12 +112,12 @@ def _to_bstr(l):
 
     if isinstance(l, string_type):
         l = l.encode('ascii', 'backslashreplace')
-    elif not isinstance(l, binary_type):
+    elif not isinstance(l, bytes_type):
         l = string_type(l).encode('ascii', 'backslashreplace')
     return l
 
 
-def format_string(m, l, capture, binary):
+def format_string(m, l, capture, is_bytes):
     """Perform a string format."""
 
     for fmt_type, value in capture[1:]:
@@ -128,7 +128,7 @@ def format_string(m, l, capture, binary):
             # Index
             l = l[value]
         elif fmt_type == FMT_CONV:
-            if binary:
+            if is_bytes:
                 # Conversion
                 if value in ('r', 'a'):
                     l = repr(l).encode('ascii', 'backslashreplace')
@@ -153,7 +153,7 @@ def format_string(m, l, capture, binary):
                     raise ValueError("Unknown format code 's' for object of type 'float'")
 
             # Ensure object is a byte string
-            l = _to_bstr(l) if binary else string_type(l)
+            l = _to_bstr(l) if is_bytes else string_type(l)
 
             spec_type = value[1]
             if spec_type == '^':
@@ -164,7 +164,7 @@ def format_string(m, l, capture, binary):
                 l = l.ljust(value[2], value[0])
 
     # Make sure the final object is a byte string
-    return _to_bstr(l) if binary else string_type(l)
+    return _to_bstr(l) if is_bytes else string_type(l)
 
 
 class Immutable(object):

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -17,10 +17,10 @@ PY36_PLUS = (3, 6) <= sys.version_info
 PY37_PLUS = (3, 7) <= sys.version_info
 
 if PY3:
-    binary_type = bytes  # noqa
+    bytes_type = bytes  # noqa
     string_type = str  # noqa
 else:
-    binary_type = str  # noqa
+    bytes_type = str  # noqa
     string_type = unicode  # noqa
 
 
@@ -760,14 +760,14 @@ class TestSearchTemplate(unittest.TestCase):
         m = pattern.match(r'P')
         self.assertTrue(m is None)
 
-    def test_binary_property(self):
-        r"""Binary patterns should match `\p` references."""
+    def test_bytes_property(self):
+        r"""Byte patterns should match `\p` references."""
 
         pattern = bre.compile_search(br'EX\p{Lu}MPLE')
         m = pattern.match(br'EXAMPLE')
         self.assertTrue(m is not None)
 
-    def test_binary_property_no_value(self):
+    def test_bytes_property_no_value(self):
         """Test when a property returns nothing in byte string."""
 
         pattern = bre.compile_search(br'EX\p{OtherAlphabetic}MPLE')
@@ -1150,8 +1150,8 @@ class TestReplaceTemplate(unittest.TestCase):
             'line line line '
         )
 
-    def test_binary_line_break(self):
-        r"""Test binary line break \R."""
+    def test_bytes_line_break(self):
+        r"""Test bytes line break \R."""
 
         self.assertEqual(
             bre.sub(br"\R", b' ', b'line\r\nline\nline\r'),
@@ -1574,8 +1574,8 @@ class TestReplaceTemplate(unittest.TestCase):
         self.assertEqual(results2, results)
         self.assertEqual('\t \\t \\\t \\\\t \\\\\t', results)
 
-    def test_binary_normal_escaping(self):
-        """Test binary normal escaped slash."""
+    def test_bytes_normal_escaping(self):
+        """Test bytes normal escaped slash."""
 
         text = b"This is a test of normal escaping!"
         pattern = re.compile(br"(.+)")
@@ -1673,16 +1673,16 @@ class TestReplaceTemplate(unittest.TestCase):
         self.assertEqual(result, "This is awesome!  Here we go!  This is awesome!  Here we go!")
         self.assertEqual(count, 2)
 
-    def test_binary_replace(self):
-        """Test that binary regex result is a binary string."""
+    def test_bytes_replace(self):
+        """Test that bytes regex result is a bytes string."""
 
-        text = b"This is some binary text!"
-        pattern = bre.compile_search(br"This is (some binary text)!")
+        text = b"This is some bytes text!"
+        pattern = bre.compile_search(br"This is (some bytes text)!")
         expand = bre.compile_replace(pattern, br'\C\1\E')
         m = pattern.match(text)
         result = expand(m)
-        self.assertEqual(result, b"SOME BINARY TEXT")
-        self.assertTrue(isinstance(result, binary_type))
+        self.assertEqual(result, b"SOME BYTES TEXT")
+        self.assertTrue(isinstance(result, bytes_type))
 
     def test_template_replace(self):
         """Test replace by passing in replace function."""
@@ -1843,7 +1843,7 @@ class TestReplaceTemplate(unittest.TestCase):
             results
         )
 
-    def test_binary_format_capture_bases(self):
+    def test_bytes_format_capture_bases(self):
         """Test capture bases."""
 
         text = b"abababab"
@@ -2018,7 +2018,7 @@ class TestReplaceTemplate(unittest.TestCase):
         # Python 3.7 will choke on \U and \u as invalid escapes, so
         # don't bother running these tests there.
         if not PY37_PLUS:
-            # Binary doesn't care about Unicode, but should evaluate bytes
+            # Bytes doesn't care about Unicode, but should evaluate bytes
             pattern = re.compile(b'Test')
             expand = bre.compile_replace(pattern, br'\C\u0109\n\x77\E\l\x57\c\u0109')
             results = expand(pattern.match(b'Test'))
@@ -2130,16 +2130,16 @@ class TestExceptions(unittest.TestCase):
 
         self.assertEqual(str(e.value), 'Invalid POSIX property!')
 
-    def test_bad_binary(self):
-        """Test bad binary."""
+    def test_bad_bytes(self):
+        """Test bad bytes."""
 
         with pytest.raises(ValueError) as e:
-            bre.compile_search(r'\p{bad_binary:n}', re.UNICODE)
+            bre.compile_search(r'\p{bad_bytes:n}', re.UNICODE)
 
         self.assertEqual(str(e.value), 'Invalid Unicode property!')
 
         with pytest.raises(ValueError) as e:
-            bre.compile_search(r'\p{bad_binary:y}', re.UNICODE)
+            bre.compile_search(r'\p{bad_bytes:y}', re.UNICODE)
 
         self.assertEqual(str(e.value), 'Invalid Unicode property!')
 

--- a/tests/test_bregex.py
+++ b/tests/test_bregex.py
@@ -14,10 +14,10 @@ import copy
 PY3 = (3, 0) <= sys.version_info < (4, 0)
 
 if PY3:
-    binary_type = bytes  # noqa
+    bytes_type = bytes  # noqa
     string_type = str  # noqa
 else:
-    binary_type = str  # noqa
+    bytes_type = str  # noqa
     string_type = unicode  # noqa
 
 
@@ -774,8 +774,8 @@ class TestReplaceTemplate(unittest.TestCase):
             'line line line '
         )
 
-    def test_binary_line_break(self):
-        r"""Test binary line break \R."""
+    def test_bytes_line_break(self):
+        r"""Test bytes line break \R."""
 
         self.assertEqual(
             bregex.sub(br"\R", b' ', b'line\r\nline\nline\r'),
@@ -1172,8 +1172,8 @@ class TestReplaceTemplate(unittest.TestCase):
         self.assertEqual(results2, results)
         self.assertEqual('\e \\e \\\e \\\\e \\\\\e', results)
 
-    def test_binary_normal_escaping(self):
-        """Test binary normal escaped slash."""
+    def test_bytes_normal_escaping(self):
+        """Test bytes normal escaped slash."""
 
         text = b"This is a test of normal escaping!"
         pattern = regex.compile(br"(.+)")
@@ -1279,16 +1279,16 @@ class TestReplaceTemplate(unittest.TestCase):
 
     #     self.assertEqual(result, "Here is a nested [] group search!")
 
-    def test_binary_replace(self):
-        """Test that binary regex result is a binary string."""
+    def test_bytes_replace(self):
+        """Test that bytes regex result is a bytes string."""
 
-        text = b"This is some binary text!"
-        pattern = bregex.compile_search(br"This is (some binary text)!")
+        text = b"This is some bytes text!"
+        pattern = bregex.compile_search(br"This is (some bytes text)!")
         expand = bregex.compile_replace(pattern, br'\C\1\E')
         m = pattern.match(text)
         result = expand(m)
-        self.assertEqual(result, b"SOME BINARY TEXT")
-        self.assertTrue(isinstance(result, binary_type))
+        self.assertEqual(result, b"SOME BYTES TEXT")
+        self.assertTrue(isinstance(result, bytes_type))
 
     def test_template_replace(self):
         """Test replace by passing in replace template."""
@@ -1448,7 +1448,7 @@ class TestReplaceTemplate(unittest.TestCase):
             results
         )
 
-    def test_binary_format_capture_bases(self):
+    def test_bytes_format_capture_bases(self):
         """Test capture bases."""
 
         text = b"abababab"
@@ -1620,7 +1620,7 @@ class TestReplaceTemplate(unittest.TestCase):
         results = expandf(pattern.match('Test'))
         self.assertEqual('\u0108\nWw\u0108', results)
 
-        # Binary doesn't care about Unicode, but should evaluate bytes
+        # Bytes doesn't care about Unicode, but should evaluate bytes
         pattern = regex.compile(b'Test')
         expand = bregex.compile_replace(pattern, br'\C\u0109\n\x77\E\l\x57\c\u0109')
         results = expand(pattern.match(b'Test'))

--- a/tests/test_uniprops.py
+++ b/tests/test_uniprops.py
@@ -11,9 +11,9 @@ PY37 = (3, 7) <= sys.version_info
 PY2 = (2, 0) <= sys.version_info < (3, 0)
 
 if PY3:
-    binary_type = bytes  # noqa
+    bytes_type = bytes  # noqa
 else:
-    binary_type = str  # noqa
+    bytes_type = str  # noqa
 
 
 class TestUniprops(unittest.TestCase):
@@ -550,13 +550,13 @@ class TestUniprops(unittest.TestCase):
     def test_posix_binary(self):
         """Test binary `posix` Category."""
 
-        result = uniprops.get_posix_property('punct', uniprops.POSIX_BINARY)
+        result = uniprops.get_posix_property('punct', uniprops.POSIX_BYTES)
         self.assertEqual(result, uniprops.unidata.ascii_posix_properties['punct'])
 
     def test_inverse_posix_binary(self):
         """Test inverse binary `posix` Category."""
 
-        result = uniprops.get_posix_property('^punct', uniprops.POSIX_BINARY)
+        result = uniprops.get_posix_property('^punct', uniprops.POSIX_BYTES)
         self.assertEqual(result, uniprops.unidata.ascii_posix_properties['^punct'])
 
     def test_posix(self):


### PR DESCRIPTION
Not sure why I started calling byte strings "binary", but it really is the wrong terminology. Make sure all byte string references use "byte" or "bytes" instead of "binary".