### PR TITLE
Deprecate grapheme cluster reference \X in bre

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,10 @@
 
 # Backrefs
 
-Backrefs is a wrapper around Python's built-in [Re][re] and the 3rd party [Regex][regex] library.  Backrefs adds various additional back references (and a couple other features) that are known to some regular expression engines, but not to Python's Re and/or Regex.  The supported back references actually vary depending on the regular expression engine being used as the engine may already have support for some.
+Backrefs is a wrapper around Python's built-in [Re][re] and the 3rd party [Regex][regex] library.  Backrefs adds various
+additional back references (and a couple other features) that are known to some regular expression engines, but not to
+Python's Re and/or Regex.  The supported back references actually vary depending on the regular expression engine being
+used as the engine may already have support for some.
 
 ```python
 from backrefs import bre
@@ -28,11 +31,18 @@ Released under the MIT license.
 
 Copyright (c) 2015 - 2020 Isaac Muse <isaacmuse@gmail.com>
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 [github-ci-image]: https://github.com/facelessuser/backrefs/workflows/build/badge.svg
 [github-ci-link]: https://github.com/facelessuser/backrefs/actions?workflow=build

--- a/backrefs/_bre_parse.py
+++ b/backrefs/_bre_parse.py
@@ -61,6 +61,12 @@ _MSG_DEPRECATE_CASE = (
     "In the future, support for this reference will be removed."
 )
 
+_MSG_DEPRECATE_GC = (
+    "The search back reference '{}' at position {} has been deprecated, please use the bregex module to take advantage "
+    "of proper grapheme cluster logic, or you can manually specify '(?:\\PM\\pM*(?!\\pM))' to use the legacy logic. "
+    "In the future, support for this reference will be removed."
+)
+
 
 class LoopException(Exception):
     """Loop exception."""
@@ -257,6 +263,7 @@ class _SearchParser(object):
             no_mark = self.unicode_props("^m", None, in_group=False)[0]
             mark = self.unicode_props("m", None, in_group=False)[0]
             current.extend(self._grapheme_cluster % (no_mark, mark, mark))
+            util.warn_deprecated(_MSG_DEPRECATE_GC.format('\\X', i.index - 2))
         elif t == "e":
             current.append(self._re_escape)
         elif t == "l":

--- a/backrefs/bre.py
+++ b/backrefs/bre.py
@@ -3,8 +3,8 @@ Backrefs re.
 
 Add the ability to use the following backrefs with re:
 
- - `\l`                                                          - Lowercase character class (search)
- - `\c`                                                          - Uppercase character class (search)
+ - `\l`                                                          - Lowercase character class (search deprecated)
+ - `\c`                                                          - Uppercase character class (search deprecated)
  - `\L`                                                          - Inverse of lowercase character class (search)
  - `\C`                                                          - Inverse of uppercase character class (search)
  - `\Q` and `\Q...\E`                                            - Escape/quote chars (search)
@@ -20,7 +20,7 @@ Add the ability to use the following backrefs with re:
  - `\m`                                                          - Starting word boundary (search)
  - `\M`                                                          - Ending word boundary (search)
  - `\R`                                                          - Generic line breaks (search)
- - `\X`                                                          - Simplified grapheme clusters (search)
+ - `\X`                                                          - Simplified grapheme clusters (search deprecated)
 
 Licensed under MIT
 Copyright (c) 2011 - 2019 Isaac Muse <isaacmuse@gmail.com>

--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -11,7 +11,8 @@
 
 ## 4.2.0
 
-- **NEW**: Deprecate the **search** references `\l`, `\L`, `\c`, and `\C`. The POSIX alternatives (which these were shortcuts for) should be used instead: `[[:lower:]]`, `[[:^lower:]]`, `[:upper:]]`, and `[[:^upper:]]` respectively.
+- **NEW**: Deprecate the **search** references `\l`, `\L`, `\c`, and `\C`. The POSIX alternatives (which these were
+  shortcuts for) should be used instead: `[[:lower:]]`, `[[:^lower:]]`, `[:upper:]]`, and `[[:^upper:]]` respectively.
 - **NEW**: Formally drop support for Python 3.4.
 
 ## 4.1.1
@@ -31,15 +32,19 @@ to work even when the Re or Regex API changes. Change was made to support new Re
 
 ## 4.0.1
 
-- **FIX**: Ensure that when generating the Unicode property tables, that the property files are read in with `UTF-8` encoding.
+- **FIX**: Ensure that when generating the Unicode property tables, that the property files are read in with `UTF-8`
+  encoding.
 
 ## 4.0.0
 
-- **NEW**: Drop support for new features in Python 2. Python 2 support is limited to the 3.X.X series and will only receive bug fixes up to 2020. All new features moving forward will be on the 4.X.X series and will be for Python 3+ only.
+- **NEW**: Drop support for new features in Python 2. Python 2 support is limited to the 3.X.X series and will only
+  receive bug fixes up to 2020. All new features moving forward will be on the 4.X.X series and will be for Python 3+
+  only.
 
 ## 3.6.0
 
-- **NEW**: Make version available via the new, and more standard, `__version__` attribute and add the `__version_info__` attribute as well. Deprecate the old `version` and `version_info` attribute for future removal.
+- **NEW**: Make version available via the new, and more standard, `__version__` attribute and add the `__version_info__`
+  attribute as well. Deprecate the old `version` and `version_info` attribute for future removal.
 
 ## 3.5.2
 
@@ -48,11 +53,13 @@ to work even when the Re or Regex API changes. Change was made to support new Re
 ## 3.5.1
 
 - **FIX**: POSIX character classes should not be part of a range.
-- **FIX**: Replace string casing logic properly follows other implementations like Boost etc. `\L`, `\C`, and `\E` should all terminate `\L`, and `\C`. `\l` and `\c` will be ignored if followed by `\C` or `\L`.
+- **FIX**: Replace string casing logic properly follows other implementations like Boost etc. `\L`, `\C`, and `\E`
+  should all terminate `\L`, and `\C`. `\l` and `\c` will be ignored if followed by `\C` or `\L`.
 
 ## 3.5.0
 
-- **NEW**: Use a more advanced format string implementation that implements all string features, included those found in `format_spec`.
+- **NEW**: Use a more advanced format string implementation that implements all string features, included those found in
+  `format_spec`.
 - **FIX**: Relax validation so not to exclude valid named Unicode values.
 - **FIX**: Caching issues where byte string patterns were confused with Unicode patterns.
 - **FIX**: More protection against using conflicting string type combinations with search and replace.
@@ -60,7 +67,8 @@ to work even when the Re or Regex API changes. Change was made to support new Re
 ## 3.4.0
 
 - **NEW**: Add support for generic line breaks (`\R`) to Re.
-- **NEW**: Add support for an overly simplified form of grapheme clusters (`\X`) to Re. Roughly equivalent to `(?>\PM\pM*)`.
+- **NEW**: Add support for an overly simplified form of grapheme clusters (`\X`) to Re. Roughly equivalent to
+  `(?>\PM\pM*)`.
 - **NEW**: Add support for `Vertical_Orientation` property for Unicode 10.0.0 on Python 3.7.
 
 ## 3.3.0
@@ -69,12 +77,15 @@ to work even when the Re or Regex API changes. Change was made to support new Re
 
 ## 3.2.1
 
-- **FIX**: `Bidi_Paired_Bracket_type` property's `None` value should be equivalent to all characters that are not `open` or `close` characters.
+- **FIX**: `Bidi_Paired_Bracket_type` property's `None` value should be equivalent to all characters that are not `open`
+  or `close` characters.
 
 ## 3.2.0
 
-- **NEW**: Add support for `Script_Extensions` Unicode properties (Python 3 only as Python 2, Unicode 5.2.0 does not define these). Can be accessed via `\p{scripts_extensions: kana}` or `\p{scx: kana}`.
-- **NEW**: When defining scripts with just their name `\p{Kana}`, use `Script_Extensions` instead of `Scripts`. To get `Scripts` results, you must specify `\p{scripts: kana}` or `\p{sc: scripts}`.
+- **NEW**: Add support for `Script_Extensions` Unicode properties (Python 3 only as Python 2, Unicode 5.2.0 does not
+  define these). Can be accessed via `\p{scripts_extensions: kana}` or `\p{scx: kana}`.
+- **NEW**: When defining scripts with just their name `\p{Kana}`, use `Script_Extensions` instead of `Scripts`. To get
+  `Scripts` results, you must specify `\p{scripts: kana}` or `\p{sc: scripts}`.
 - **NEW**: Add `Bidi_Paired_Bracket_Type` Unicode property (Python 3.4+ only).
 - **NEW**: Add support for `IsBinary` for binary properties: `\p{IsAlphabetic}` == `\p{Alphabetic: Y}`.
 - **FIX**: Tweaks/improvements to string iteration.
@@ -85,14 +96,14 @@ to work even when the Re or Regex API changes. Change was made to support new Re
 
 ## 3.1.1
 
-Feb 11, 2018
-
 - **FIX**: `bregex.compile` now supports additional keyword arguments for named lists like `bregex.compile_search` does.
 
 ## 3.1.0
 
-- **NEW**: Start and end word boundary back references are now specified with `\m` and `\M` like Regex does.  `\<` and `\>` have been removed from Regex.
-- **FIX**: Escaped `\<` and `\>` are no longer processed as Re is known to escape these in versions less than Python 3.7.
+- **NEW**: Start and end word boundary back references are now specified with `\m` and `\M` like Regex does.  `\<` and
+  `\>` have been removed from Regex.
+- **FIX**: Escaped `\<` and `\>` are no longer processed as Re is known to escape these in versions less than Python
+  3.7.
 
 ## 3.0.5
 
@@ -136,18 +147,22 @@ Feb 11, 2018
 - **NEW**: Add support for `\<` and `\>` word boundary escapes.
 - **FIX**: Missing block properties on narrow systems when the property starts beyond the narrow limit.
 - **FIX**: Fix issue where an invalid general category could sometimes pass and return no characters.
-- **FIX**: Fix `\Q...\E` behavior so it is applied first as a separate step. No longer avoids `\Q...\E` in things like character groups or comments.
+- **FIX**: Fix `\Q...\E` behavior so it is applied first as a separate step. No longer avoids `\Q...\E` in things like
+  character groups or comments.
 - **FIX**: Flag related parsing issues in Regex and Re Python 3.6+.
 
 ## 2.2.0
 
 - **NEW**: Proper support for `\N{Unicode Name}`.
-- **FIX**: Incomplete escapes will not be passed through, but will instead throw an error. For instance `\p` should only be passed through if it is complete `\p{category}`.  Python 3.7 will error on this if we pass it through, and Python 3.6 will generate warnings.  We should just consistently fail on it for all Python versions.
+- **FIX**: Incomplete escapes will not be passed through, but will instead throw an error. For instance `\p` should only
+  be passed through if it is complete `\p{category}`.  Python 3.7 will error on this if we pass it through, and Python
+  3.6 will generate warnings.  We should just consistently fail on it for all Python versions.
 
 ## 2.1.0
 
 - **NEW**: Handle Unicode and byte notation in Re replace templates.
-- **NEW**: Rework algorithm to handle replace casing back references in Python 3.7 development builds in preparation for Python 3.7 release.
+- **NEW**: Rework algorithm to handle replace casing back references in Python 3.7 development builds in preparation for
+  Python 3.7 release.
 - **NEW**: Add support for case back references when using the Regex module's `subf` and `subfn`.
 - **NEW**: Add new convenience method `expandf` to Regex that can take a format string and apply format style replaces.
 - **NEW**: Add `FORMAT` flag to `compile_replace` to apply format style replaces when applicable.
@@ -159,7 +174,8 @@ Feb 11, 2018
 
 ## 2.0.0
 
-- **NEW**: First attempt at bringing Python 3.7 support, fixing back reference logic, and adding new back reference. Released and then removed due to very poor behavior.
+- **NEW**: First attempt at bringing Python 3.7 support, fixing back reference logic, and adding new back reference.
+  Released and then removed due to very poor behavior.
 
 ## 1.0.2
 

--- a/docs/src/markdown/contributing.md
+++ b/docs/src/markdown/contributing.md
@@ -11,7 +11,8 @@ Contribution from the community is encouraged and can be done in a variety of wa
 
 ## Bug Reports
 
-1. Please **read the documentation** and **search the issue tracker** to try to find the answer to your question **before** posting an issue.
+1. Please **read the documentation** and **search the issue tracker** to try to find the answer to your question
+  **before** posting an issue.
 
 2. When creating an issue on the repository, please provide as much info as possible:
 
@@ -19,21 +20,28 @@ Contribution from the community is encouraged and can be done in a variety of wa
     - Operating system.
     - Errors in console.
     - Detailed description of the problem.
-    - Examples for reproducing the error.  You can post pictures, but if specific text or code is required to reproduce the issue, please provide the text in a plain text format for easy copy/paste.
+    - Examples for reproducing the error.  You can post pictures, but if specific text or code is required to reproduce
+      the issue, please provide the text in a plain text format for easy copy/paste.
 
     The more info provided the greater the chance someone will take the time to answer, implement, or fix the issue.
 
-3. Be prepared to answer questions and provide additional information if required.  Issues in which the creator refuses to respond to follow up questions will be marked as stale and closed.
+3. Be prepared to answer questions and provide additional information if required.  Issues in which the creator refuses
+  to respond to follow up questions will be marked as stale and closed.
 
 ## Reviewing Code
 
-Take part in reviewing pull requests and/or reviewing direct commits.  Make suggestions to improve the code and discuss solutions to overcome weakness in the algorithm.
+Take part in reviewing pull requests and/or reviewing direct commits.  Make suggestions to improve the code and discuss
+solutions to overcome weakness in the algorithm.
 
 ## Pull Requests
 
-Pull requests are welcome, and if you plan on contributing directly to the code, there are a couple of things to be mindful of.
+Pull requests are welcome, and if you plan on contributing directly to the code, there are a couple of things to be
+mindful of.
 
-Continuous integration tests on are run on all pull requests and commits via Travis CI.  When making a pull request, the tests will automatically be run, and the request must pass to be accepted.  You can (and should) run these tests before pull requesting.  If it is not possible to run these tests locally, they will be run when the pull request is made, but it is strongly suggested that requesters make an effort to verify before requesting to allow for a quick, smooth merge.
+Continuous integration tests on are run on all pull requests and commits via Travis CI.  When making a pull request, the
+tests will automatically be run, and the request must pass to be accepted.  You can (and should) run these tests before
+pull requesting.  If it is not possible to run these tests locally, they will be run when the pull request is made, but
+it is strongly suggested that requesters make an effort to verify before requesting to allow for a quick, smooth merge.
 
 Feel free to use a virtual environment if you are concerned about installing any of the Python packages.
 
@@ -55,8 +63,14 @@ Feel free to use a virtual environment if you are concerned about installing any
 
 ## Documentation Improvements
 
-A ton of time has been spent not only creating and supporting this plugin, but also spent making this documentation.  If you feel it is still lacking, show your appreciation for the plugin by helping to improve the documentation.  Help with documentation is always appreciated and can be done via pull requests.  There shouldn't be any need to run validation tests if only updating documentation.
+A ton of time has been spent not only creating and supporting this plugin, but also spent making this documentation. If
+you feel it is still lacking, show your appreciation for the plugin by helping to improve the documentation.  Help with
+documentation is always appreciated and can be done via pull requests.  There shouldn't be any need to run validation
+tests if only updating documentation.
 
-You don't have to render the docs locally before pull requesting, but if you wish to, I currently use a combination of [MkDocs][mkdocs], the [Material theme][mkdocs-material], and [PyMdown Extensions][pymdown-extensions] to render the docs.  You can preview the docs if you install these two packages.  The command for previewing the docs is `mkdocs serve` from the root directory. You can then view the documents at `localhost:8000`.
+You don't have to render the docs locally before pull requesting, but if you wish to, I currently use a combination of
+[MkDocs][mkdocs], the [Material theme][mkdocs-material], and [PyMdown Extensions][pymdown-extensions] to render the
+docs.  You can preview the docs if you install these two packages.  The command for previewing the docs is
+`mkdocs serve` from the root directory. You can then view the documents at `localhost:8000`.
 
 --8<-- "links.txt"

--- a/docs/src/markdown/index.md
+++ b/docs/src/markdown/index.md
@@ -2,9 +2,14 @@
 
 ## Overview
 
-Backrefs is a wrapper around Python's built-in [Re][re] and the 3rd party [Regex][regex] library.  Backrefs adds various additional back references (and a couple other features) that are known to some regular expression engines, but not to Python's Re and/or Regex.  The supported back references actually vary depending on the regular expression engine being used as the engine may already have support for some, or things that prevent implementation of a feature.
+Backrefs is a wrapper around Python's built-in [Re][re] and the 3rd party [Regex][regex] library.  Backrefs adds various
+additional back references (and a couple other features) that are known to some regular expression engines, but not to
+Python's Re and/or Regex.  The supported back references actually vary depending on the regular expression engine being
+used as the engine may already have support for some, or things that prevent implementation of a feature.
 
-It is important to note that Backrefs doesn't alter the regular expression engine that it wraps around, it is essentially a string processor that looks for certain symbols in a regular expression search or replace string, and alters the pattern before sending it to the regular expression engine.
+It is important to note that Backrefs doesn't alter the regular expression engine that it wraps around, it is
+essentially a string processor that looks for certain symbols in a regular expression search or replace string, and
+alters the pattern before sending it to the regular expression engine.
 
 For instance, if we used `\m` in our regular expression, it would be transformed into `\b(?=\w)`.
 
@@ -20,7 +25,13 @@ Or if we used a Unicode property, it would be transformed into a character group
 re.compile('test [\ud800\udb7f-\udb80\udbff-\udc00\udfff]')
 ```
 
-Replace templates are a little different than searches and require a bit more control to accomplish some of the replace features. Backrefs, like with searches, processes the string before passing it through the regular expression engine. Once Backrefs has parsed and altered the string as needed, it is then passed the regular expression engine to extract string literals and the group mapping (search groups to replace group placeholders). Backrefs will then return a replace object that should be used to apply the replace. The object will handle applying casing (upper or lower) to the returned captured groups, and assemble the desired string output. For these reasons, Backrefs requires you to compile your replaces and use the returned replace object if you want to take advantage of replace features.
+Replace templates are a little different than searches and require a bit more control to accomplish some of the replace
+features. Backrefs, like with searches, processes the string before passing it through the regular expression engine.
+Once Backrefs has parsed and altered the string as needed, it is then passed the regular expression engine to extract
+string literals and the group mapping (search groups to replace group placeholders). Backrefs will then return a replace
+object that should be used to apply the replace. The object will handle applying casing (upper or lower) to the returned
+captured groups, and assemble the desired string output. For these reasons, Backrefs requires you to compile your
+replaces and use the returned replace object if you want to take advantage of replace features.
 
 ```pycon3
 >>> pattern = bre.compile_search(r'(\p{Letter}+)')
@@ -38,11 +49,16 @@ from backrefs import bre
 from backrefs import bregex
 ```
 
-Backrefs can be applied to search patterns and/or replace patterns. You can control whether you want to use search augmentation, replace augmentation, or both.
+Backrefs can be applied to search patterns and/or replace patterns. You can control whether you want to use search
+augmentation, replace augmentation, or both.
 
 ### Search Patterns
 
-To augment the search pattern of Re or Regex to utilize search back references, you can use Backrefs to compile the search. This will apply a preprocessor to the pattern and replace the back references (or other special syntax) with the appropriate content to construct a valid regular expression for Re or Regex. It will then return a valid compiled pattern for the respective regular expression engine. Since the return is a valid compiled pattern, you can use it as expected.
+To augment the search pattern of Re or Regex to utilize search back references, you can use Backrefs to compile the
+search. This will apply a preprocessor to the pattern and replace the back references (or other special syntax) with
+the appropriate content to construct a valid regular expression for Re or Regex. It will then return a valid compiled
+pattern for the respective regular expression engine. Since the return is a valid compiled pattern, you can use it as
+expected.
 
 ```py3
 >>> pattern = bre.compile_search(r'\p{Letter}+', bre.UNICODE)
@@ -52,9 +68,15 @@ True
 
 ### Replace Templates
 
-Backrefs also provides special back references for replace templates as well. In order to utilize these back references, the template string must be run through a compiler as well. The replace compiler will run a preprocessor on the replace template that will strip out the back references and augment the template accordingly creating a valid replace template. Then it will return a replace object that can be used in place of your replace string. When used as your replace, the object will properly apply all the replace back references to your returned string and insert matched groups into the template.  These replace objects can be passed into `sub`, `subn` etc.
+Backrefs also provides special back references for replace templates as well. In order to utilize these back references,
+the template string must be run through a compiler as well. The replace compiler will run a preprocessor on the replace
+template that will strip out the back references and augment the template accordingly creating a valid replace template.
+Then it will return a replace object that can be used in place of your replace string. When used as your replace, the
+object will properly apply all the replace back references to your returned string and insert matched groups into the
+template.  These replace objects can be passed into `sub`, `subn` etc.
 
-Search templates must be run through the compiler with an associated compiled search pattern so that it can properly map to the groups in your search pattern.
+Search templates must be run through the compiler with an associated compiled search pattern so that it can properly map
+to the groups in your search pattern.
 
 ```pycon3
 >>> pattern = bre.compile_search(r'(\p{Letter}+)')
@@ -63,7 +85,8 @@ Search templates must be run through the compiler with an associated compiled se
 'SOMETEXT'
 ```
 
-Since compiled replaces are not template strings, but functions, you wont be able to apply compiled replaces via `#!py m.expand(replace)`. Instead, you can use the compiled replace directly.
+Since compiled replaces are not template strings, but functions, you wont be able to apply compiled replaces via
+`#!py m.expand(replace)`. Instead, you can use the compiled replace directly.
 
 ```pycon3
 >>> pattern = bre.compile_search(r'(\p{Letter}+)')
@@ -73,7 +96,8 @@ Since compiled replaces are not template strings, but functions, you wont be abl
 'SOMETEXT'
 ```
 
-If you have a one time expand, and don't feel like pre-compiling, you can use Backrefs `expand` method (it can also take pre-compiled patterns as well).
+If you have a one time expand, and don't feel like pre-compiling, you can use Backrefs `expand` method (it can also take
+pre-compiled patterns as well).
 
 ```pycon3
 >>> pattern = bre.compile_search(r'(\p{Letter}+)')
@@ -84,7 +108,10 @@ If you have a one time expand, and don't feel like pre-compiling, you can use Ba
 
 ### Search & Replace Together
 
-If you plan on using both the search and replace features, using `compile_search` and `compile_replace` can be a little awkward. If you wish to use something a bit more familiar, you can use the `compile` function to create a pattern object that mimics Re and Regex's pattern object. Once created, it will work very similar to how Re and Regex pattern objects work.  It will also auto compile replace patterns for you:
+If you plan on using both the search and replace features, using `compile_search` and `compile_replace` can be a little
+awkward. If you wish to use something a bit more familiar, you can use the `compile` function to create a pattern object
+that mimics Re and Regex's pattern object. Once created, it will work very similar to how Re and Regex pattern objects
+work.  It will also auto compile replace patterns for you:
 
 ```pycon3
 >>> pattern = bre.compile(r'(\p{Letter}+)')
@@ -101,7 +128,8 @@ If needed, you can use the object's `compile` function to pre-compile the replac
 'SOMETEXT'
 ```
 
-If you want to disable the patterns use of replace back references, you can disable the pre-compile of replace templates:
+If you want to disable the patterns use of replace back references, you can disable the pre-compile of replace
+templates:
 
 ```pycon3
 >>> pattern = bre.compile(r'(\p{Letter}+)', auto_compile=False)
@@ -111,18 +139,26 @@ If you want to disable the patterns use of replace back references, you can disa
 
 ### Other Functions
 
-Backrefs exposes most of the usual functions which Backrefs is wrapped around.  For instance, Backrefs wraps around `purge` so that it can purge its cache along with the regular expression engine's cache.
+Backrefs exposes most of the usual functions which Backrefs is wrapped around.  For instance, Backrefs wraps around
+`purge` so that it can purge its cache along with the regular expression engine's cache.
 
-Backrefs also wraps around the global matching functions. So if you have a one time `finditer`, `match`, `sub`, `search`, or other operation, Backrefs provides wrappers for these methods too.  The wrappers will compile the search and replace patterns for you on the fly, but they will also accept and pass pre-compiled patterns through as well.  They should take all the flags and options your chosen regular expression engine normally accepts with the same names and positions.
+Backrefs also wraps around the global matching functions. So if you have a one time `finditer`, `match`, `sub`,
+`search`, or other operation, Backrefs provides wrappers for these methods too.  The wrappers will compile the search
+and replace patterns for you on the fly, but they will also accept and pass pre-compiled patterns through as well. They
+should take all the flags and options your chosen regular expression engine normally accepts with the same names and
+positions.
 
 ```pycon3
 >>> bre.sub(r'(\p{Letter}+)', r'\C\1\E', 'sometext')
 SOMETEXT
 ```
 
-In general, all options and flags for any of the compile, search, or replace wrappers should be the same as your actual regular expression engine.  They are mirrored in the `bre` and `bregex` library to save you from having to import the the original `re` and `regex` respectively, but you could just as easily use the original flags if desired.
+In general, all options and flags for any of the compile, search, or replace wrappers should be the same as your actual
+regular expression engine.  They are mirrored in the `bre` and `bregex` library to save you from having to import the
+original `re` and `regex` respectively, but you could just as easily use the original flags if desired.
 
-In order to escape patterns formulated for Backrefs, you can simply use your regular expressions built-in escape method or the one mirrored in Backrefs; they are the same.
+In order to escape patterns formulated for Backrefs, you can simply use your regular expressions built-in escape method
+or the one mirrored in Backrefs; they are the same.
 
 ```pycon3
 >>> pattern = bre.compile_search(bre.escape(r'(\p{Letter}+)'))
@@ -132,7 +168,10 @@ In order to escape patterns formulated for Backrefs, you can simply use your reg
 
 ### Format Replacements
 
-The Regex library has a feature where you can use format strings to implement replacements. This is useful for Regex as it provides a way to access different captures when multiple are captured by a single group. Most likely it was born from the need to provide an easy way to access multiple captures as Regex stores all captures while Re stores only the last.
+The Regex library has a feature where you can use format strings to implement replacements. This is useful for Regex as
+it provides a way to access different captures when multiple are captured by a single group. Most likely it was born
+from the need to provide an easy way to access multiple captures as Regex stores all captures while Re stores only the
+last.
 
 ```pycon3
 >>> regex.subf(r"(\w+) (\w+)", "{0} => {2} {1}", "foo bar")
@@ -146,9 +185,15 @@ The Regex library has a feature where you can use format strings to implement re
 'foo bar => bar f'
 ```
 
-Backrefs implements format string replacements in a way that is similar to Regex's that works for both Re and Regex.  While it is similar to Regex's implementation, there are some differences.
+Backrefs implements format string replacements in a way that is similar to Regex's that works for both Re and Regex.
+While it is similar to Regex's implementation, there are some differences.
 
-1. Though you can use normal strings with Backrefs' format templates, it is recommended to use raw strings for format replacements as back slashes are handled special to implement lower casing and upper casing via the replace back references. In Backrefs a template would look like `#!py r'\L{1}{2}\E'`, and if you used a normal string it would look like `#!py '\\L{1}{2}\\E'`.  Because Backrefs more or less requires raw strings for sane replace template creation, you can also use normal string and Unicode escapes in the format replace templates, so it should feel like a normal string.
+1. Though you can use normal strings with Backrefs' format templates, it is recommended to use raw strings for format
+  replacements as back slashes are handled special to implement lower casing and upper casing via the replace back
+  references. In Backrefs a template would look like `#!py r'\L{1}{2}\E'`, and if you used a normal string it would look
+  like `#!py '\\L{1}{2}\\E'`.  Because Backrefs more or less requires raw strings for sane replace template creation,
+  you can also use normal string and Unicode escapes in the format replace templates, so it should feel like a normal
+  string.
 
     ```pycon3
     >>> bregex.subf(r'(test)', r'{0:\n^8}', 'test')
@@ -157,7 +202,10 @@ Backrefs implements format string replacements in a way that is similar to Regex
     '||TEST||'
     ```
 
-2. Normally format strings don't allow you to index with negative integers as they are recognized as strings, but like Regex's format implementation, Backrefs allows you to use negative numbers (`-1`), hex (`0x01`), octal (`0o001`), or even binary (`0b1`).  While it may not be practical to use some of the latter forms, they are available to have feature parity with Regex's implementation.
+2. Normally format strings don't allow you to index with negative integers as they are recognized as strings, but like
+  Regex's format implementation, Backrefs allows you to use negative numbers (`-1`), hex (`0x01`), octal (`0o001`), or
+  even binary (`0b1`).  While it may not be practical to use some of the latter forms, they are available to have
+  feature parity with Regex's implementation.
 
 
     ```pycon3
@@ -165,7 +213,9 @@ Backrefs implements format string replacements in a way that is similar to Regex
     'test'
     ```
 
-3. Backrefs implements a subset of the [Format Specification Mini-Language][format-spec] that allows for a few more additional features that Regex doesn't (`format_spec`). As regular expression replace is only dealing with strings (or byte strings), only string features are available with the `format_spec`.
+3. Backrefs implements a subset of the [Format Specification Mini-Language][format-spec] that allows for a few more
+  additional features that Regex doesn't (`format_spec`). As regular expression replace is only dealing with strings
+  (or byte strings), only string features are available with the `format_spec`.
 
     ```
     replacement_field ::=  "{" [field_name] ["!" conversion] [":" format_spec] "}"
@@ -186,9 +236,13 @@ Backrefs implements format string replacements in a way that is similar to Regex
     type        ::=  "s"
     ```
 
-    Note that in situations such as `{:030}`, where a width has a leading zero and no alignment specified, this would normally trigger the integer alignment `=`, but since integer features are not implemented, this would fail.
+    Note that in situations such as `{:030}`, where a width has a leading zero and no alignment specified, this would
+    normally trigger the integer alignment `=`, but since integer features are not implemented, this would fail.
 
-4. Backrefs allows format strings to work for byte strings as well. In almost all instances, using conversion types won't make sense in a regular expression replace as the objects will already be strings in the needed format, but if you were to use a conversion, ASCII would be assumed, and the object or Unicode string would be encoded with `backslashreplace`.
+4. Backrefs allows format strings to work for byte strings as well. In almost all instances, using conversion types
+  won't make sense in a regular expression replace as the objects will already be strings in the needed format, but if
+  you were to use a conversion, ASCII would be assumed, and the object or Unicode string would be encoded with
+  `backslashreplace`.
 
 When using Backrefs' format replace, it should feel similar to Regex's format replace, except you will use raw strings:
 
@@ -261,12 +315,17 @@ Backrefs also provides an `expand` variant for format templates called `expandf`
 
 ## Search Back References
 
-Each supported regular expression engine's supported search features vary, so features are broken up to show what is specifically added for Re and for Regex.
+Each supported regular expression engine's supported search features vary, so features are broken up to show what is
+specifically added for Re and for Regex.
 
 ### Re
 
 !!! info "`LOCALE` and Character Properties"
-    Backrefs does not consider `LOCALE` when inserting POSIX or Unicode properties. In byte strings, Unicode properties will be truncated to the ASCII range of `\xff`. POSIX properties will use either Unicode categories or POSIX categories depending on whether the `UNICODE` flag is set. If the `LOCALE` flag is set, it is considered **not** Unicode. Keep in mind that Backrefs doesn't stop `LOCALE` from being applied, only that Backrefs inserts its categories as either Unicode or ASCII only.
+    Backrefs does not consider `LOCALE` when inserting POSIX or Unicode properties. In byte strings, Unicode properties
+    will be truncated to the ASCII range of `\xff`. POSIX properties will use either Unicode categories or POSIX
+    categories depending on whether the `UNICODE` flag is set. If the `LOCALE` flag is set, it is considered **not**
+    Unicode. Keep in mind that Backrefs doesn't stop `LOCALE` from being applied, only that Backrefs inserts its
+    categories as either Unicode or ASCII only.
 
 Back\ References      | Description
 --------------------- |------------
@@ -285,15 +344,23 @@ Back\ References      | Description
 `\m`                  | Start word boundary. Translates to `\b(?=\w)`.
 `\M`                  | End word boundary. Translates to `\b(?<=\w)`.
 `\R`                  | Generic line breaks. This will use the pattern `(?:\r\n|(?!\r\n)[\n\v\f\r\x85\u2028\u2029])` which is roughly equivalent the to atomic group form that other engines use: `(?>\r\n|[\n\v\f\r\x85\u2028\u2029])`. When applied to byte strings, the pattern `(?:\r\n|(?!\r\n)[\n\v\f\r\x85])` will be used.
-`\X`                  | Grapheme clusters. This will use the pattern `(?:\PM\pM*(?!\pM))` which is roughly equivalent to the atomic group form that other engines use:  `(?>\PM\pM*)`. This does not implement [full, proper grapheme clusters][grapheme-boundaries] like the 3rd party Regex module does as this would require changes to the Re core engine. Instead it provides a simplified solution that has been seen in regular expression engines in the past.
+`\X`                  | **Deprecated**: Grapheme clusters. This will use the pattern `(?:\PM\pM*(?!\pM))` which is roughly equivalent to the atomic group form that other engines have used in the past: `(?>\PM\pM*)`. This does not implement [full, proper grapheme clusters][grapheme-boundaries] like the 3rd party Regex module does as this would require changes to the Re core engine. Instead it provides a simplified solution that has been seen in regular expression engines in the past.
 
 !!! warning "Deprecated 4.2.0"
-    `\l`, `\L`, `\c`, and `\C` search back references have been deprecated in 4.2.0 and will be removed at some future time. It is recommended to use `[[:lower:]]`, `[[:^lower:]]`, `[[:upper:]]`, and `[[:^upper:]]` respectively.
+    `\l`, `\L`, `\c`, and `\C` search back references have been deprecated in 4.2.0 and will be removed at some future
+    time. It is recommended to use `[[:lower:]]`, `[[:^lower:]]`, `[[:upper:]]`, and `[[:^upper:]]` respectively.
+
+!!! warning "Deprecated 4.4.0"
+    `\X` search back reference has been deprecated in 4.4.0 and will be removed at some future time. It is recommended
+    to use the [Regex](#regex) implementation via `bregex` to get proper grapheme cluster logic. But if this rough
+    version is sufficient for your needs, you can always manually use the pattern `(?:\PM\pM*(?!\pM))` which is is what
+    this reference used.
 
 ### Regex
 
 !!! note
-    Regex already natively supports `\p{...}`, `\P{...}`, `\pX`, `\PX`, `\N{...}`, `\X`, `\m`, and `\M` so Backrefs does not attempt to add this to search patterns.
+    Regex already natively supports `\p{...}`, `\P{...}`, `\pX`, `\PX`, `\N{...}`, `\X`, `\m`, and `\M` so Backrefs does
+    not attempt to add this to search patterns.
 
 Back\ References | Description
 ---------------- | -----------
@@ -303,10 +370,14 @@ Back\ References | Description
 
 ## Replace Back References
 
-The replace back references below apply to both Re **and** Regex and are essentially non-specific to the regular expression engine being used.  Casing is applied to both the literal text and the replacement groups within the replace template.  In most cases you'd only need to wrap the groups, but it may be useful to apply casing to the literal portions if you are dynamically assembling replacement patterns.
+The replace back references below apply to both Re **and** Regex and are essentially non-specific to the regular
+expression engine being used.  Casing is applied to both the literal text and the replacement groups within the replace
+template.  In most cases you'd only need to wrap the groups, but it may be useful to apply casing to the literal
+portions if you are dynamically assembling replacement patterns.
 
 !!! info "`LOCALE` and Casing"
-    `LOCALE` is not considered when applying character casing. Unicode casing is applied in Unicode strings and ASCII casing is applied to byte strings.
+    `LOCALE` is not considered when applying character casing. Unicode casing is applied in Unicode strings and ASCII
+    casing is applied to byte strings.
 
 Back\ References     | Description
 ---------------------|-------------
@@ -328,11 +399,19 @@ Back\ References     | Description
 
 ## Unicode Properties
 
-A number of various Unicode properties are supported in Backrefs, but only for Re as Regex already has its own implementation of Unicode properties. Some properties may not be available on certain Python versions due to the included Unicode build.
+A number of various Unicode properties are supported in Backrefs, but only for Re as Regex already has its own
+implementation of Unicode properties. Some properties may not be available on certain Python versions due to the
+included Unicode build.
 
-It is important to note that Backrefs handles Unicode properties by transforming them to character classes with all the associated characters: `\p{Cs}` --> `[\ud800\udb7f-\udb80\udbff-\udc00\udfff]`.  Because of this, Backrefs can create really large regular expressions that the underlying engine must walk through.  In short, Re with Backrefs will never be as efficient or fast as using Regex's Unicode properties, but it is very useful when you need or want to use Re.
+It is important to note that Backrefs handles Unicode properties by transforming them to character classes with all the
+associated characters: `\p{Cs}` --> `[\ud800\udb7f-\udb80\udbff-\udc00\udfff]`.  Because of this, Backrefs can create
+really large regular expressions that the underlying engine must walk through.  In short, Re with Backrefs will never be
+as efficient or fast as using Regex's Unicode properties, but it is very useful when you need or want to use Re.
 
-Also, keep in mind that there are most likely some differences between Regex's Unicode Properties and Backrefs' Unicode properties. One notable difference is Regex does not currently implement `script_extensions` while Backrefs' does and uses them as the default when specifying them in the form `\p{IsScriptValue}`  or `\p{ScriptValue}` just like Perl does.  See [Special Syntax Exceptions](#special-syntax-exceptions) for more info.
+Also, keep in mind that there are most likely some differences between Regex's Unicode Properties and Backrefs' Unicode
+properties. One notable difference is Regex does not currently implement `script_extensions` while Backrefs' does and
+uses them as the default when specifying them in the form `\p{IsScriptValue}`  or `\p{ScriptValue}` just like Perl does.
+See [Special Syntax Exceptions](#special-syntax-exceptions) for more info.
 
 Supported\ Properties                       | Aliases
 ------------------------------------------- | -------
@@ -366,38 +445,63 @@ Supported\ Properties                       | Aliases
 `Word_Break`                                | `wb`
 
 !!! note
-    The Binary property is not actually a property, but a group of different properties with binary characteristics. The available binary properties may differ from Unicode version to Unicode version.
+    The Binary property is not actually a property, but a group of different properties with binary characteristics. The
+    available binary properties may differ from Unicode version to Unicode version.
 
-Exhaustive documentation on all these properties and their values is not currently provided. In general, we'll cover the syntax rules, and [special exceptions](#special-syntax-exceptions) to those rules for specific properties. Though we will outline all the values for General Category, we will not outline all of the valid values for the other properties. You can look at [Perl's Unicode property documentation][perl-uniprops] to get an idea of what values are appropriate for a given property, but keep in mind, syntax may vary from Perl's syntax.
+Exhaustive documentation on all these properties and their values is not currently provided. In general, we'll cover the
+syntax rules, and [special exceptions](#special-syntax-exceptions) to those rules for specific properties. Though we
+will outline all the values for General Category, we will not outline all of the valid values for the other properties.
+You can look at [Perl's Unicode property documentation][perl-uniprops] to get an idea of what values are appropriate for
+a given property, but keep in mind, syntax may vary from Perl's syntax.
 
-Unicode properties are specific to search patterns and can be used to specify a request to match all the characters in a specific Unicode property. Unicode properties can be used in byte strings, but the patterns will be restricted to the range `\x00-\xff`.
+Unicode properties are specific to search patterns and can be used to specify a request to match all the characters in a
+specific Unicode property. Unicode properties can be used in byte strings, but the patterns will be restricted to the
+range `\x00-\xff`.
 
-If you are using a narrow python build, your max Unicode value will be `\uffff`.  Unicode blocks above that limit will not be available.  Also Unicode values above the limit will not be available in character classes either. If you are using a wide build, you should have access to all Unicode values.
+If you are using a narrow python build, your max Unicode value will be `\uffff`.  Unicode blocks above that limit will
+not be available.  Also Unicode values above the limit will not be available in character classes either. If you are
+using a wide build, you should have access to all Unicode values.
 
 ### Syntax
 
-Unicode properties can be specified with the format: `\p{property=value}`, `\p{property:value}`. You can also do inverse properties by using the `^` character (`\p{^property=value}`) or by using a capital `P` (`\P{property=value}`. `\P{property:value}`).
+Unicode properties can be specified with the format: `\p{property=value}`, `\p{property:value}`. You can also do inverse
+properties by using the `^` character (`\p{^property=value}`) or by using a capital `P` (`\P{property=value}` or
+`\P{property:value}`).
 
-Unicode properties may only have one property specified between the curly braces.  If you want to use multiple properties to capture a singe character, create a character class: `[\p{UnicodeProperty}\p{OtherUnicodeProperty}]`.
+Unicode properties may only have one property specified between the curly braces.  If you want to use multiple
+properties to capture a singe character, create a character class: `[\p{UnicodeProperty}\p{OtherUnicodeProperty}]`.
 
-When specifying a property, the property and value matching is case insensitive and characters like `[ -_]` will be stripped out.  So the following are all equivalent: `\p{Uppercase_Letter}`, `\p{Uppercase-letter}`, `\p{UPPERCASELETTER}`, `\p{upper case letter}`.
+When specifying a property, the property and value matching is case insensitive and characters like `[ -_]` will be
+stripped out.  So the following are all equivalent: `\p{Uppercase_Letter}`, `\p{Uppercase-letter}`,
+`\p{UPPERCASELETTER}`, `\p{upper case letter}`.
 
-There are a number of binary properties. In general, binary properties are specified by stating the binary property and a boolean value. True values can be `Yes`, `Y`, `True`, or `T`. False values can be `No`, `N`, `False`, or `F`. For example, to specify characters that are "alphabetic", we can use `\p{Alphabetic: Y}`. To specify characters that are **not** "alphabetic": `\p{Alphabetic: N}`.
+There are a number of binary properties. In general, binary properties are specified by stating the binary property and
+a boolean value. True values can be `Yes`, `Y`, `True`, or `T`. False values can be `No`, `N`, `False`, or `F`. For
+example, to specify characters that are "alphabetic", we can use `\p{Alphabetic: Y}`. To specify characters that are
+**not** "alphabetic": `\p{Alphabetic: N}`.
 
 ### Special Syntax Exceptions
 
-General Category, Script, Blocks, and Binary all can be specified by their value alone: `\p{value}`, but they will be evaluated in the following order to resolve name conflicts as some the same value that is used in Script may be used in Blocks etc.
+General Category, Script, Blocks, and Binary all can be specified by their value alone: `\p{value}`, but they will be
+evaluated in the following order to resolve name conflicts as some the same value that is used in Script may be used in
+Blocks etc.
 
 1. General Category
 2. Script (with Script Extensions on Python 3+)
 3. Blocks
 4. Binary
 
-Script and Binary properties can also be defined in the format `IsValue`.  For instance, if we wanted to match characters in the `Latin` script, we could use the syntax `\p{IsLatin}`, which would be the same as `\p{Latin}` or `\p{scx: Latin}`.  For Binary properties, `\p{IsAlphabetic}` is the same as `\p{Alphabetic: Y}` or `\p{Alphabetic}`.
+Script and Binary properties can also be defined in the format `IsValue`.  For instance, if we wanted to match
+characters in the `Latin` script, we could use the syntax `\p{IsLatin}`, which would be the same as `\p{Latin}` or
+`\p{scx: Latin}`.  For Binary properties, `\p{IsAlphabetic}` is the same as `\p{Alphabetic: Y}` or `\p{Alphabetic}`.
 
-Block properties have a similar short form as Script and Binary properties.  For Blocks you can use `InValue` to specify a block. If we wanted to match characters in the `Basic_Latin` block, we could use the syntax `\p{InBasic_Latin}`. This would be the same as `\p{Block: Basic_Latin}` or `\p{Basic_Latin}`.
+Block properties have a similar short form as Script and Binary properties.  For Blocks you can use `InValue` to specify
+a block. If we wanted to match characters in the `Basic_Latin` block, we could use the syntax `\p{InBasic_Latin}`. This
+would be the same as `\p{Block: Basic_Latin}` or `\p{Basic_Latin}`.
 
-Lastly, you can specify general category properties in the form `\pX` where `X` is the single letter terse property form. In this form, you can only use the single character values. So you could specify `Letter`, whose terse form is `L` with `\pL`, but cannot specify `Cased_Letter` which has a terse form of `Lc`.
+Lastly, you can specify general category properties in the form `\pX` where `X` is the single letter terse property
+form. In this form, you can only use the single character values. So you could specify `Letter`, whose terse form is `L`
+with `\pL`, but cannot specify `Cased_Letter` which has a terse form of `Lc`.
 
 See the table below to see all the Unicode General Category values and their terse forms.
 
@@ -444,9 +548,17 @@ Verbose\ Property\ Form            | Terse\ Property\ Form
 
 ### POSIX Style Properties
 
-A number of POSIX property names are also available in the form `[:posix:]`. Inverse properties are also available in the form `[:^posix:]`. These properties must only be included in a character class: `[[:upper:]a-z]`. There are two definitions for a given POSIX property: ASCII and Unicode. The Unicode definitions leverage Unicode properties and are only used if the pattern is a Unicode string **and** the regular expression's `UNICODE` flag is set.  In Python 3, the default is Unicode unless the `ASCII` flag is set (the `LOCALE` flag is the equivalent of not having `UNICODE` set).
+A number of POSIX property names are also available in the form `[:posix:]`. Inverse properties are also available in
+the form `[:^posix:]`. These properties must only be included in a character class: `[[:upper:]a-z]`. There are two
+definitions for a given POSIX property: ASCII and Unicode. The Unicode definitions leverage Unicode properties and are
+only used if the pattern is a Unicode string **and** the regular expression's `UNICODE` flag is set.  In Python 3, the
+default is Unicode unless the `ASCII` flag is set (the `LOCALE` flag is the equivalent of not having `UNICODE` set).
 
-The Unicode variants of the POSIX properties are also available via the `\p{...}` form.  There are some name collisions with existing Unicode properties like `punct` which exists as both a name for a Unicode property and a slightly different POSIX property. To access the POSIX property, you should prefix the name with `posix`: `\p{PosixPunct}`. It should be noted that you can use the `posix` prefix to access any of the POSIX properties, even if there is no name collision. The POSIX properties are treated as [binary Unicode properties](#binary).
+The Unicode variants of the POSIX properties are also available via the `\p{...}` form.  There are some name collisions
+with existing Unicode properties like `punct` which exists as both a name for a Unicode property and a slightly
+different POSIX property. To access the POSIX property, you should prefix the name with `posix`: `\p{PosixPunct}`. It
+should be noted that you can use the `posix` prefix to access any of the POSIX properties, even if there is no name
+collision. The POSIX properties are treated as [binary Unicode properties](#binary).
 
 
 \[:posix:] | \\p\{Posix} | ASCII                                             | Unicode

--- a/docs/src/markdown/license.md
+++ b/docs/src/markdown/license.md
@@ -4,8 +4,15 @@ MIT license.
 
 Copyright (c) 2015 - 2020 Isaac Muse <isaacmuse@gmail.com>
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -2575,6 +2575,7 @@ class TestDeprecated(unittest.TestCase):
     def test_lowercase(self):
         """Test deprecated lower."""
 
+        bre.purge()
         with warnings.catch_warnings(record=True) as w:
             # Cause all warnings to always be triggered.
             warnings.simplefilter("always")
@@ -2586,6 +2587,7 @@ class TestDeprecated(unittest.TestCase):
     def test_inverse_lowercase(self):
         """Test deprecated inverse lower."""
 
+        bre.purge()
         with warnings.catch_warnings(record=True) as w:
             # Cause all warnings to always be triggered.
             warnings.simplefilter("always")
@@ -2597,6 +2599,7 @@ class TestDeprecated(unittest.TestCase):
     def test_uppercase(self):
         """Test deprecated upper."""
 
+        bre.purge()
         with warnings.catch_warnings(record=True) as w:
             # Cause all warnings to always be triggered.
             warnings.simplefilter("always")
@@ -2608,6 +2611,7 @@ class TestDeprecated(unittest.TestCase):
     def test_inverse_uppercase(self):
         """Test deprecated inverse upper."""
 
+        bre.purge()
         with warnings.catch_warnings(record=True) as w:
             # Cause all warnings to always be triggered.
             warnings.simplefilter("always")
@@ -2619,10 +2623,11 @@ class TestDeprecated(unittest.TestCase):
     def test_grapheme_cluster(self):
         """Test deprecated grapheme cluster."""
 
+        bre.purge()
         with warnings.catch_warnings(record=True) as w:
             # Cause all warnings to always be triggered.
             warnings.simplefilter("always")
 
-            p = bre.compile(r'\X')
+            bre.compile(r'\X')
             self.assertTrue(len(w) == 1)
             self.assertTrue(issubclass(w[-1].category, DeprecationWarning))

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -2584,7 +2584,7 @@ class TestDeprecated(unittest.TestCase):
             self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
 
     def test_inverse_lowercase(self):
-        """Test inverse deprecated lower."""
+        """Test deprecated inverse lower."""
 
         with warnings.catch_warnings(record=True) as w:
             # Cause all warnings to always be triggered.
@@ -2606,12 +2606,23 @@ class TestDeprecated(unittest.TestCase):
             self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
 
     def test_inverse_uppercase(self):
-        """Test inverse deprecated upper."""
+        """Test deprecated inverse upper."""
 
         with warnings.catch_warnings(record=True) as w:
             # Cause all warnings to always be triggered.
             warnings.simplefilter("always")
 
             bre.compile(r'\C')
+            self.assertTrue(len(w) == 1)
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+
+    def test_grapheme_cluster(self):
+        """Test deprecated grapheme cluster."""
+
+        with warnings.catch_warnings(record=True) as w:
+            # Cause all warnings to always be triggered.
+            warnings.simplefilter("always")
+
+            p = bre.compile(r'\X')
             self.assertTrue(len(w) == 1)
             self.assertTrue(issubclass(w[-1].category, DeprecationWarning))


### PR DESCRIPTION
This deprecates the grapheme cluster back reference in bre. It is honestly not useful enough to keep around when there is options like regex's full grapheme cluster solution that is accessible in our bregex library.

Closes #129 