### PR TITLE
Deprecate boost style case references

### DIFF
--- a/backrefs/__meta__.py
+++ b/backrefs/__meta__.py
@@ -186,5 +186,5 @@ def parse_version(ver, pre=False):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(4, 1, 1, "final")
+__version_info__ = Version(4, 2, 0, "final")
 __version__ = __version_info__._get_canonical()

--- a/backrefs/_bre_parse.py
+++ b/backrefs/_bre_parse.py
@@ -11,6 +11,7 @@ from . import util as _util
 import sre_parse as _sre_parse
 import unicodedata as _unicodedata
 from . import uniprops as _uniprops
+from . import util
 
 __all__ = ("ReplaceTemplate",)
 
@@ -55,6 +56,11 @@ _BACK_SLASH_TRANSLATION = {
 }
 
 _FMT_CONV_TYPE = ('a', 'r', 's')
+
+_MSG_DEPRECATE_CASE = (
+    "The search back reference '{}' at position {} has been deprecated, please use the posix '{}'. "
+    "In the future, support for this reference will be removed."
+)
 
 
 class LoopException(Exception):
@@ -257,15 +263,19 @@ class _SearchParser(object):
         elif t == "l":
             current.extend(self.letter_case_props(_LOWER, in_group))
             self.found_property = True
+            util.warn_deprecated(_MSG_DEPRECATE_CASE.format('\\l', i.index - 2, "'[:lower:]'"))
         elif t == "L":
             current.extend(self.letter_case_props(_LOWER, in_group, negate=True))
             self.found_property = True
+            util.warn_deprecated(_MSG_DEPRECATE_CASE.format('\\L', i.index - 2, "'[:^lower:]'"))
         elif t == "c":
             current.extend(self.letter_case_props(_UPPER, in_group))
             self.found_property = True
+            util.warn_deprecated(_MSG_DEPRECATE_CASE.format('\\l', i.index - 2, "'[:upper:]'"))
         elif t == "C":
             current.extend(self.letter_case_props(_UPPER, in_group, negate=True))
             self.found_property = True
+            util.warn_deprecated(_MSG_DEPRECATE_CASE.format('\\l', i.index - 2, "'[:^upper:]'"))
         elif t == 'p':
             prop = self.get_unicode_property(i)
             current.extend(self.unicode_props(prop[0], prop[1], in_group=in_group))

--- a/backrefs/util.py
+++ b/backrefs/util.py
@@ -5,6 +5,7 @@ Licensed under MIT
 Copyright (c) 2015 - 2019 Isaac Muse <isaacmuse@gmail.com>
 """
 import sys
+import warnings
 
 PY34 = (3, 4) <= sys.version_info
 PY36 = (3, 6) <= sys.version_info
@@ -137,3 +138,13 @@ class Immutable(object):
         """Prevent mutability."""
 
         raise AttributeError('Class is immutable!')
+
+
+def warn_deprecated(message, stacklevel=2):  # pragma: no cover
+    """Warn deprecated."""
+
+    warnings.warn(
+        message,
+        category=DeprecationWarning,
+        stacklevel=stacklevel
+    )

--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.2.0
+
+- **NEW**: Deprecate the **search** references `\l`, `\L`, `\c`, and `\C`. The POSIX alternatives (which these were shortcuts for) should be used instead: `[[:lower:]]`, `[[:^lower:]]`, `[:upper:]]`, and `[[:^upper:]]` respectively.
+
 ## 4.1.1
 
 - **FIX**: Later pre-release versions of Python 3.8 will support Unicode 12.1.0.

--- a/docs/src/markdown/index.md
+++ b/docs/src/markdown/index.md
@@ -271,10 +271,10 @@ Each supported regular expression engine's supported search features vary, so fe
 Back\ References      | Description
 --------------------- |------------
 `\e`                  | Escape character `\x1b`.
-`\c`                  | Shortcut for the uppercase [POSIX character class](#posix-style-properties) `[[:upper:]]`.  ASCII or Unicode when re Unicode flag is used.  Can be used in character classes `[]`.
-`\l`                  | Shortcut for the lowercase [POSIX character class](#posix-style-properties) `[[:lower:]]`.  ASCII or Unicode when re Unicode flag is used.  Can be used in character classes `[]`.
-`\C`                  | Shortcut for the inverse uppercase [POSIX character class](#posix-style-properties) `[[:^upper:]]`.  ASCII or Unicode when re Unicode flag is used.  Can be used in character classes `[]`.
-`\L`                  | Shortcut for the inverse lowercase [POSIX character class](#posix-style-properties) `[[:^lower:]]`.  ASCII or Unicode when re Unicode flag is used.  Can be used in character classes `[]`.
+`\c`                  | **Deprecated**: Shortcut for the uppercase [POSIX character class](#posix-style-properties) `[[:upper:]]`.  ASCII or Unicode when re Unicode flag is used.  Can be used in character classes `[]`.
+`\l`                  | **Deprecated**: Shortcut for the lowercase [POSIX character class](#posix-style-properties) `[[:lower:]]`.  ASCII or Unicode when re Unicode flag is used.  Can be used in character classes `[]`.
+`\C`                  | **Deprecated**: Shortcut for the inverse uppercase [POSIX character class](#posix-style-properties) `[[:^upper:]]`.  ASCII or Unicode when re Unicode flag is used.  Can be used in character classes `[]`.
+`\L`                  | **Deprecated**: Shortcut for the inverse lowercase [POSIX character class](#posix-style-properties) `[[:^lower:]]`.  ASCII or Unicode when re Unicode flag is used.  Can be used in character classes `[]`.
 `\Q...\E`             | Quotes (escapes) text for regular expression.  `\E` signifies the end of the quoting. Affects any and all characters no matter where in the regular expression pattern it is placed.
 `\p{UnicodeProperty}` | Unicode property character class. Can be used in character classes `[]`. See [Unicode Properties](#unicode-properties) for more info.
 `\pX`                 | Unicode property character class where `X` is the uppercase letter that represents the General Category property.  For instance, `\pL` would be equivalent to `\p{L}` or `\p{Letter}`.
@@ -287,12 +287,13 @@ Back\ References      | Description
 `\R`                  | Generic line breaks. This will use the pattern `(?:\r\n|(?!\r\n)[\n\v\f\r\x85\u2028\u2029])` which is roughly equivalent the to atomic group form that other engines use: `(?>\r\n|[\n\v\f\r\x85\u2028\u2029])`. When applied to byte strings, the pattern `(?:\r\n|(?!\r\n)[\n\v\f\r\x85])` will be used.
 `\X`                  | Grapheme clusters. This will use the pattern `(?:\PM\pM*(?!\pM))` which is roughly equivalent to the atomic group form that other engines use:  `(?>\PM\pM*)`. This does not implement [full, proper grapheme clusters][grapheme-boundaries] like the 3rd party Regex module does as this would require changes to the Re core engine. Instead it provides a simplified solution that has been seen in regular expression engines in the past.
 
+!!! warning "Deprecated 4.2.0"
+    `\l`, `\L`, `\c`, and `\C` search back references have been deprecated in 4.2.0 and will be removed at some future time. It is recommended to use `[[:lower:]]`, `[[:^lower:]]`, `[[:upper:]]`, and `[[:^upper:]]` respectively.
+
 ### Regex
 
 !!! note
     Regex already natively supports `\p{...}`, `\P{...}`, `\pX`, `\PX`, `\N{...}`, `\X`, `\m`, and `\M` so Backrefs does not attempt to add this to search patterns.
-
-    Backrefs **only** implements `\c`, `\l`, `L` and `L` in Re search patterns, not in Regex search patterns. Regex already defines some these references for different purposes. These references are just shortcuts for the related POSIX properties, so when using Regex, it is suggested to just use the POSIX properties.
 
 Back\ References | Description
 ---------------- | -----------

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -10,6 +10,7 @@ import sre_constants
 import random
 from backrefs import _bre_parse
 import copy
+import warnings
 
 PY34_PLUS = (3, 4) <= sys.version_info
 PY36_PLUS = (3, 6) <= sys.version_info
@@ -2569,3 +2570,51 @@ class TestConvenienceFunctions(unittest.TestCase):
                 p.sub(r'\ltest', 'tests')
         else:
             self.assertEqual(p.sub(r'\ltest', 'tests'), r'\ltest')
+
+
+class TestDeprecated(unittest.TestCase):
+    """Test deprecated."""
+
+    def test_lowercase(self):
+        """Test deprecated lower."""
+
+        with warnings.catch_warnings(record=True) as w:
+            # Cause all warnings to always be triggered.
+            warnings.simplefilter("always")
+
+            bre.compile(r'\l')
+            self.assertTrue(len(w) == 1)
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+
+    def test_inverse_lowercase(self):
+        """Test inverse deprecated lower."""
+
+        with warnings.catch_warnings(record=True) as w:
+            # Cause all warnings to always be triggered.
+            warnings.simplefilter("always")
+
+            bre.compile(r'\L')
+            self.assertTrue(len(w) == 1)
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+
+    def test_uppercase(self):
+        """Test deprecated upper."""
+
+        with warnings.catch_warnings(record=True) as w:
+            # Cause all warnings to always be triggered.
+            warnings.simplefilter("always")
+
+            bre.compile(r'\c')
+            self.assertTrue(len(w) == 1)
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+
+    def test_inverse_uppercase(self):
+        """Test inverse deprecated upper."""
+
+        with warnings.catch_warnings(record=True) as w:
+            # Cause all warnings to always be triggered.
+            warnings.simplefilter("always")
+
+            bre.compile(r'\C')
+            self.assertTrue(len(w) == 1)
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))


### PR DESCRIPTION
For consistency between re and regex libraries, the search references \l, \L, \c, and \C will
be removed from the bre library. This is the first step: deprecation.
The POSIX form, which these references where shortcuts for, should be
used instead. The removal only pertains to search patterns and does not apply to the replace pattern references which are used for augmenting cases of groups etc.