### PR TITLE
Handle consecutive single cases

### DIFF
--- a/backrefs/_bre_parse.py
+++ b/backrefs/_bre_parse.py
@@ -1280,12 +1280,6 @@ class _ReplaceParser(object):
                     except StopIteration:
                         self.result.append(t)
                         raise
-                elif self.single_stack:
-                    single = self.get_single_stack()
-                    text = self.convert_case(t, case)
-                    if single:
-                        text = self.convert_case(text[0], single) + text[1:]
-                    self.result.append(text)
                 else:
                     self.result.append(self.convert_case(t, case))
                 if self.end_found or count > len(self.span_stack):
@@ -1313,6 +1307,9 @@ class _ReplaceParser(object):
     def single_case(self, i, case):
         """Uppercase or lowercase the next character."""
 
+        # Pop a previous case if we have consecutive ones.
+        if self.single_stack:
+            self.single_stack.pop()
         self.single_stack.append(case)
         try:
             t = next(i)

--- a/backrefs/_bregex_parse.py
+++ b/backrefs/_bregex_parse.py
@@ -1049,12 +1049,6 @@ class _ReplaceParser(object):
                     except StopIteration:
                         self.result.append(t)
                         raise
-                elif self.single_stack:
-                    single = self.get_single_stack()
-                    text = self.convert_case(t, case)
-                    if single:
-                        text = self.convert_case(text[0], single) + text[1:]
-                    self.result.append(text)
                 else:
                     self.result.append(self.convert_case(t, case))
                 if self.end_found or count > len(self.span_stack):
@@ -1082,6 +1076,9 @@ class _ReplaceParser(object):
     def single_case(self, i, case):
         """Uppercase or lowercase the next character."""
 
+        # Pop a previous case if we have consecutive ones.
+        if self.single_stack:
+            self.single_stack.pop()
         self.single_stack.append(case)
         try:
             t = next(i)

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -1331,7 +1331,7 @@ class TestReplaceTemplate(unittest.TestCase):
         expand = bre.compile_replace(pattern, r'\1\c\l\2\3')
         results = expand(pattern.match(text))
 
-        self.assertEqual('This is a test for Stacking!', results)
+        self.assertEqual('This is a test for stacking!', results)
 
     def test_span_stacked_case(self):
         """Test stacked casing of non-spans in and out of a span."""

--- a/tests/test_bregex.py
+++ b/tests/test_bregex.py
@@ -896,7 +896,7 @@ class TestReplaceTemplate(unittest.TestCase):
         expand = bregex.compile_replace(pattern, r'\1\c\l\2\3')
         results = expand(pattern.match(text))
 
-        self.assertEqual('This is a test for Stacking!', results)
+        self.assertEqual('This is a test for stacking!', results)
 
     def test_span_stacked_case(self):
         """Test stacked casing of non-spans in and out of a span."""


### PR DESCRIPTION
Stacking single case  `\l\c` should only case with the last `\c`.  Like stacked span cases `\L\C`, the next encountered casing should cancel the previous. Related #84.