### PR TITLE
Support pyspelling 0.2.0a2 and above

### DIFF
--- a/.spelling.yml
+++ b/.spelling.yml
@@ -1,41 +1,9 @@
 documents:
 - name: mkdocs
-  parser: pyspelling.parsers.html_parser
-  options:
-    comments: false
-    attributes:
-    - title
-    - alt
-    ignores:
-    - code
-    - pre
-    - a.magiclink-compare
-    - a.magiclink-commit
-    - span.keys
-    - .MathJax_Preview
-    - .md-nav__link
-    - .md-footer-custom-text
-    - .md-source__repository
-    - .headerlink
-    - .md-icon
   sources:
-  - site
-  aspell:
-    lang: en
-  dictionary:
-    lang: en
-    wordlists:
-    - docs/src/dictionary/en-custom.txt
-    output: build/dictionary/mkdocs.dic
-
-- name: markdown
-  parser: pyspelling.parsers.markdown_parser
-  options:
-    markdown_extensions:
-    - pymdownx.superfences:
-    - pymdownx.highlight:
-  sources:
-  - README.md
+  - site/**/*.html
+  hunspell:
+    d: docs/src/dictionary/hunspell/en_US
   aspell:
     lang: en
   dictionary:
@@ -44,7 +12,42 @@ documents:
     - docs/src/dictionary/en-custom.txt
     output: build/dictionary/mkdocs.dic
   filters:
-  - pyspelling.filters.html_filter:
+  - pyspelling.filters.html:
+      comments: false
+      attributes:
+      - title
+      - alt
+      ignores:
+      - code
+      - pre
+      - a.magiclink-compare
+      - a.magiclink-commit
+      - span.keys
+      - .MathJax_Preview
+      - .md-nav__link
+      - .md-footer-custom-text
+      - .md-source__repository
+      - .headerlink
+      - .md-icon
+
+- name: markdown
+  sources:
+  - README.md
+  hunspell:
+    d: docs/src/dictionary/hunspell/en_US
+  aspell:
+    lang: en
+  dictionary:
+    lang: en
+    wordlists:
+    - docs/src/dictionary/en-custom.txt
+    output: build/dictionary/mkdocs.dic
+  filters:
+  - pyspelling.filters.markdown:
+      markdown_extensions:
+      - pymdownx.superfences:
+      - pymdownx.highlight:
+  - pyspelling.filters.html:
       comments: false
       attributes:
       - title
@@ -54,16 +57,11 @@ documents:
       - pre
 
 - name: python
-  parser: pyspelling.parsers.python_parser
-  options:
-    comments: false
-    strings: false
   sources:
-  - backrefs
-  - tests
-  - tools
-  excludes:
-  - backrefs/uniprops/unidata/*
+  - setup.py
+  - "{backrefs,tests,tools}/**/*.py|!backrefs/uniprops/unidata/*"
+  hunspell:
+    d: docs/src/dictionary/hunspell/en_US
   aspell:
     lang: en
   dictionary:
@@ -73,13 +71,16 @@ documents:
     - docs/src/dictionary/en-python.txt
     output: build/dictionary/python.dic
   filters:
-  - pyspelling.filters.context_filter:
+  - pyspelling.filters.python:
+      strings: false
+      comments: false
+  - pyspelling.filters.context:
       context_visible_first: true
       escapes: \\[\\`~]
       delimiters:
-      - open: (?P<open>`+)
-        content: .*?
-        close: (?P=open)
-      - open: (?s)^(?P<open>\s*~{3,})
-        content: .*?
-        close: ^(?P=open)$
+        - open: (?P<open>`+)
+          content: .*?
+          close: (?P=open)
+        - open: (?s)^(?P<open>\s*~{3,})
+          content: .*?
+          close: ^(?P=open)$

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ def get_requirements():
 
 
 def get_unicodedata():
-    """Download the unicodedata version for the given Python version."""
+    """Download the `unicodedata` version for the given Python version."""
 
     import unicodedata
 
@@ -62,7 +62,7 @@ def get_unicodedata():
 
 
 def generate_unicode_table():
-    """Generate the unicode table for the given Python version."""
+    """Generate the Unicode table for the given Python version."""
 
     fail = False
     path = os.path.join(os.path.dirname(__file__), 'tools')

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps=
     -rrequirements/docs.txt
 commands=
     {envpython} -m mkdocs build --clean --verbose --strict
-    {envpython} pyspelling
+    {envbindir}/pyspelling
 
 [testenv:lint]
 deps=

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps=
     -rrequirements/docs.txt
 commands=
     {envpython} -m mkdocs build --clean --verbose --strict
-    {envpython} -m pyspelling
+    {envpython} pyspelling
 
 [testenv:lint]
 deps=


### PR DESCRIPTION
Recently overhauled pyspelling to fix a number of things I didn't like about it. Changes were quite large, so update config to reflect recent changes. Hoping any further chagnes in pyspelling will be backwards compatible, or at least a deprecation path.

Thinking about switching over to using Hunspell, which is now supported, but Travis CI is on such old Linux distros, we can't currently install Hunspell 1.6.X.  Xenial is on Hunspell 1.3.X.  It requires us to git clone a modified dictionary we have, but works quite well, and I've been able to get it running on Windows, which I haven't been able to do with Aspell (at least not a recent enough version).
 