### PR TITLE
38 dev test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,16 @@ matrix:
     - python: 3.7
       dist: xenial
       env: TOXENV=py37
+    - python: 3.8-dev
+      dist: xenial
+      env: TOXENV=py38
       sudo: true
     - python: 3.6
       env: TOXENV=lint
     - python: 3.6
       env: TOXENV=documents
+  allow_failures:
+    - python: 3.8-dev
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
     - python: 3.7
       dist: xenial
       env: TOXENV=py37
+      sudo: true
     - python: 3.8-dev
       dist: xenial
       env: TOXENV=py38

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    {py27,py33,py34,py35,py36,py37},
+    {py27,py33,py34,py35,py36,py37,py38},
     lint,
     spelling
 


### PR DESCRIPTION
Test Python38-dev to catch breaking changes, but allow failures so it doesn't block currently supported releases.

Ref #57
