### PR TITLE
Remove support for Python 2

### DIFF
--- a/.pyspelling.yml
+++ b/.pyspelling.yml
@@ -17,10 +17,10 @@ matrix:
       - title
       - alt
       ignores:
-      - ':matches(code, pre)'
-      - 'a:matches(.magiclink-compare, .magiclink-commit, .magiclink-repository)'
+      - ':is(code, pre)'
+      - 'a:is(.magiclink-compare, .magiclink-commit, .magiclink-repository)'
       - 'span.keys'
-      - ':matches(.MathJax_Preview, .md-nav__link, .md-footer-custom-text, .md-source__repository, .headerlink, .md-icon)'
+      - ':is(.MathJax_Preview, .md-nav__link, .md-footer-custom-text, .md-source__repository, .headerlink, .md-icon)'
   - pyspelling.filters.url:
 
 - name: markdown

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ language: python
 
 matrix:
   include:
-    - python: 2.7
-      env: TOXENV=py27
     - python: 3.4
       env: TOXENV=py34
     - python: 3.5

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,6 @@
 build: false
 environment:
   matrix:
-    - PYTHON: "C:/Python27"
-      TOXENV: "py27"
     - PYTHON: "C:/Python34"
       TOXENV: "py34"
     - PYTHON: "C:/Python35"

--- a/backrefs/__meta__.py
+++ b/backrefs/__meta__.py
@@ -186,5 +186,5 @@ def parse_version(ver, pre=False):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(4, 0, 0, ".dev")
+__version_info__ = Version(4, 0, 0, "final")
 __version__ = __version_info__._get_canonical()

--- a/backrefs/__meta__.py
+++ b/backrefs/__meta__.py
@@ -186,5 +186,5 @@ def parse_version(ver, pre=False):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(2, 0, 0, "final")
+__version_info__ = Version(4, 0, 0, ".dev")
 __version__ = __version_info__._get_canonical()

--- a/backrefs/_bre_parse.py
+++ b/backrefs/_bre_parse.py
@@ -6,6 +6,7 @@ Copyright (c) 2011 - 2018 Isaac Muse <isaacmuse@gmail.com>
 """
 from __future__ import unicode_literals
 import re as _re
+import copyreg as _copyreg
 from . import util as _util
 import sre_parse as _sre_parse
 import unicodedata as _unicodedata
@@ -32,10 +33,7 @@ _STANDARD_ESCAPES = frozenset(('a', 'b', 'f', 'n', 'r', 't', 'v'))
 _CURLY_BRACKETS = frozenset(('{', '}'))
 _PROPERTY_STRIP = frozenset((' ', '-', '_'))
 _PROPERTY = _WORD | _DIGIT | _PROPERTY_STRIP
-if _util.PY3:
-    _GLOBAL_FLAGS = frozenset(('a', 'u', 'L'))
-else:
-    _GLOBAL_FLAGS = frozenset(('u', 'L'))
+_GLOBAL_FLAGS = frozenset(('a', 'u', 'L'))
 _SCOPED_FLAGS = frozenset(('i', 'm', 's', 'u', 'x'))
 
 _CURLY_BRACKETS_ORD = frozenset((0x7b, 0x7d))
@@ -56,7 +54,7 @@ _BACK_SLASH_TRANSLATION = {
     "\\\\": '\\'
 }
 
-_FMT_CONV_TYPE = ('a', 'r', 's') if _util.PY3 else ('r', 's')
+_FMT_CONV_TYPE = ('a', 'r', 's')
 
 
 class LoopException(Exception):
@@ -81,7 +79,7 @@ class _SearchParser(object):
     def __init__(self, search, re_verbose=False, re_unicode=None):
         """Initialize."""
 
-        if isinstance(search, _util.bytes_type):
+        if isinstance(search, bytes):
             self.is_bytes = True
         else:
             self.is_bytes = False
@@ -164,7 +162,7 @@ class _SearchParser(object):
         """Analyze flags."""
 
         global_retry = False
-        if _util.PY3 and ('a' in text or 'L' in text) and self.unicode:
+        if ('a' in text or 'L' in text) and self.unicode:
             self.unicode = False
             if not _SCOPED_FLAG_SUPPORT or not scoped:
                 self.temp_global_flag_swap["unicode"] = True
@@ -280,7 +278,7 @@ class _SearchParser(object):
         """Get Unicode character."""
 
         value = int(self.get_wide_unicode(i) if wide else self.get_narrow_unicode(i), 16)
-        return ('\\%03o' % value) if value <= 0xFF else _util.uchr(value)
+        return ('\\%03o' % value) if value <= 0xFF else chr(value)
 
     def reference(self, t, i, in_group=False):
         """Handle references."""
@@ -311,11 +309,6 @@ class _SearchParser(object):
         elif t == "C":
             current.extend(self.letter_case_props(_UPPER, in_group, negate=True))
             self.found_property = True
-
-        elif _util.PY2 and not self.is_bytes and t == "U":
-            current.append(self.get_unicode(i, True))
-        elif _util.PY2 and not self.is_bytes and t == "u":
-            current.append(self.get_unicode(i))
         elif t == 'p':
             prop = self.get_unicode_property(i)
             current.extend(self.unicode_props(prop[0], prop[1], in_group=in_group))
@@ -606,7 +599,7 @@ class _SearchParser(object):
     def unicode_name(self, name, in_group=False):
         """Insert Unicode value by its name."""
 
-        value = _util.uord(_unicodedata.lookup(name))
+        value = ord(_unicodedata.lookup(name))
         if (self.is_bytes and value > 0xFF):
             value = ""
         if not in_group and value == "":
@@ -614,7 +607,7 @@ class _SearchParser(object):
         elif value == "":
             return value
         else:
-            return ['\\%03o' % value if value <= 0xFF else _util.uchr(value)]
+            return ['\\%03o' % value if value <= 0xFF else chr(value)]
 
     def unicode_props(self, props, value, in_group=False, negate=False):
         """
@@ -696,11 +689,8 @@ class _SearchParser(object):
             "unicode": False,
             "verbose": False
         }
-        if _util.PY3:
-            self.ascii = self.re_unicode is not None and not self.re_unicode
-        else:
-            self.ascii = False
-        if _util.PY3 and not self.unicode and not self.ascii:
+        self.ascii = self.re_unicode is not None and not self.re_unicode
+        if not self.unicode and not self.ascii:
             self.unicode = True
 
         new_pattern = []
@@ -803,7 +793,7 @@ class _ReplaceParser(object):
                 # Try and covert to integer index
                 field = ''.join(value).strip()
                 try:
-                    value = [(_util.FMT_FIELD, _util.string_type(int(field, 10)))]
+                    value = [(_util.FMT_FIELD, str(int(field, 10)))]
                 except ValueError:
                     value = [(_util.FMT_FIELD, field)]
                     pass
@@ -967,16 +957,16 @@ class _ReplaceParser(object):
         else:
             single = self.get_single_stack()
             if self.span_stack:
-                text = self.convert_case(_util.uchr(value), self.span_stack[-1])
-                value = _util.uord(self.convert_case(text, single)) if single is not None else _util.uord(text)
+                text = self.convert_case(chr(value), self.span_stack[-1])
+                value = ord(self.convert_case(text, single)) if single is not None else ord(text)
             elif single:
-                value = _util.uord(self.convert_case(_util.uchr(value), single))
+                value = ord(self.convert_case(chr(value), single))
             if self.use_format and value in _CURLY_BRACKETS_ORD:
-                self.handle_format(_util.uchr(value), i)
+                self.handle_format(chr(value), i)
             elif value <= 0xFF:
                 self.result.append('\\%03o' % value)
             else:
-                self.result.append(_util.uchr(value))
+                self.result.append(chr(value))
 
     def get_named_unicode(self, i):
         """Get named Unicode."""
@@ -998,19 +988,19 @@ class _ReplaceParser(object):
     def parse_named_unicode(self, i):
         """Parse named Unicode."""
 
-        value = _util.uord(_unicodedata.lookup(self.get_named_unicode(i)))
+        value = ord(_unicodedata.lookup(self.get_named_unicode(i)))
         single = self.get_single_stack()
         if self.span_stack:
-            text = self.convert_case(_util.uchr(value), self.span_stack[-1])
-            value = _util.uord(self.convert_case(text, single)) if single is not None else _util.uord(text)
+            text = self.convert_case(chr(value), self.span_stack[-1])
+            value = ord(self.convert_case(text, single)) if single is not None else ord(text)
         elif single:
-            value = _util.uord(self.convert_case(_util.uchr(value), single))
+            value = ord(self.convert_case(chr(value), single))
         if self.use_format and value in _CURLY_BRACKETS_ORD:
-            self.handle_format(_util.uchr(value), i)
+            self.handle_format(chr(value), i)
         elif value <= 0xFF:
             self.result.append('\\%03o' % value)
         else:
-            self.result.append(_util.uchr(value))
+            self.result.append(chr(value))
 
     def get_wide_unicode(self, i):
         """Get narrow Unicode."""
@@ -1056,16 +1046,16 @@ class _ReplaceParser(object):
         value = int(text, 16)
         single = self.get_single_stack()
         if self.span_stack:
-            text = self.convert_case(_util.uchr(value), self.span_stack[-1])
-            value = _util.uord(self.convert_case(text, single)) if single is not None else _util.uord(text)
+            text = self.convert_case(chr(value), self.span_stack[-1])
+            value = ord(self.convert_case(text, single)) if single is not None else ord(text)
         elif single:
-            value = _util.uord(self.convert_case(_util.uchr(value), single))
+            value = ord(self.convert_case(chr(value), single))
         if self.use_format and value in _CURLY_BRACKETS_ORD:
-            self.handle_format(_util.uchr(value), i)
+            self.handle_format(chr(value), i)
         elif value <= 0xFF:
             self.result.append('\\%03o' % value)
         else:
-            self.result.append(_util.uchr(value))
+            self.result.append(chr(value))
 
     def get_byte(self, i):
         """Get byte."""
@@ -1086,11 +1076,11 @@ class _ReplaceParser(object):
         single = self.get_single_stack()
         if self.span_stack:
             text = self.convert_case(chr(value), self.span_stack[-1])
-            value = _util.uord(self.convert_case(text, single)) if single is not None else _util.uord(text)
+            value = ord(self.convert_case(text, single)) if single is not None else ord(text)
         elif single:
-            value = _util.uord(self.convert_case(chr(value), single))
+            value = ord(self.convert_case(chr(value), single))
         if self.use_format and value in _CURLY_BRACKETS_ORD:
-            self.handle_format(_util.uchr(value), i)
+            self.handle_format(chr(value), i)
         else:
             self.result.append('\\%03o' % value)
 
@@ -1159,17 +1149,17 @@ class _ReplaceParser(object):
             if value > 0xFF and self.is_bytes:
                 # Re fails on octal greater than `0o377` or `0xFF`
                 raise ValueError("octal escape value outside of range 0-0o377!")
-            value = _util.uchr(value)
+            value = chr(value)
         elif t in _STANDARD_ESCAPES or t == '\\':
             value = _BACK_SLASH_TRANSLATION['\\' + t]
         elif not self.is_bytes and t == "U":
-            value = _util.uchr(int(self.get_wide_unicode(i), 16))
+            value = chr(int(self.get_wide_unicode(i), 16))
         elif not self.is_bytes and t == "u":
-            value = _util.uchr(int(self.get_narrow_unicode(i), 16))
+            value = chr(int(self.get_narrow_unicode(i), 16))
         elif not self.is_bytes and t == "N":
             value = _unicodedata.lookup(self.get_named_unicode(i))
         elif t == "x":
-            value = _util.uchr(int(self.get_byte(i), 16))
+            value = chr(int(self.get_byte(i), 16))
         else:
             i.rewind(1)
             value = '\\'
@@ -1340,12 +1330,12 @@ class _ReplaceParser(object):
         # Handle auto incrementing group indexes
         if field == '':
             if self.auto:
-                field = _util.string_type(self.auto_index)
+                field = str(self.auto_index)
                 text[0] = (_util.FMT_FIELD, field)
                 self.auto_index += 1
             elif not self.manual and not self.auto:
                 self.auto = True
-                field = _util.string_type(self.auto_index)
+                field = str(self.auto_index)
                 text[0] = (_util.FMT_FIELD, field)
                 self.auto_index += 1
             else:
@@ -1397,11 +1387,11 @@ class _ReplaceParser(object):
     def parse(self, pattern, template, use_format=False):
         """Parse template."""
 
-        if isinstance(template, _util.bytes_type):
+        if isinstance(template, bytes):
             self.is_bytes = True
         else:
             self.is_bytes = False
-        if isinstance(pattern.pattern, _util.bytes_type) != self.is_bytes:
+        if isinstance(pattern.pattern, bytes) != self.is_bytes:
             raise TypeError('Pattern string type must match replace template string type!')
         self._original = template
         self.use_format = use_format
@@ -1513,7 +1503,7 @@ class ReplaceTemplate(_util.Immutable):
             raise ValueError("Match is None!")
 
         sep = m.string[:0]
-        if isinstance(sep, _util.bytes_type) != self._bytes:
+        if isinstance(sep, bytes) != self._bytes:
             raise TypeError('Match string type does not match expander string type!')
         text = []
         # Expand string
@@ -1557,4 +1547,4 @@ def _pickle(r):
     return ReplaceTemplate, (r.groups, r.group_slots, r.literals, r.pattern_hash, r.use_format, r._bytes)
 
 
-_util.copyreg.pickle(ReplaceTemplate, _pickle)
+_copyreg.pickle(ReplaceTemplate, _pickle)

--- a/backrefs/_bre_parse.py
+++ b/backrefs/_bre_parse.py
@@ -237,49 +237,6 @@ class _SearchParser(object):
 
         return ''.join(value)
 
-    def get_wide_unicode(self, i):
-        """Get narrow Unicode."""
-
-        value = []
-        for x in range(3):
-            c = next(i)
-            if c == '0':
-                value.append(c)
-            else:  # pragma: no cover
-                raise SyntaxError('Invalid wide Unicode character at %d!' % (i.index - 1))
-
-        c = next(i)
-        if c in ('0', '1'):
-            value.append(c)
-        else:  # pragma: no cover
-            raise SyntaxError('Invalid wide Unicode character at %d!' % (i.index - 1))
-
-        for x in range(4):
-            c = next(i)
-            if c.lower() in _HEX:
-                value.append(c)
-            else:  # pragma: no cover
-                raise SyntaxError('Invalid wide Unicode character at %d!' % (i.index - 1))
-        return ''.join(value)
-
-    def get_narrow_unicode(self, i):
-        """Get narrow Unicode."""
-
-        value = []
-        for x in range(4):
-            c = next(i)
-            if c.lower() in _HEX:
-                value.append(c)
-            else:  # pragma: no cover
-                raise SyntaxError('Invalid Unicode character at %d!' % (i.index - 1))
-        return ''.join(value)
-
-    def get_unicode(self, i, wide=False):
-        """Get Unicode character."""
-
-        value = int(self.get_wide_unicode(i) if wide else self.get_narrow_unicode(i), 16)
-        return ('\\%03o' % value) if value <= 0xFF else chr(value)
-
     def reference(self, t, i, in_group=False):
         """Handle references."""
 

--- a/backrefs/bre.py
+++ b/backrefs/bre.py
@@ -28,6 +28,8 @@ Copyright (c) 2011 - 2018 Isaac Muse <isaacmuse@gmail.com>
 from __future__ import unicode_literals
 import sys as _sys
 import re as _re
+import copyreg as _copyreg
+from functools import lru_cache as _lru_cache
 from . import util as _util
 from . import _bre_parse
 from ._bre_parse import ReplaceTemplate
@@ -35,9 +37,9 @@ from ._bre_parse import ReplaceTemplate
 __all__ = (
     "expand", "expandf", "search", "match", "fullmatch", "split", "findall", "finditer", "sub", "subf",
     "subn", "subfn", "purge", "escape", "DEBUG", "I", "IGNORECASE", "L", "LOCALE", "M", "MULTILINE",
-    "S", "DOTALL", "U", "UNICODE", "X", "VERBOSE", "compile", "compile_search", "compile_replace", "Bregex",
-    "ReplaceTemplate"
-) + (("A", "ASCII") if _util.PY3 else tuple()) + (("fullmatch",) if _util.PY34 else tuple())
+    "S", "DOTALL", "U", "UNICODE", "X", "VERBOSE", "compile", "compile_search", "compile_replace", "Bre",
+    "ReplaceTemplate", "A", "ASCII"
+) + (("fullmatch",) if _util.PY34 else tuple())
 
 # Expose some common re flags and methods to
 # save having to import re and backrefs libraries
@@ -54,9 +56,8 @@ U = _re.U
 UNICODE = _re.UNICODE
 X = _re.X
 VERBOSE = _re.VERBOSE
-if _util.PY3:
-    A = _re.A
-    ASCII = _re.ASCII
+A = _re.A
+ASCII = _re.ASCII
 escape = _re.escape
 
 # Replace flags
@@ -68,14 +69,14 @@ _MAXCACHE = 500
 _RE_TYPE = type(_re.compile('', 0))
 
 
-@_util.lru_cache(maxsize=_MAXCACHE)
+@_lru_cache(maxsize=_MAXCACHE)
 def _cached_search_compile(pattern, re_verbose, re_version, pattern_type):
     """Cached search compile."""
 
     return _bre_parse._SearchParser(pattern, re_verbose, re_version).parse()
 
 
-@_util.lru_cache(maxsize=_MAXCACHE)
+@_lru_cache(maxsize=_MAXCACHE)
 def _cached_replace_compile(pattern, repl, flags, pattern_type):
     """Cached replace compile."""
 
@@ -113,17 +114,17 @@ def _apply_replace_backrefs(m, repl=None, flags=0):
     else:
         if isinstance(repl, ReplaceTemplate):
             return repl.expand(m)
-        elif isinstance(repl, (_util.string_type, _util.bytes_type)):
+        elif isinstance(repl, (str, bytes)):
             return _bre_parse._ReplaceParser().parse(m.re, repl, bool(flags & FORMAT)).expand(m)
 
 
 def _apply_search_backrefs(pattern, flags=0):
     """Apply the search backrefs to the search pattern."""
 
-    if isinstance(pattern, (_util.string_type, _util.bytes_type)):
+    if isinstance(pattern, (str, bytes)):
         re_verbose = bool(VERBOSE & flags)
         re_unicode = None
-        if _util.PY3 and bool((ASCII | LOCALE) & flags):
+        if bool((ASCII | LOCALE) & flags):
             re_unicode = False
         elif bool(UNICODE & flags):
             re_unicode = True
@@ -152,7 +153,7 @@ def _assert_expandable(repl, use_format=False):
                 raise ValueError("Replace not compiled as a format replace")
             else:
                 raise ValueError("Replace should not be compiled as a format replace!")
-    elif not isinstance(repl, (_util.string_type, _util.bytes_type)):
+    elif not isinstance(repl, (str, bytes)):
         raise TypeError("Expected string, buffer, or compiled replace!")
 
 
@@ -237,7 +238,7 @@ class Bre(_util.Immutable):
         """Compile replacements."""
 
         is_replace = _is_replace(template)
-        is_string = isinstance(template, (_util.string_type, _util.bytes_type))
+        is_string = isinstance(template, (str, bytes))
         if is_replace and use_format != template.use_format:
             raise ValueError("Compiled replace cannot be a format object!")
         if is_replace or (is_string and self.auto_compile):
@@ -334,7 +335,7 @@ def compile_replace(pattern, repl, flags=0):
 
     call = None
     if pattern is not None and isinstance(pattern, _RE_TYPE):
-        if isinstance(repl, (_util.string_type, _util.bytes_type)):
+        if isinstance(repl, (str, bytes)):
             if not (pattern.flags & DEBUG):
                 call = _cached_replace_compile(pattern, repl, flags, type(repl))
             else:  # pragma: no cover
@@ -414,7 +415,7 @@ def sub(pattern, repl, string, count=0, flags=0):
     """Apply `sub` after applying backrefs."""
 
     is_replace = _is_replace(repl)
-    is_string = isinstance(repl, (_util.string_type, _util.bytes_type))
+    is_string = isinstance(repl, (str, bytes))
     if is_replace and repl.use_format:
         raise ValueError("Compiled replace cannot be a format object!")
 
@@ -428,7 +429,7 @@ def subf(pattern, format, string, count=0, flags=0):  # noqa A002
     """Apply `sub` with format style replace."""
 
     is_replace = _is_replace(format)
-    is_string = isinstance(format, (_util.string_type, _util.bytes_type))
+    is_string = isinstance(format, (str, bytes))
     if is_replace and not format.use_format:
         raise ValueError("Compiled replace is not a format object!")
 
@@ -444,7 +445,7 @@ def subn(pattern, repl, string, count=0, flags=0):
     """Apply `subn` with format style replace."""
 
     is_replace = _is_replace(repl)
-    is_string = isinstance(repl, (_util.string_type, _util.bytes_type))
+    is_string = isinstance(repl, (str, bytes))
     if is_replace and repl.use_format:
         raise ValueError("Compiled replace cannot be a format object!")
 
@@ -458,7 +459,7 @@ def subfn(pattern, format, string, count=0, flags=0):  # noqa A002
     """Apply `subn` after applying backrefs."""
 
     is_replace = _is_replace(format)
-    is_string = isinstance(format, (_util.string_type, _util.bytes_type))
+    is_string = isinstance(format, (str, bytes))
     if is_replace and not format.use_format:
         raise ValueError("Compiled replace is not a format object!")
 
@@ -474,4 +475,4 @@ def _pickle(p):
     return Bre, (p._pattern, p.auto_compile)
 
 
-_util.copyreg.pickle(Bre, _pickle)
+_copyreg.pickle(Bre, _pickle)

--- a/backrefs/uniprops/__init__.py
+++ b/backrefs/uniprops/__init__.py
@@ -3,19 +3,10 @@ from __future__ import unicode_literals
 from . import unidata
 import sys
 
-NARROW = sys.maxunicode == 0xFFFF
-if NARROW:
-    UNICODE_RANGE = '\u0000-\uffff'
-else:
-    UNICODE_RANGE = '\u0000-\U0010ffff'
+UNICODE_RANGE = '\u0000-\U0010ffff'
 
-PY3 = sys.version_info >= (3, 0) and sys.version_info[0:2] < (4, 0)
 PY35 = sys.version_info >= (3, 5)
 PY37 = sys.version_info >= (3, 7)
-if PY3:
-    bytes_type = bytes  # noqa
-else:
-    bytes_type = str  # noqa
 
 POSIX = 0
 POSIX_BYTES = 1
@@ -446,10 +437,7 @@ def get_is_property(value, is_bytes=False):
     if prefix != 'is':
         raise ValueError("Does not start with 'is'!")
 
-    if PY3:
-        script_obj = unidata.ascii_script_extensions if is_bytes else unidata.unicode_script_extensions
-    else:
-        script_obj = unidata.ascii_scripts if is_bytes else unidata.unicode_scripts
+    script_obj = unidata.ascii_script_extensions if is_bytes else unidata.unicode_script_extensions
     bin_obj = unidata.ascii_binary if is_bytes else unidata.unicode_binary
 
     value = negate + unidata.unicode_alias['script'].get(temp, temp)
@@ -500,7 +488,7 @@ def get_unicode_property(value, prop=None, is_bytes=False):
                 return get_gc_property(value, is_bytes)
             elif prop == 'script':
                 return get_script_property(value, is_bytes)
-            elif PY3 and prop == 'scriptextensions':
+            elif prop == 'scriptextensions':
                 return get_script_extension_property(value, is_bytes)
             elif prop == 'block':
                 return get_block_property(value, is_bytes)
@@ -516,9 +504,9 @@ def get_unicode_property(value, prop=None, is_bytes=False):
                 return get_east_asian_width_property(value, is_bytes)
             elif PY35 and prop == 'indicpositionalcategory':
                 return get_indic_positional_category_property(value, is_bytes)
-            elif PY3 and not PY35 and prop == 'indicmatracategory':
+            elif not PY35 and prop == 'indicmatracategory':
                 return get_indic_positional_category_property(value, is_bytes)
-            elif PY3 and prop == 'indicsyllabiccategory':
+            elif prop == 'indicsyllabiccategory':
                 return get_indic_syllabic_category_property(value, is_bytes)
             elif prop == 'hangulsyllabletype':
                 return get_hangul_syllable_type_property(value, is_bytes)
@@ -563,10 +551,7 @@ def get_unicode_property(value, prop=None, is_bytes=False):
         pass
 
     try:
-        if PY3:
-            return get_script_extension_property(value, is_bytes)
-        else:
-            return get_script_property(value, is_bytes)
+        return get_script_extension_property(value, is_bytes)
     except Exception:
         pass
 

--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -1,19 +1,23 @@
 # Changelog
 
+## 4.0.0
+
+- **NEW**: Drop support for new features in Python 2. Python 2 support is limited to the 3.X.X series and will only receive bug fixes up to 2020. All new features moving forward will be on the 4.X.X series and will be for Python 3+ only.
+
+## 3.6.0
+
+- **NEW**: Make version available via the new, and more standard, `__version__` attribute and add the `__version_info__` attribute as well. Deprecate the old `version` and `version_info` attribute for future removal.
+
 ## 3.5.2
 
 - **FIX**: Include zip for Unicode 11 (Python 3.7) to make installation more reliable.
 
 ## 3.5.1
 
-Jun 3, 2018
-
 - **FIX**: POSIX character classes should not be part of a range.
 - **FIX**: Replace string casing logic properly follows other implementations like Boost etc. `\L`, `\C`, and `\E` should all terminate `\L`, and `\C`. `\l` and `\c` will be ignored if followed by `\C` or `\L`.
 
 ## 3.5.0
-
-Mar 13, 2018
 
 - **NEW**: Use a more advanced format string implementation that implements all string features, included those found in `format_spec`.
 - **FIX**: Relax validation so not to exclude valid named Unicode values.
@@ -22,27 +26,19 @@ Mar 13, 2018
 
 ## 3.4.0
 
-Mar 8, 2018
-
 - **NEW**: Add support for generic line breaks (`\R`) to Re.
 - **NEW**: Add support for an overly simplified form of grapheme clusters (`\X`) to Re. Roughly equivalent to `(?>\PM\pM*)`.
 - **NEW**: Add support for `Vertical_Orientation` property for Unicode 10.0.0 on Python 3.7.
 
 ## 3.3.0
 
-Feb 27, 2018
-
 - **NEW**: Add support for `Indic_Positional_Category`\\`Indic_Matra_Category` and `Indic_Syllabic_Category` properties.
 
 ## 3.2.1
 
-Feb 26, 2018
-
 - **FIX**: `Bidi_Paired_Bracket_type` property's `None` value should be equivalent to all characters that are not `open` or `close` characters.
 
 ## 3.2.0
-
-Feb 25, 2018
 
 - **NEW**: Add support for `Script_Extensions` Unicode properties (Python 3 only as Python 2, Unicode 5.2.0 does not define these). Can be accessed via `\p{scripts_extensions: kana}` or `\p{scx: kana}`.
 - **NEW**: When defining scripts with just their name `\p{Kana}`, use `Script_Extensions` instead of `Scripts`. To get `Scripts` results, you must specify `\p{scripts: kana}` or `\p{sc: scripts}`.
@@ -51,8 +47,6 @@ Feb 25, 2018
 - **FIX**: Tweaks/improvements to string iteration.
 
 ## 3.1.2
-
-Feb 12, 2018
 
 - **FIX**: Properly escape any problematic characters in Unicode tables.
 
@@ -64,41 +58,29 @@ Feb 11, 2018
 
 ## 3.1.0
 
-Feb 11, 2018
-
 - **NEW**: Start and end word boundary back references are now specified with `\m` and `\M` like Regex does.  `\<` and `\>` have been removed from Regex.
 - **FIX**: Escaped `\<` and `\>` are no longer processed as Re is known to escape these in versions less than Python 3.7.
 
 ## 3.0.5
-
-Feb 9, 2018
 
 - **FIX**: Process non raw string equivalent escaped Unicode on Python 2.7.
 - **FIX**: Compiled objects should return the pattern string, not the pattern object via the property `pattern`.
 
 ## 3.0.4
 
-Feb 8, 2018
-
 - **FIX**: Formally enable Python 3.7 support.
 - **FIX**: Tweak to Unicode wide character handling.
 
 ## 3.0.3
-
-Jan 28, 2018
 
 - **FIX**: Compiled search and replace objects should be hashable.
 - **FIX**: Handle cases where a new compiled pattern object is passed back through compile functions.
 
 ## 3.0.2
 
-Jan 22, 2018
-
 - **FIX**: Bregex purge was calling Re's purge instead of Regex's purge.
 
 ## 3.0.1
-
-Jan 21, 2018
 
 - **FIX**: Do not accidentally `\.` as a group in replace strings (don't use `isdigit` string method).
 - **FIX**: Group names can start with `_` in replace strings.
@@ -107,8 +89,6 @@ Jan 21, 2018
 - **FIX**: Raise some exceptions in a few places we weren't.
 
 ## 3.0.0
-
-Jan 20, 2018
 
 - **NEW**: Added new `compile` function that returns a pattern object that feels like Re's and Regex's pattern object.
 - **NEW**: Add some caching of search and replace patterns.
@@ -128,14 +108,10 @@ Jan 20, 2018
 
 ## 2.2.0
 
-Dec 11, 2017
-
 - **NEW**: Proper support for `\N{Unicode Name}`.
 - **FIX**: Incomplete escapes will not be passed through, but will instead throw an error. For instance `\p` should only be passed through if it is complete `\p{category}`.  Python 3.7 will error on this if we pass it through, and Python 3.6 will generate warnings.  We should just consistently fail on it for all Python versions.
 
 ## 2.1.0
-
-Sep 29, 2017
 
 - **NEW**: Handle Unicode and byte notation in Re replace templates.
 - **NEW**: Rework algorithm to handle replace casing back references in Python 3.7 development builds in preparation for Python 3.7 release.
@@ -154,18 +130,12 @@ Sep 29, 2017
 
 ## 1.0.2
 
-Aug 06, 2017
-
 - **FIX**: Issues related to downloading Unicode data and Unicode table generation. Include Unicode data in release.
 
 ## 1.0.1
 
-Jan 16, 2017
-
 - **FIX**: Fixes for Python 3.6.
 
 ## 1.0.0
-
-May 3, 2016
 
 - **NEW**: Initial release.

--- a/docs/src/markdown/index.md
+++ b/docs/src/markdown/index.md
@@ -178,8 +178,6 @@ Backrefs implements format string replacements in a way that is similar to Regex
     format_spec       ::=  <described in the next section>
     ```
 
-    Conversion `a` is not supported in Python 2.
-
     ```
     format_spec ::=  [[fill]align][0][width][type]
     fill        ::=  <any character>
@@ -395,9 +393,6 @@ General Category, Script, Blocks, and Binary all can be specified by their value
 4. Binary
 
 Script and Binary properties can also be defined in the format `IsValue`.  For instance, if we wanted to match characters in the `Latin` script, we could use the syntax `\p{IsLatin}`, which would be the same as `\p{Latin}` or `\p{scx: Latin}`.  For Binary properties, `\p{IsAlphabetic}` is the same as `\p{Alphabetic: Y}` or `\p{Alphabetic}`.
-
-!!! note
-    If you use the form `\p{Latin}` or `\p{IsLatin}` for Script, you will get `Scripts` on Python 2 and `Scripts_Extensions` on Python 3. This is because Python 2 uses Unicode version 5.2.0 which does not define `Scripts_Extensions`.
 
 Block properties have a similar short form as Script and Binary properties.  For Blocks you can use `InValue` to specify a block. If we wanted to match characters in the `Basic_Latin` block, we could use the syntax `\p{InBasic_Latin}`. This would be the same as `\p{Block: Basic_Latin}` or `\p{Basic_Latin}`.
 

--- a/requirements/project.txt
+++ b/requirements/project.txt
@@ -1,2 +1,1 @@
-backports.functools_lru_cache ; python_version < '3'
 pep562

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ generate_unicode_table()
 setup(
     name='backrefs',
     version=VER,
+    python_requires=">=3.4",
     keywords='regex re',
     description='A wrapper around re and regex that adds additional back references.',
     long_description=get_description(),
@@ -111,8 +112,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',

--- a/tests/test_uniprops.py
+++ b/tests/test_uniprops.py
@@ -4,16 +4,9 @@ import unittest
 import sys
 from backrefs import uniprops
 
-PY3 = (3, 0) <= sys.version_info < (4, 0)
 PY34 = (3, 4) <= sys.version_info
 PY35 = (3, 5) <= sys.version_info
 PY37 = (3, 7) <= sys.version_info
-PY2 = (2, 0) <= sys.version_info < (3, 0)
-
-if PY3:
-    bytes_type = bytes  # noqa
-else:
-    bytes_type = str  # noqa
 
 
 class TestUniprops(unittest.TestCase):
@@ -58,26 +51,14 @@ class TestUniprops(unittest.TestCase):
     def test_script_extensions(self):
         """Test `script extensions` Category."""
 
-        if PY2:
-            with self.assertRaises(ValueError) as e:
-                uniprops.get_unicode_property('kana', 'scx')
-
-            self.assertTrue(str(e), 'Invalid Unicode property!')
-        else:
-            result = uniprops.get_unicode_property('kana', 'scx')
-            self.assertEqual(result, uniprops.unidata.unicode_script_extensions['katakana'])
+        result = uniprops.get_unicode_property('kana', 'scx')
+        self.assertEqual(result, uniprops.unidata.unicode_script_extensions['katakana'])
 
     def test_inverse_script_extensions(self):
         """Test inverse `script extensions` Category."""
 
-        if PY2:
-            with self.assertRaises(ValueError) as e:
-                uniprops.get_unicode_property('^kana', 'scx')
-
-            self.assertTrue(str(e), 'Invalid Unicode property!')
-        else:
-            result = uniprops.get_unicode_property('^kana', 'scx')
-            self.assertEqual(result, uniprops.unidata.unicode_script_extensions['^katakana'])
+        result = uniprops.get_unicode_property('^kana', 'scx')
+        self.assertEqual(result, uniprops.unidata.unicode_script_extensions['^katakana'])
 
     def test_bidi(self):
         """Test `bidi class` Category."""
@@ -154,58 +135,34 @@ class TestUniprops(unittest.TestCase):
     def test_indicpositionalcategory(self):
         """Test `indic positional/matra category` Category."""
 
-        if PY3:
-            if PY35:
-                result = uniprops.get_unicode_property('top', 'inpc')
-                self.assertEqual(result, uniprops.unidata.unicode_indic_positional_category['top'])
-            else:
-                result = uniprops.get_unicode_property('top', 'inmc')
-                self.assertEqual(result, uniprops.unidata.unicode_indic_matra_category['top'])
+        if PY35:
+            result = uniprops.get_unicode_property('top', 'inpc')
+            self.assertEqual(result, uniprops.unidata.unicode_indic_positional_category['top'])
         else:
-            with self.assertRaises(ValueError) as e:
-                uniprops.get_unicode_property('top', 'inpc')
-
-            self.assertTrue(str(e), 'Invalid Unicode property!')
+            result = uniprops.get_unicode_property('top', 'inmc')
+            self.assertEqual(result, uniprops.unidata.unicode_indic_matra_category['top'])
 
     def test_inverse_indicpositionalcategory(self):
         """Test inverse `indic positional/matra category` Category."""
 
-        if PY3:
-            if PY35:
-                result = uniprops.get_unicode_property('^top', 'inpc')
-                self.assertEqual(result, uniprops.unidata.unicode_indic_positional_category['^top'])
-            else:
-                result = uniprops.get_unicode_property('^top', 'inmc')
-                self.assertEqual(result, uniprops.unidata.unicode_indic_matra_category['^top'])
+        if PY35:
+            result = uniprops.get_unicode_property('^top', 'inpc')
+            self.assertEqual(result, uniprops.unidata.unicode_indic_positional_category['^top'])
         else:
-            with self.assertRaises(ValueError) as e:
-                uniprops.get_unicode_property('^top', 'inpc')
-
-            self.assertTrue(str(e), 'Invalid Unicode property!')
+            result = uniprops.get_unicode_property('^top', 'inmc')
+            self.assertEqual(result, uniprops.unidata.unicode_indic_matra_category['^top'])
 
     def test_indicsylabiccategory(self):
         """Test `indic syllabic category` Category."""
 
-        if PY3:
-            result = uniprops.get_unicode_property('bindu', 'insc')
-            self.assertEqual(result, uniprops.unidata.unicode_indic_syllabic_category['bindu'])
-        else:
-            with self.assertRaises(ValueError) as e:
-                uniprops.get_unicode_property('bindu', 'insc')
-
-            self.assertTrue(str(e), 'Invalid Unicode property!')
+        result = uniprops.get_unicode_property('bindu', 'insc')
+        self.assertEqual(result, uniprops.unidata.unicode_indic_syllabic_category['bindu'])
 
     def test_inverse_indicsyllabiccategory(self):
         """Test inverse `indic syllabic category` Category."""
 
-        if PY3:
-            result = uniprops.get_unicode_property('^bindu', 'insc')
-            self.assertEqual(result, uniprops.unidata.unicode_indic_syllabic_category['^bindu'])
-        else:
-            with self.assertRaises(ValueError) as e:
-                uniprops.get_unicode_property('^bindu', 'insc')
-
-            self.assertTrue(str(e), 'Invalid Unicode property!')
+        result = uniprops.get_unicode_property('^bindu', 'insc')
+        self.assertEqual(result, uniprops.unidata.unicode_indic_syllabic_category['^bindu'])
 
     def test_hangulsyllabletype(self):
         """Test `hangul syllable type` Category."""
@@ -415,19 +372,13 @@ class TestUniprops(unittest.TestCase):
         """Test `isscript` Category."""
 
         result = uniprops.get_unicode_property('islatin')
-        if PY3:
-            self.assertEqual(result, uniprops.unidata.unicode_script_extensions['latin'])
-        else:
-            self.assertEqual(result, uniprops.unidata.unicode_scripts['latin'])
+        self.assertEqual(result, uniprops.unidata.unicode_script_extensions['latin'])
 
     def test_inverse_is_script(self):
         """Test inverse `isscript` Category."""
 
         result = uniprops.get_unicode_property('^islatin')
-        if PY3:
-            self.assertEqual(result, uniprops.unidata.unicode_script_extensions['^latin'])
-        else:
-            self.assertEqual(result, uniprops.unidata.unicode_scripts['^latin'])
+        self.assertEqual(result, uniprops.unidata.unicode_script_extensions['^latin'])
 
     def test_is_binary(self):
         """Test `isbinary` Category."""
@@ -445,19 +396,13 @@ class TestUniprops(unittest.TestCase):
         """Test script simple Category."""
 
         result = uniprops.get_unicode_property('latin')
-        if PY3:
-            self.assertEqual(result, uniprops.unidata.unicode_script_extensions['latin'])
-        else:
-            self.assertEqual(result, uniprops.unidata.unicode_scripts['latin'])
+        self.assertEqual(result, uniprops.unidata.unicode_script_extensions['latin'])
 
     def test_inverse_script_simple(self):
         """Test inverse script simple Category."""
 
         result = uniprops.get_unicode_property('^latin')
-        if PY3:
-            self.assertEqual(result, uniprops.unidata.unicode_script_extensions['^latin'])
-        else:
-            self.assertEqual(result, uniprops.unidata.unicode_scripts['^latin'])
+        self.assertEqual(result, uniprops.unidata.unicode_script_extensions['^latin'])
 
     def test_in_block(self):
         """Test `inblock` Category."""

--- a/tools/unidatadownload.py
+++ b/tools/unidatadownload.py
@@ -3,18 +3,13 @@ from __future__ import unicode_literals
 import sys
 import os
 import zipfile
+from urllib.request import urlopen
 
 __version__ = '2.2.0'
 
-PY3 = sys.version_info >= (3, 0) and sys.version_info[0:2] < (4, 0)
 PY34 = sys.version_info >= (3, 4)
 PY35 = sys.version_info >= (3, 5)
 PY37 = sys.version_info >= (3, 7)
-
-if PY3:
-    from urllib.request import urlopen
-else:
-    from urllib2 import urlopen
 
 HOME = os.path.dirname(os.path.abspath(__file__))
 
@@ -75,13 +70,12 @@ def download_unicodedata(version, output=HOME, no_zip=False):
         'extracted/DerivedCombiningClass.txt'
     ]
 
-    if PY3:
-        files.append('ScriptExtensions.txt')
-        if PY35:
-            files.append('IndicPositionalCategory.txt')
-        else:
-            files.append('IndicMatraCategory.txt')
-        files.append('IndicSyllabicCategory.txt')
+    files.append('ScriptExtensions.txt')
+    if PY35:
+        files.append('IndicPositionalCategory.txt')
+    else:
+        files.append('IndicMatraCategory.txt')
+    files.append('IndicSyllabicCategory.txt')
 
     if PY34:
         files.append('BidiBrackets.txt')


### PR DESCRIPTION
Technically Python 2 isn't EOL till 2020, but it is unlikely that there will be any new features for Python 2, maybe bug fixes, but that is most likely it. Anyone dependent on backrefs on Python2 can easily just lock to the last major release, and it will be more than sufficient.

Most new releases moving forward will be to update for later versions of Python and new Unicode versions which will in no way impact Python 2. Feature wise, we are more likely to back off things than implement new features. As Python's Re adds new features, it may replace what we are doing.

Let's be honest as well, I'm pretty sure the actual usage of backrefs (outside of Rummage and wcmatch, which are both my modules) is pretty small. 