### PR TITLE
Test Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ matrix:
       env: TOXENV=py37
     - python: 3.8
       env: TOXENV=py38
+    - python: 3.9-dev
+      env: TOXENV=py39
+  allow_failures:
+    - python: 3.9-dev
 
 install:
   - pip install tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py35,py36,py37,py38,
+    py35,py36,py37,py38,py39
     lint
 
 [testenv]


### PR DESCRIPTION
Python 3.9 currently uses the same Unicode version as 3.8. Try and enable testing on 3.9. This will help keep us aware of if/when things change.