### PR TITLE
Create a more sane API for uniprops

### DIFF
--- a/backrefs/_bre_parse.py
+++ b/backrefs/_bre_parse.py
@@ -14,8 +14,6 @@ from . import util
 
 __all__ = ("ReplaceTemplate",)
 
-_SCOPED_FLAG_SUPPORT = _util.PY36
-
 _ASCII_LETTERS = frozenset(
     (
         'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
@@ -169,19 +167,19 @@ class _SearchParser(object):
         global_retry = False
         if ('a' in text or 'L' in text) and self.unicode:
             self.unicode = False
-            if not _SCOPED_FLAG_SUPPORT or not scoped:
+            if not scoped:
                 self.temp_global_flag_swap["unicode"] = True
                 global_retry = True
         elif 'u' in text and not self.unicode and not self.is_bytes:
             self.unicode = True
-            if not _SCOPED_FLAG_SUPPORT or not scoped:
+            if not scoped:
                 self.temp_global_flag_swap["unicode"] = True
                 global_retry = True
-        if _SCOPED_FLAG_SUPPORT and '-x' in text and self.verbose:
+        if '-x' in text and self.verbose:
             self.verbose = False
         elif 'x' in text and not self.verbose:
             self.verbose = True
-            if not _SCOPED_FLAG_SUPPORT or not scoped:
+            if not scoped:
                 self.temp_global_flag_swap["verbose"] = True
                 global_retry = True
         if global_retry:
@@ -330,9 +328,6 @@ class _SearchParser(object):
 
     def get_flags(self, i, scoped=False):
         """Get flags."""
-
-        if scoped and not _SCOPED_FLAG_SUPPORT:
-            return None
 
         index = i.index
         value = ['(']

--- a/backrefs/_bre_parse.py
+++ b/backrefs/_bre_parse.py
@@ -583,7 +583,7 @@ class _SearchParser(object):
         Insert Unicode properties.
 
         Unicode properties are very forgiving.
-        Case doesn't matter and `[ -_]` will be stripped ouaqst.
+        Case doesn't matter and `[ -_]` will be stripped out.
         """
 
         if props.startswith("^"):

--- a/backrefs/_bre_parse.py
+++ b/backrefs/_bre_parse.py
@@ -578,32 +578,23 @@ class _SearchParser(object):
         else:
             return ['\\%03o' % value if value <= 0xFF else chr(value)]
 
-    def unicode_props(self, props, value, in_group=False, negate=False):
+    def unicode_props(self, props, prop_value, in_group=False, negate=False):
         """
         Insert Unicode properties.
 
         Unicode properties are very forgiving.
-        Case doesn't matter and `[ -_]` will be stripped out.
+        Case doesn't matter and `[ -_]` will be stripped ouaqst.
         """
 
-        # `'GC = Some_Unpredictable-Category Name' -> 'gc=someunpredictablecategoryname'`
-        category = None
-
-        # `\p{^negated}` Strip off the caret after evaluation.
         if props.startswith("^"):
-            negate = not negate
-        if props.startswith("^"):
-            props = props[1:]
+            if negate:
+                props = props[1:]
+        elif negate:
+            props = '^' + props
+        if not prop_value and prop_value is not None:
+            prop_value = None
 
-        # Get the property and value.
-        # If a property is present and not block,
-        # we can assume `GC` as that is all we support.
-        # If we are wrong it will fail.
-        if value:
-            category = props
-            props = value
-
-        v = _uniprops.get_unicode_property(("^" if negate else "") + props, category, self.is_bytes)
+        v = _uniprops.get_unicode_property(props, prop_value, self.is_bytes)
         if not in_group:
             if not v:
                 v = '^%s' % (_uniprops.ASCII_RANGE if self.is_bytes else _uniprops.UNICODE_RANGE)

--- a/backrefs/uniprops/__init__.py
+++ b/backrefs/uniprops/__init__.py
@@ -8,7 +8,7 @@ ASCII_RANGE = '\x00-\xff'
 PY37 = sys.version_info >= (3, 7)
 
 POSIX = 0
-POSIX_ASCII = POSIX_BYTES = 1
+POSIX_ASCII = 1
 POSIX_UNICODE = 2
 
 
@@ -473,24 +473,26 @@ def _is_binary(name):
     return name in unidata.unicode_binary or name in unidata.unicode_alias['binary']
 
 
-def get_unicode_property(value, prop=None, limit_ascii=False):
+def get_unicode_property(prop, value=None, limit_ascii=False):
     """Retrieve the Unicode category from the table."""
 
-    if prop is not None:
+    if value is not None:
 
         # Normalize binary true/false input so we can handle it properly
         if _is_binary(prop):
-            negate = value.startswith('^')
+            negate = prop.startswith('^')
             if negate:
-                value = value[1:]
+                prop = prop[1:]
 
             if value in ('n', 'no', 'f', 'false'):
                 negate = not negate
             elif value not in ('y', 'yes', 't', 'true'):
                 raise ValueError('Invalid Unicode property!')
 
-            value = '^' + prop if negate else prop
-            prop = 'binary'
+            return get_binary_property('^' + prop if negate else prop, limit_ascii)
+        elif prop.startswith('^'):
+            value = '^' + value
+            prop = prop[1:]
 
         prop = unidata.unicode_alias['_'].get(prop, prop)
         try:
@@ -502,8 +504,6 @@ def get_unicode_property(value, prop=None, limit_ascii=False):
                 return get_script_extension_property(value, limit_ascii)
             elif prop == 'block':
                 return get_block_property(value, limit_ascii)
-            elif prop == 'binary':
-                return get_binary_property(value, limit_ascii)
             elif prop == 'bidiclass':
                 return get_bidi_property(value, limit_ascii)
             elif prop == 'bidipairedbrackettype':
@@ -554,32 +554,32 @@ def get_unicode_property(value, prop=None, limit_ascii=False):
             raise ValueError('Invalid Unicode property!')
 
     try:
-        return get_gc_property(value, limit_ascii)
+        return get_gc_property(prop, limit_ascii)
     except Exception:
         pass
 
     try:
-        return get_script_extension_property(value, limit_ascii)
+        return get_binary_property(prop, limit_ascii)
     except Exception:
         pass
 
     try:
-        return get_block_property(value, limit_ascii)
+        return get_script_extension_property(prop, limit_ascii)
     except Exception:
         pass
 
     try:
-        return get_binary_property(value, limit_ascii)
+        return get_block_property(prop, limit_ascii)
     except Exception:
         pass
 
     try:
-        return get_is_property(value, limit_ascii)
+        return get_is_property(prop, limit_ascii)
     except Exception:
         pass
 
     try:
-        return get_in_property(value, limit_ascii)
+        return get_in_property(prop, limit_ascii)
     except Exception:
         pass
 

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -772,6 +772,15 @@ class TestSearchTemplate(unittest.TestCase):
         m = pattern.match(r'P')
         self.assertTrue(m is not None)
 
+    def test_unicode_properties_inverse_value_inverse(self):
+        """Exercising inverse Unicode properties that are using inverse values."""
+
+        pattern = bre.compile_search(r'\P{^Po}', re.UNICODE)
+        m = pattern.match(r'·')
+        self.assertTrue(m is not None)
+        m = pattern.match(r'P')
+        self.assertTrue(m is None)
+
     def test_negated_unicode_properties_inverse(self):
         """Exercising negated inverse Unicode properties."""
 

--- a/tests/test_uniprops.py
+++ b/tests/test_uniprops.py
@@ -12,312 +12,312 @@ class TestUniprops(unittest.TestCase):
     def test_gc(self):
         """Test `General` Category."""
 
-        result = uniprops.get_unicode_property('lu', 'gc')
+        result = uniprops.get_unicode_property('gc', 'lu')
         self.assertEqual(result, uniprops.unidata.unicode_properties['l']['u'])
 
     def test_inverse_gc(self):
         """Test inverse `General` Category."""
 
-        result = uniprops.get_unicode_property('^lu', 'gc')
+        result = uniprops.get_unicode_property('^gc', 'lu')
         self.assertEqual(result, uniprops.unidata.unicode_properties['l']['^u'])
 
     def test_block(self):
         """Test `Block` Category."""
 
-        result = uniprops.get_unicode_property('basiclatin', 'blk')
+        result = uniprops.get_unicode_property('blk', 'basiclatin')
         self.assertEqual(result, uniprops.unidata.unicode_blocks['basiclatin'])
 
     def test_inverse_block(self):
         """Test inverse `Block` Category."""
 
-        result = uniprops.get_unicode_property('^basiclatin', 'blk')
+        result = uniprops.get_unicode_property('^blk', 'basiclatin')
         self.assertEqual(result, uniprops.unidata.unicode_blocks['^basiclatin'])
 
     def test_script(self):
         """Test `script` Category."""
 
-        result = uniprops.get_unicode_property('latin', 'sc')
+        result = uniprops.get_unicode_property('sc', 'latin')
         self.assertEqual(result, uniprops.unidata.unicode_scripts['latin'])
 
     def test_inverse_script(self):
         """Test inverse `script` Category."""
 
-        result = uniprops.get_unicode_property('^latin', 'sc')
+        result = uniprops.get_unicode_property('^sc', 'latin')
         self.assertEqual(result, uniprops.unidata.unicode_scripts['^latin'])
 
     def test_script_extensions(self):
         """Test `script extensions` Category."""
 
-        result = uniprops.get_unicode_property('kana', 'scx')
+        result = uniprops.get_unicode_property('scx', 'kana')
         self.assertEqual(result, uniprops.unidata.unicode_script_extensions['katakana'])
 
     def test_inverse_script_extensions(self):
         """Test inverse `script extensions` Category."""
 
-        result = uniprops.get_unicode_property('^kana', 'scx')
+        result = uniprops.get_unicode_property('^scx', 'kana')
         self.assertEqual(result, uniprops.unidata.unicode_script_extensions['^katakana'])
 
     def test_bidi(self):
         """Test `bidi class` Category."""
 
-        result = uniprops.get_unicode_property('en', 'bc')
+        result = uniprops.get_unicode_property('bc', 'en')
         self.assertEqual(result, uniprops.unidata.unicode_bidi_classes['en'])
 
     def test_inverse_bidi(self):
         """Test inverse `bidi class` Category."""
 
-        result = uniprops.get_unicode_property('^en', 'bc')
+        result = uniprops.get_unicode_property('^bc', 'en')
         self.assertEqual(result, uniprops.unidata.unicode_bidi_classes['^en'])
 
     def test_bidi_paired_bracket_type(self):
         """Test `bidi paired bracket type` Category."""
 
-        result = uniprops.get_unicode_property('o', 'bpt')
+        result = uniprops.get_unicode_property('bpt', 'o')
         self.assertEqual(result, uniprops.unidata.unicode_bidi_paired_bracket_type['o'])
 
     def test_inverse_bidi_paired_bracket_type(self):
         """Test inverse `bidi paired bracket type` Category."""
 
-        result = uniprops.get_unicode_property('^o', 'bpt')
+        result = uniprops.get_unicode_property('^bpt', 'o')
         self.assertEqual(result, uniprops.unidata.unicode_bidi_paired_bracket_type['^o'])
 
     def test_decompostion(self):
         """Test `decomposition type` Category."""
 
-        result = uniprops.get_unicode_property('small', 'dt')
+        result = uniprops.get_unicode_property('dt', 'small')
         self.assertEqual(result, uniprops.unidata.unicode_decomposition_type['small'])
 
     def test_inverse_decompostion(self):
         """Test inverse `decomposition type` Category."""
 
-        result = uniprops.get_unicode_property('^small', 'dt')
+        result = uniprops.get_unicode_property('^dt', 'small')
         self.assertEqual(result, uniprops.unidata.unicode_decomposition_type['^small'])
 
     def test_canonical(self):
         """Test `canonical combining class type` Category."""
 
-        result = uniprops.get_unicode_property('200', 'ccc')
+        result = uniprops.get_unicode_property('ccc', '200')
         self.assertEqual(result, uniprops.unidata.unicode_canonical_combining_class['200'])
 
     def test_inverse_canonical(self):
         """Test inverse `canonical combining class type` Category."""
 
-        result = uniprops.get_unicode_property('^200', 'ccc')
+        result = uniprops.get_unicode_property('^ccc', '200')
         self.assertEqual(result, uniprops.unidata.unicode_canonical_combining_class['^200'])
 
     def test_eastasianwidth(self):
         """Test `east asian width` Category."""
 
-        result = uniprops.get_unicode_property('f', 'ea')
+        result = uniprops.get_unicode_property('ea', 'f')
         self.assertEqual(result, uniprops.unidata.unicode_east_asian_width['f'])
 
     def test_inverse_eastasianwidth(self):
         """Test inverse `east asian width` Category."""
 
-        result = uniprops.get_unicode_property('^f', 'ea')
+        result = uniprops.get_unicode_property('^ea', 'f')
         self.assertEqual(result, uniprops.unidata.unicode_east_asian_width['^f'])
 
     def test_indicpositionalcategory(self):
         """Test `indic positional/matra category` Category."""
 
-        result = uniprops.get_unicode_property('top', 'inpc')
+        result = uniprops.get_unicode_property('inpc', 'top')
         self.assertEqual(result, uniprops.unidata.unicode_indic_positional_category['top'])
 
     def test_inverse_indicpositionalcategory(self):
         """Test inverse `indic positional/matra category` Category."""
 
-        result = uniprops.get_unicode_property('^top', 'inpc')
+        result = uniprops.get_unicode_property('^inpc', 'top')
         self.assertEqual(result, uniprops.unidata.unicode_indic_positional_category['^top'])
 
     def test_indicsylabiccategory(self):
         """Test `indic syllabic category` Category."""
 
-        result = uniprops.get_unicode_property('bindu', 'insc')
+        result = uniprops.get_unicode_property('insc', 'bindu')
         self.assertEqual(result, uniprops.unidata.unicode_indic_syllabic_category['bindu'])
 
     def test_inverse_indicsyllabiccategory(self):
         """Test inverse `indic syllabic category` Category."""
 
-        result = uniprops.get_unicode_property('^bindu', 'insc')
+        result = uniprops.get_unicode_property('^insc', 'bindu')
         self.assertEqual(result, uniprops.unidata.unicode_indic_syllabic_category['^bindu'])
 
     def test_hangulsyllabletype(self):
         """Test `hangul syllable type` Category."""
 
-        result = uniprops.get_unicode_property('l', 'hst')
+        result = uniprops.get_unicode_property('hst', 'l')
         self.assertEqual(result, uniprops.unidata.unicode_hangul_syllable_type['l'])
 
     def test_inverse_hangulsyllabletype(self):
         """Test inverse `hangul syllable type` Category."""
 
-        result = uniprops.get_unicode_property('^l', 'hst')
+        result = uniprops.get_unicode_property('^hst', 'l')
         self.assertEqual(result, uniprops.unidata.unicode_hangul_syllable_type['^l'])
 
     def test_age(self):
         """Test `age` Category."""
 
-        result = uniprops.get_unicode_property('5.0', 'age')
+        result = uniprops.get_unicode_property('age', '5.0')
         self.assertEqual(result, uniprops.unidata.unicode_age['5.0'])
 
     def test_inverse_age(self):
         """Test inverse `age` Category."""
 
-        result = uniprops.get_unicode_property('^5.0', 'age')
+        result = uniprops.get_unicode_property('^age', '5.0')
         self.assertEqual(result, uniprops.unidata.unicode_age['^5.0'])
 
     def test_numerictype(self):
         """Test `numeric type` Category."""
 
-        result = uniprops.get_unicode_property('decimal', 'nt')
+        result = uniprops.get_unicode_property('nt', 'decimal')
         self.assertEqual(result, uniprops.unidata.unicode_numeric_type['decimal'])
 
     def test_inverse_numerictype(self):
         """Test inverse `numeric type` Category."""
 
-        result = uniprops.get_unicode_property('^decimal', 'nt')
+        result = uniprops.get_unicode_property('^nt', 'decimal')
         self.assertEqual(result, uniprops.unidata.unicode_numeric_type['^decimal'])
 
     def test_numericvalue(self):
         """Test `numeric value` Category."""
 
-        result = uniprops.get_unicode_property('1/10', 'nv')
+        result = uniprops.get_unicode_property('nv', '1/10')
         self.assertEqual(result, uniprops.unidata.unicode_numeric_values['1/10'])
 
     def test_inverse_numericvalue(self):
         """Test inverse `numeric value` Category."""
 
-        result = uniprops.get_unicode_property('^1/10', 'nv')
+        result = uniprops.get_unicode_property('^nv', '1/10')
         self.assertEqual(result, uniprops.unidata.unicode_numeric_values['^1/10'])
 
     def test_joiningtype(self):
         """Test `joining type` Category."""
 
-        result = uniprops.get_unicode_property('c', 'jt')
+        result = uniprops.get_unicode_property('jt', 'c')
         self.assertEqual(result, uniprops.unidata.unicode_joining_type['c'])
 
     def test_inverse_joiningtype(self):
         """Test inverse `joining type` Category."""
 
-        result = uniprops.get_unicode_property('^c', 'jt')
+        result = uniprops.get_unicode_property('^jt', 'c')
         self.assertEqual(result, uniprops.unidata.unicode_joining_type['^c'])
 
     def test_joininggroup(self):
         """Test `joining group` Category."""
 
-        result = uniprops.get_unicode_property('e', 'jg')
+        result = uniprops.get_unicode_property('jg', 'e')
         self.assertEqual(result, uniprops.unidata.unicode_joining_group['e'])
 
     def test_inverse_joininggroup(self):
         """Test inverse `joining group` Category."""
 
-        result = uniprops.get_unicode_property('^e', 'jg')
+        result = uniprops.get_unicode_property('^jg', 'e')
         self.assertEqual(result, uniprops.unidata.unicode_joining_group['^e'])
 
     def test_linebreak(self):
         """Test `line break` Category."""
 
-        result = uniprops.get_unicode_property('jl', 'lb')
+        result = uniprops.get_unicode_property('lb', 'jl')
         self.assertEqual(result, uniprops.unidata.unicode_line_break['jl'])
 
     def test_inverse_linebreak(self):
         """Test inverse `line break` Category."""
 
-        result = uniprops.get_unicode_property('^jl', 'lb')
+        result = uniprops.get_unicode_property('^lb', 'jl')
         self.assertEqual(result, uniprops.unidata.unicode_line_break['^jl'])
 
     def test_sentencebreak(self):
         """Test `sentence` break Category."""
 
-        result = uniprops.get_unicode_property('cr', 'sb')
+        result = uniprops.get_unicode_property('sb', 'cr')
         self.assertEqual(result, uniprops.unidata.unicode_sentence_break['cr'])
 
     def test_inverse_sentencebreak(self):
         """Test inverse `sentence` break Category."""
 
-        result = uniprops.get_unicode_property('^cr', 'sb')
+        result = uniprops.get_unicode_property('^sb', 'cr')
         self.assertEqual(result, uniprops.unidata.unicode_sentence_break['^cr'])
 
     def test_wordbreak(self):
         """Test `word break` Category."""
 
-        result = uniprops.get_unicode_property('lf', 'wb')
+        result = uniprops.get_unicode_property('wb', 'lf')
         self.assertEqual(result, uniprops.unidata.unicode_word_break['lf'])
 
     def test_inverse_wordbreak(self):
         """Test inverse `word break` Category."""
 
-        result = uniprops.get_unicode_property('^lf', 'wb')
+        result = uniprops.get_unicode_property('^wb', 'lf')
         self.assertEqual(result, uniprops.unidata.unicode_word_break['^lf'])
 
     def test_graphemeclusterbreak(self):
         """Test `grapheme` cluster break Category."""
 
-        result = uniprops.get_unicode_property('control', 'gcb')
+        result = uniprops.get_unicode_property('gcb', 'control')
         self.assertEqual(result, uniprops.unidata.unicode_grapheme_cluster_break['control'])
 
     def test_inverse_graphemeclusterbreak(self):
         """Test inverse `grapheme` cluster break Category."""
 
-        result = uniprops.get_unicode_property('^control', 'gcb')
+        result = uniprops.get_unicode_property('^gcb', 'control')
         self.assertEqual(result, uniprops.unidata.unicode_grapheme_cluster_break['^control'])
 
     def test_nfcquickcheck(self):
         """Test `nfc` quick check Category."""
 
-        result = uniprops.get_unicode_property('y', 'nfcqc')
+        result = uniprops.get_unicode_property('nfcqc', 'y')
         self.assertEqual(result, uniprops.unidata.unicode_nfc_quick_check['y'])
 
     def test_inverse_nfcquickcheck(self):
         """Test inverse `nfc` quick check Category."""
 
-        result = uniprops.get_unicode_property('^y', 'nfcqc')
+        result = uniprops.get_unicode_property('^nfcqc', 'y')
         self.assertEqual(result, uniprops.unidata.unicode_nfc_quick_check['^y'])
 
     def test_nfkcquickcheck(self):
         """Test `nfkc` quick check Category."""
 
-        result = uniprops.get_unicode_property('y', 'nfkcqc')
+        result = uniprops.get_unicode_property('nfkcqc', 'y')
         self.assertEqual(result, uniprops.unidata.unicode_nfkc_quick_check['y'])
 
     def test_inverse_nfkcquickcheck(self):
         """Test inverse `nfkc` quick check Category."""
 
-        result = uniprops.get_unicode_property('^y', 'nfkcqc')
+        result = uniprops.get_unicode_property('^nfkcqc', 'y')
         self.assertEqual(result, uniprops.unidata.unicode_nfkc_quick_check['^y'])
 
     def test_nfdquickcheck(self):
         """Test `nfd` quick check Category."""
 
-        result = uniprops.get_unicode_property('y', 'nfdqc')
+        result = uniprops.get_unicode_property('nfdqc', 'y')
         self.assertEqual(result, uniprops.unidata.unicode_nfd_quick_check['y'])
 
     def test_inverse_nfdquickcheck(self):
         """Test inverse `nfd` quick check Category."""
 
-        result = uniprops.get_unicode_property('^y', 'nfdqc')
+        result = uniprops.get_unicode_property('^nfdqc', 'y')
         self.assertEqual(result, uniprops.unidata.unicode_nfd_quick_check['^y'])
 
     def test_nfkdquickcheck(self):
         """Test `nfkd` quick check Category."""
 
-        result = uniprops.get_unicode_property('y', 'nfkdqc')
+        result = uniprops.get_unicode_property('nfkdqc', 'y')
         self.assertEqual(result, uniprops.unidata.unicode_nfkd_quick_check['y'])
 
     def test_inverse_nfkdquickcheck(self):
         """Test inverse `nfkd` quick check Category."""
 
-        result = uniprops.get_unicode_property('^y', 'nfkdqc')
+        result = uniprops.get_unicode_property('^nfkdqc', 'y')
         self.assertEqual(result, uniprops.unidata.unicode_nfkd_quick_check['^y'])
 
     def test_vertical_orientation(self):
         """Test `vertical orientation` Category."""
 
         if PY37:
-            result = uniprops.get_unicode_property('u', 'vo')
+            result = uniprops.get_unicode_property('vo', 'u')
             self.assertEqual(result, uniprops.unidata.unicode_vertical_orientation['u'])
         else:
             with self.assertRaises(ValueError) as e:
-                uniprops.get_unicode_property('u', 'vo')
+                uniprops.get_unicode_property('vo', 'u')
 
             self.assertTrue(str(e), 'Invalid Unicode property!')
 
@@ -325,11 +325,11 @@ class TestUniprops(unittest.TestCase):
         """Test inverse `vertical orientation` Category."""
 
         if PY37:
-            result = uniprops.get_unicode_property('^u', 'vo')
+            result = uniprops.get_unicode_property('^vo', 'u')
             self.assertEqual(result, uniprops.unidata.unicode_vertical_orientation['^u'])
         else:
             with self.assertRaises(ValueError) as e:
-                uniprops.get_unicode_property('^u', 'vo')
+                uniprops.get_unicode_property('^vo', 'u')
 
             self.assertTrue(str(e), 'Invalid Unicode property!')
 
@@ -405,47 +405,35 @@ class TestUniprops(unittest.TestCase):
         result = uniprops.get_unicode_property('^basiclatin')
         self.assertEqual(result, uniprops.unidata.unicode_blocks['^basiclatin'])
 
-    def test_binary(self):
-        """Test binary Category."""
-
-        result = uniprops.get_unicode_property('alphabetic', 'binary')
-        self.assertEqual(result, uniprops.unidata.unicode_binary['alphabetic'])
-
     def test_binary_value(self):
         """Test binary Category with a value."""
 
-        result = uniprops.get_unicode_property('true', 'alphabetic')
+        result = uniprops.get_unicode_property('alphabetic', 'true')
         self.assertEqual(result, uniprops.unidata.unicode_binary['alphabetic'])
 
     def test_binary_value_inverted(self):
         """Test binary Category with an inverted value."""
 
-        result = uniprops.get_unicode_property('^true', 'alphabetic')
-        self.assertEqual(result, uniprops.unidata.unicode_binary['^alphabetic'])
-
-    def test_inverse_binary(self):
-        """Test inverse binary Category."""
-
-        result = uniprops.get_unicode_property('^alphabetic', 'binary')
+        result = uniprops.get_unicode_property('^alphabetic', 'true')
         self.assertEqual(result, uniprops.unidata.unicode_binary['^alphabetic'])
 
     def test_inverse_binary_value(self):
         """Test inverse binary Category with a value."""
 
-        result = uniprops.get_unicode_property('false', 'alphabetic')
+        result = uniprops.get_unicode_property('alphabetic', 'false')
         self.assertEqual(result, uniprops.unidata.unicode_binary['^alphabetic'])
 
     def test_inverse_binary_value_inverted(self):
         """Test inverse binary Category with inverted value."""
 
-        result = uniprops.get_unicode_property('^false', 'alphabetic')
+        result = uniprops.get_unicode_property('^alphabetic', 'false')
         self.assertEqual(result, uniprops.unidata.unicode_binary['alphabetic'])
 
     def test_bad_binary(self):
         """Test binary property with bad value."""
 
         with self.assertRaises(ValueError):
-            uniprops.get_unicode_property('bad', 'alphabetic')
+            uniprops.get_unicode_property('alphabetic', 'bad')
 
     def test_binary_simple(self):
         """Test binary simple Category."""
@@ -463,7 +451,7 @@ class TestUniprops(unittest.TestCase):
         """Test property with bad category."""
 
         with self.assertRaises(ValueError) as e:
-            uniprops.get_unicode_property('^alphabetic', 'bad')
+            uniprops.get_unicode_property('^bad', 'alphabetic')
 
         self.assertTrue(str(e), 'Invalid Unicode property!')
 
@@ -471,7 +459,7 @@ class TestUniprops(unittest.TestCase):
         """Test bad property with category."""
 
         with self.assertRaises(ValueError) as e:
-            uniprops.get_unicode_property('^bad', 'binary')
+            uniprops.get_unicode_property('nfkcqc', '^bad')
 
         self.assertTrue(str(e), 'Invalid Unicode property!')
 
@@ -540,6 +528,6 @@ class TestUniprops(unittest.TestCase):
 
         for a, b in [(k, v) for k, v in uniprops.unidata.alias.unicode_alias['_'].items()]:
             for k, v in uniprops.unidata.alias.unicode_alias[b].items():
-                result1 = uniprops.get_unicode_property(k, a)
-                result2 = uniprops.get_unicode_property(v, b)
+                result1 = uniprops.get_unicode_property(a, k)
+                result2 = uniprops.get_unicode_property(b, v)
                 self.assertEqual(result1, result2)

--- a/tools/unidatadownload.py
+++ b/tools/unidatadownload.py
@@ -1,5 +1,4 @@
 """Download `Unicodedata` files."""
-from __future__ import unicode_literals
 import os
 import zipfile
 import codecs

--- a/tools/unipropgen.py
+++ b/tools/unipropgen.py
@@ -1,5 +1,4 @@
 """Generate a Unicode prop table for Python builds."""
-from __future__ import unicode_literals
 import sys
 import unicodedata
 import codecs


### PR DESCRIPTION
Accept inputs the way they are given opposed to manipulating the input.

- Don't require 'binary' as the property with the binary property name
  as the value, just accept the binary property name as the property.
- get_unicode_property should accept the property name first followed
  by the value
- Negation via ^ should be accepted on the property just as it is
  accepted via regular expression syntax.
- Special values that are accepted like property names (script values,
  block values, general property values, etc.) are passed as properties
  and can be negated the same way property names can.