### PR TITLE
Don't include version in all or provide custom __dir__

### DIFF
--- a/backrefs/__init__.py
+++ b/backrefs/__init__.py
@@ -4,7 +4,9 @@ from .__meta__ import __version__, __version_info__
 import sys
 import warnings
 
-__all__ = ("__version__", "__version_info__")
+# Nothing to import with all
+__all__ = tuple()
+
 __deprecated__ = {
     "version": ("__version__", __version__),
     "version_info": ("__version_info__", __version_info__)
@@ -25,12 +27,6 @@ def __getattr__(name):  # noqa: N807
         )
         return deprecated[1]
     raise AttributeError("module '{}' has no attribute '{}'".format(__name__, name))
-
-
-def __dir__():  # noqa: N807
-    """Module directory."""
-
-    return sorted(list(__all__) + list(__deprecated__.keys()))
 
 
 if not PY37:

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -125,14 +125,3 @@ class TestVersionDeprecations(unittest.TestCase):
             self.assertTrue(len(w) == 1)
             self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
             self.assertEqual(version_info, backrefs.__version_info__)
-
-    def test_deprecation_wrapper_dir(self):
-        """Tests the `__dir__` attribute of the class as it replaces the module's."""
-
-        import backrefs
-
-        dir_attr = dir(backrefs)
-        self.assertTrue('version' in dir_attr)
-        self.assertTrue('__version__' in dir_attr)
-        self.assertTrue('version_info' in dir_attr)
-        self.assertTrue('__version_info__' in dir_attr)


### PR DESCRIPTION
There is no need for us to provide version stuff in __all__. Also, I am fine withnot exposing legacy version in __dir__.