### PR TITLE
Add static typing

### DIFF
--- a/.pyspelling.yml
+++ b/.pyspelling.yml
@@ -73,7 +73,7 @@ matrix:
       context_visible_first: true
       delimiters:
       # Ignore lint (noqa) and coverage (pragma) as well as shebang (#!)
-      - open: '^(?: *(?:noqa\b|pragma: no cover)|!)'
+      - open: '^(?: *(?:noqa\b|pragma: no cover|type: .*?)|!)'
         close: '$'
       # Ignore Python encoding string -*- encoding stuff -*-
       - open: '^ *-\*-'

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-recursive-include backrefs *.py
+recursive-include backrefs *.py py.typed
 prune backrefs/uniprops/unidata
 recursive-include tests *.py
 recursive-include tools *.py *.zip LICENSE

--- a/backrefs/__meta__.py
+++ b/backrefs/__meta__.py
@@ -79,7 +79,11 @@ class Version(namedtuple("Version", ["major", "minor", "micro", "release", "pre"
 
     """
 
-    def __new__(cls, major, minor, micro, release="final", pre=0, post=0, dev=0):
+    def __new__(
+        cls,
+        major: int, minor: int, micro: int, release: str = "final",
+        pre: int = 0, post: int = 0, dev: int = 0
+    ) -> "Version":
         """Validate version info."""
 
         # Ensure all parts are positive integers.
@@ -115,27 +119,27 @@ class Version(namedtuple("Version", ["major", "minor", "micro", "release", "pre"
 
         return super(Version, cls).__new__(cls, major, minor, micro, release, pre, post, dev)
 
-    def _is_pre(self):
+    def _is_pre(self) -> bool:
         """Is prerelease."""
 
-        return self.pre > 0
+        return bool(self.pre > 0)
 
-    def _is_dev(self):
+    def _is_dev(self) -> bool:
         """Is development."""
 
         return bool(self.release < "alpha")
 
-    def _is_post(self):
+    def _is_post(self) -> bool:
         """Is post."""
 
-        return self.post > 0
+        return bool(self.post > 0)
 
-    def _get_dev_status(self):  # pragma: no cover
+    def _get_dev_status(self) -> str:  # pragma: no cover
         """Get development status string."""
 
         return DEV_STATUS[self.release]
 
-    def _get_canonical(self):
+    def _get_canonical(self) -> str:
         """Get the canonical output string."""
 
         # Assemble major, minor, micro version and append `pre`, `post`, or `dev` if needed..
@@ -153,10 +157,13 @@ class Version(namedtuple("Version", ["major", "minor", "micro", "release", "pre"
         return ver
 
 
-def parse_version(ver, pre=False):
+def parse_version(ver: str) -> Version:
     """Parse version into a comparable Version tuple."""
 
     m = RE_VER.match(ver)
+
+    if m is None:
+        raise ValueError("'{}' is not a valid version".format(ver))
 
     # Handle major, minor, micro
     major = int(m.group('major'))

--- a/backrefs/_bre_parse.py
+++ b/backrefs/_bre_parse.py
@@ -10,6 +10,7 @@ from . import util as _util
 import sre_parse as _sre_parse
 import unicodedata as _unicodedata
 from . import uniprops as _uniprops
+from typing import Generic, Tuple, AnyStr, Optional, Match, List, Any, Dict, Union, Pattern
 
 __all__ = ("ReplaceTemplate",)
 
@@ -62,7 +63,7 @@ class GlobalRetryException(Exception):
     """Global retry exception."""
 
 
-class _SearchParser(object):
+class _SearchParser(Generic[AnyStr]):
     """Search Template."""
 
     _new_refs = ("c", "C", "e", "E", "h", "l", "L", "m", "M", "N", "p", "P", "Q", "R", "X")
@@ -71,9 +72,17 @@ class _SearchParser(object):
     _re_end_wb = r"\b(?<=\w)"
     _line_break = r'(?:\r\n|(?!\r\n)[\n\v\f\r\x85\u2028\u2029])'
     _bytes_line_break = r'(?:\r\n|(?!\r\n)[\n\v\f\r\x85])'
-    _grapheme_cluster = r'(?:%s%s*(?!%s))'
+    _grapheme_cluster = r'(?:{}{}*(?!{}))'
 
-    def __init__(self, search, re_verbose=False, re_unicode=None):
+    verbose: bool
+    unicode: bool
+    global_flag_swap: Dict[str, bool]
+    temp_global_flag_swap: Dict[str, bool]
+    ascii: bool  # noqa: A003
+    is_bytes: bool
+    search: AnyStr
+
+    def __init__(self, search: AnyStr, re_verbose: bool = False, re_unicode: Optional[bool] = None) -> None:
         """Initialize."""
 
         if isinstance(search, bytes):
@@ -89,13 +98,13 @@ class _SearchParser(object):
         self.re_verbose = re_verbose
         self.re_unicode = re_unicode
 
-    def process_quotes(self, text):
+    def process_quotes(self, text: str) -> str:
         """Process quotes."""
 
         escaped = False
         in_quotes = False
         current = []
-        quoted = []
+        quoted = []  # type: List[str]
         i = _util.StringIter(text)
 
         for t in i:
@@ -129,7 +138,7 @@ class _SearchParser(object):
 
         return "".join(current)
 
-    def verbose_comment(self, t, i):
+    def verbose_comment(self, t: str, i: _util.StringIter) -> List[str]:
         """Handle verbose comments."""
 
         current = []
@@ -155,7 +164,7 @@ class _SearchParser(object):
             current.append(t)
         return current
 
-    def flags(self, text, scoped=False):
+    def flags(self, text: str, scoped: bool = False) -> None:
         """Analyze flags."""
 
         global_retry = False
@@ -179,7 +188,7 @@ class _SearchParser(object):
         if global_retry:
             raise GlobalRetryException('Global Retry')
 
-    def get_unicode_property(self, i, brackets=False):
+    def get_unicode_property(self, i: _util.StringIter, brackets: bool = False) -> Tuple[str, str]:
         """Get Unicode property."""
 
         index = i.index
@@ -190,7 +199,7 @@ class _SearchParser(object):
             if c.upper() in _ASCII_LETTERS:
                 prop.append(c)
             elif not brackets and c != '{' or brackets and c != ':':
-                raise SyntaxError("Unicode property missing '{' at %d!" % (i.index - 1))
+                raise SyntaxError("Unicode property missing '{{' at {}!".format(i.index - 1))
             else:
                 c = next(i)
                 if c == '^':
@@ -199,7 +208,7 @@ class _SearchParser(object):
 
                 while c not in (':', '=', '}'):
                     if c not in _PROPERTY:
-                        raise SyntaxError('Invalid Unicode property character at %d!' % (i.index - 1))
+                        raise SyntaxError('Invalid Unicode property character at {}!'.format(i.index - 1))
                     if c not in _PROPERTY_STRIP:
                         prop.append(c)
                     c = next(i)
@@ -221,43 +230,43 @@ class _SearchParser(object):
                     if not skip:
                         while c != end:
                             if c not in _PROPERTY:
-                                raise SyntaxError('Invalid Unicode property character at %d!' % (i.index - 1))
+                                raise SyntaxError('Invalid Unicode property character at {}!'.format(i.index - 1))
                             if c not in _PROPERTY_STRIP:
                                 value.append(c)
                             c = next(i)
                         if brackets and c == ':':
                             c = next(i)
                             if c != ']':
-                                raise SyntaxError('Invalid Unicode property character at %d!' % (i.index - 1))
+                                raise SyntaxError('Invalid Unicode property character at {}!'.format(i.index - 1))
                         if not value:
                             raise SyntaxError('Invalid Unicode property!')
 
         except StopIteration:
             if brackets:
-                raise SyntaxError("Missing or unmatched ':]' at %d!" % index)
+                raise SyntaxError("Missing or unmatched ':]' at {}!".format(index))
             else:
-                raise SyntaxError("Missing or unmatched '{' at %d!" % index)
+                raise SyntaxError("Missing or unmatched '{{' at {}!".format(index))
 
         return ''.join(prop).lower(), ''.join(value).lower()
 
-    def get_named_unicode(self, i):
+    def get_named_unicode(self, i: _util.StringIter) -> str:
         """Get Unicode name."""
 
         index = i.index
         value = []
         try:
             if next(i) != '{':
-                raise ValueError("Named Unicode missing '{' %d!" % (i.index - 1))
+                raise ValueError("Named Unicode missing '{{' {}!".format(i.index - 1))
             c = next(i)
             while c != '}':
                 value.append(c)
                 c = next(i)
         except Exception:
-            raise SyntaxError("Unmatched '{' at %d!" % index)
+            raise SyntaxError("Unmatched '{{' at {}!".format(index))
 
         return ''.join(value)
 
-    def reference(self, t, i, in_group=False):
+    def reference(self, t: str, i: _util.StringIter, in_group: bool = False) -> List[str]:
         """Handle references."""
 
         current = []
@@ -271,7 +280,7 @@ class _SearchParser(object):
         elif not in_group and t == "X":
             no_mark = self.unicode_props("^m", None, in_group=False)[0]
             mark = self.unicode_props("m", None, in_group=False)[0]
-            current.extend(self._grapheme_cluster % (no_mark, mark, mark))
+            current.extend(self._grapheme_cluster.format(no_mark, mark, mark))
         elif t == "e":
             current.append(self._re_escape)
         elif t == "h":
@@ -297,7 +306,7 @@ class _SearchParser(object):
             current.extend(["\\", t])
         return current
 
-    def get_comments(self, i):
+    def get_comments(self, i: _util.StringIter) -> Optional[str]:
         """Get comments."""
 
         index = i.index
@@ -324,11 +333,11 @@ class _SearchParser(object):
                 c = next(i)
             value.append(c)
         except StopIteration:
-            raise SyntaxError("Unmatched '(' at %d!" % (index - 1))
+            raise SyntaxError("Unmatched '(' at {}!".format(index - 1))
 
         return ''.join(value)
 
-    def get_flags(self, i, scoped=False):
+    def get_flags(self, i: _util.StringIter, scoped: bool = False) -> Optional[str]:
         """Get flags."""
 
         index = i.index
@@ -362,10 +371,10 @@ class _SearchParser(object):
 
         return ''.join(value) if value else None
 
-    def subgroup(self, t, i):
+    def subgroup(self, t: str, i: _util.StringIter) -> List[str]:
         """Handle parenthesis."""
 
-        current = []
+        current = []  # type: List[str]
 
         # (?flags)
         flags = self.get_flags(i)
@@ -407,14 +416,14 @@ class _SearchParser(object):
             current.append(t)
         return current
 
-    def char_groups(self, t, i):
+    def char_groups(self, t: str, i: _util.StringIter) -> List[str]:
         """Handle character groups."""
 
         current = []
         pos = i.index - 1
         found = False
         escaped = False
-        first = None
+        first = 0
         found_property = False
         self.found_property = False
         self.found_named_unicode = False
@@ -449,7 +458,7 @@ class _SearchParser(object):
                 elif t == "[":
                     index = i.index
                     try:
-                        prop = self.get_unicode_property(i, True)
+                        prop = self.get_unicode_property(i, True)  # type: Optional[Tuple[str, str]]
                     except Exception:
                         prop = None
                         i.rewind(i.index - index)
@@ -484,19 +493,19 @@ class _SearchParser(object):
         # either the Unicode char limit on a narrow system,
         # or the ASCII limit in a byte string pattern.
         if found_property or self.found_named_unicode:
-            value = "".join(current)
-            if value == '[]':
+            temp = "".join(current)
+            if temp == '[]':
                 # We specified some properties, but they are all
                 # out of reach.  Therefore we can match nothing.
-                current = ['[^%s]' % (_uniprops.ASCII_RANGE if self.is_bytes else _uniprops.UNICODE_RANGE)]
-            elif value == '[^]':
-                current = ['[%s]' % (_uniprops.ASCII_RANGE if self.is_bytes else _uniprops.UNICODE_RANGE)]
+                current = ['[^{}]'.format(_uniprops.ASCII_RANGE if self.is_bytes else _uniprops.UNICODE_RANGE)]
+            elif temp == '[^]':
+                current = ['[{}]'.format(_uniprops.ASCII_RANGE if self.is_bytes else _uniprops.UNICODE_RANGE)]
             else:
-                current = [value]
+                current = [temp]
 
         return current
 
-    def normal(self, t, i):
+    def normal(self, t: str, i: _util.StringIter) -> List[str]:
         """Handle normal chars."""
 
         current = []
@@ -517,20 +526,24 @@ class _SearchParser(object):
             current.append(t)
         return current
 
-    def unicode_name(self, name, in_group=False):
+    def unicode_name(self, name: str, in_group: bool = False) -> List[str]:
         """Insert Unicode value by its name."""
 
         value = ord(_unicodedata.lookup(name))
-        if (self.is_bytes and value > 0xFF):
-            value = ""
-        if not in_group and value == "":
-            return '[^%s]' % (_uniprops.ASCII_RANGE if self.is_bytes else _uniprops.UNICODE_RANGE)
-        elif value == "":
-            return value
-        else:
-            return ['\\%03o' % value if value <= 0xFF else chr(value)]
+        if self.is_bytes and value > 0xFF:
+            if not in_group:
+                return ['[^{}]'.format(_uniprops.ASCII_RANGE if self.is_bytes else _uniprops.UNICODE_RANGE)]
+            else:
+                return ['']
+        return ['\\{:03o}'.format(value) if value <= 0xFF else chr(value)]
 
-    def unicode_props(self, props, prop_value, in_group=False, negate=False):
+    def unicode_props(
+        self,
+        props: str,
+        prop_value: Optional[str],
+        in_group: bool = False,
+        negate: bool = False
+    ) -> List[str]:
         """
         Insert Unicode properties.
 
@@ -556,13 +569,13 @@ class _SearchParser(object):
         v = _uniprops.get_unicode_property(props, prop_value, mode)
         if not in_group:
             if not v:
-                v = '^%s' % (_uniprops.ASCII_RANGE if self.is_bytes else _uniprops.UNICODE_RANGE)
-            v = "[%s]" % v
+                v = '^{}'.format(_uniprops.ASCII_RANGE if self.is_bytes else _uniprops.UNICODE_RANGE)
+            v = "[{}]".format(v)
         properties = [v]
 
         return properties
 
-    def main_group(self, i):
+    def main_group(self, i: _util.StringIter) -> List[str]:
         """The main group: group 0."""
 
         current = []
@@ -574,8 +587,8 @@ class _SearchParser(object):
                 break
         return current
 
-    def parse(self):
-        """Apply search template."""
+    def _parse(self, search: str) -> str:
+        """Begin parsing."""
 
         self.verbose = bool(self.re_verbose)
         self.unicode = bool(self.re_unicode)
@@ -592,9 +605,7 @@ class _SearchParser(object):
             self.unicode = True
 
         new_pattern = []
-        text = self.process_quotes(self.search.decode('latin-1') if self.is_bytes else self.search)
-
-        i = _util.StringIter(text)
+        i = _util.StringIter(self.process_quotes(search))
 
         retry = True
         while retry:
@@ -620,28 +631,42 @@ class _SearchParser(object):
                 }
                 i.rewind(i.index)
                 retry = True
+        return "".join(new_pattern)
 
-        return "".join(new_pattern).encode('latin-1') if self.is_bytes else "".join(new_pattern)
+    def parse(self) -> AnyStr:
+        """Apply search template."""
+
+        if isinstance(self.search, bytes):
+            return self._parse(self.search.decode('latin-1')).encode('latin-1')
+        else:
+            return self._parse(self.search)
 
 
-class _ReplaceParser(object):
+class _ReplaceParser(Generic[AnyStr]):
     """Pre-replace template."""
 
-    def __init__(self):
+    def __init__(self, pattern: Pattern[AnyStr], template: AnyStr, use_format: bool = False) -> None:
         """Initialize."""
 
+        self.pattern = pattern  # type: Pattern[AnyStr]
+        self._original = template  # type: AnyStr
+        self._template = template  # type: AnyStr
+        self.use_format = use_format
         self.end_found = False
-        self.group_slots = []
-        self.literal_slots = []
-        self.result = []
-        self.span_stack = []
-        self.single_stack = []
+        self.group_slots = []  # type: List[Tuple[int, Tuple[Optional[int], Optional[int], Any]]]
+        self.literal_slots = []  # type: List[str]
+        self.result = []  # type: List[str]
+        self.span_stack = []  # type: List[int]
+        self.single_stack = []  # type: List[int]
+        self.literals = []  # type: List[Optional[AnyStr]]
+        self.groups = []  # type: List[Tuple[int, int]]
         self.slot = 0
         self.manual = False
         self.auto = False
         self.auto_index = 0
+        self.is_bytes = isinstance(self._original, bytes)
 
-    def parse_format_index(self, text):
+    def parse_format_index(self, text: str) -> Union[int, str]:
         """Parse format index."""
 
         base = 10
@@ -655,40 +680,41 @@ class _ReplaceParser(object):
             elif char == "x":
                 base = 16
         try:
-            text = int(text, base)
+            idx = int(text, base)  # type: Union[int, str]
         except Exception:
-            pass
-        return text
+            idx = text
+        return idx
 
-    def get_format(self, c, i):
+    def get_format(self, c: str, i: _util.StringIter) -> Tuple[str, List[Tuple[int, Any]]]:
         """Get format group."""
 
         index = i.index
         field = ''
-        value = []
+        value = []  # type: List[Tuple[int, Any]]
 
         try:
             if c == '}':
                 value.append((_util.FMT_FIELD, ''))
             else:
                 # Field
+                temp = []  # type: List[str]
                 if c in _LETTERS_UNDERSCORE:
                     # Handle name
-                    value.append(c)
+                    temp.append(c)
                     c = self.format_next(i)
                     while c in _WORD:
-                        value.append(c)
+                        temp.append(c)
                         c = self.format_next(i)
                 elif c in _DIGIT:
                     # Handle group number
-                    value.append(c)
+                    temp.append(c)
                     c = self.format_next(i)
                     while c in _DIGIT:
-                        value.append(c)
+                        temp.append(c)
                         c = self.format_next(i)
 
                 # Try and covert to integer index
-                field = ''.join(value).strip()
+                field = ''.join(temp).strip()
                 try:
                     value = [(_util.FMT_FIELD, str(int(field, 10)))]
                 except ValueError:
@@ -706,7 +732,7 @@ class _ReplaceParser(object):
                                 findex.append(c)
                                 c = self.format_next(i)
                         except StopIteration:
-                            raise SyntaxError("Unmatched '[' at %d" % (sindex - 1))
+                            raise SyntaxError("Unmatched '[' at {}".format(sindex - 1))
                         idx = self.parse_format_index(''.join(findex))
                         if isinstance(idx, int):
                             value.append((_util.FMT_INDEX, idx))
@@ -725,13 +751,13 @@ class _ReplaceParser(object):
                 if c == '!':
                     c = self.format_next(i)
                     if c not in _FMT_CONV_TYPE:
-                        raise SyntaxError("Invalid conversion type at %d!" % (i.index - 1))
+                        raise SyntaxError("Invalid conversion type at {}!".format(i.index - 1))
                     value.append((_util.FMT_CONV, c))
                     c = self.format_next(i)
 
                 # Format spec
                 if c == ':':
-                    fill = None
+                    fill = None  # type: Optional[str]
                     width = []
                     align = None
                     convert = None
@@ -763,7 +789,7 @@ class _ReplaceParser(object):
                             fill = None
                         if fill is not None:
                             if c not in ('<', '>', '^'):
-                                raise SyntaxError('Invalid format spec char at %d!' % (i.index - 1))
+                                raise SyntaxError('Invalid format spec char at {}!'.format(i.index - 1))
                             align = c
                             c = self.format_next(i)
 
@@ -780,21 +806,29 @@ class _ReplaceParser(object):
                         convert = c
                         c = self.format_next(i)
 
-                    if fill and self.is_bytes:
-                        fill = fill.encode('latin-1')
-                    elif not fill:
-                        fill = b' ' if self.is_bytes else ' '
+                    if not fill:
+                        fill = ' '
 
-                    value.append((_util.FMT_SPEC, (fill, align, (int(''.join(width)) if width else 0), convert)))
+                    value.append(
+                        (
+                            _util.FMT_SPEC,
+                            (
+                                fill.encode('latin-1') if self.is_bytes else fill,
+                                align,
+                                (int(''.join(width)) if width else 0),
+                                convert
+                            )
+                        )
+                    )
 
             if c != '}':
-                raise SyntaxError("Unmatched '{' at %d" % (index - 1))
+                raise SyntaxError("Unmatched '{{' at {}".format(index - 1))
         except StopIteration:
-            raise SyntaxError("Unmatched '{' at %d!" % (index - 1))
+            raise SyntaxError("Unmatched '{{' at {}!".format(index - 1))
 
         return field, value
 
-    def handle_format(self, t, i):
+    def handle_format(self, t: str, i: _util.StringIter) -> None:
         """Handle format."""
 
         if t == '{':
@@ -811,9 +845,9 @@ class _ReplaceParser(object):
                 self.get_single_stack()
                 self.result.append(t)
             else:
-                raise SyntaxError("Unmatched '}' at %d!" % (i.index - 2))
+                raise SyntaxError("Unmatched '}}' at {}!".format(i.index - 2))
 
-    def get_octal(self, c, i):
+    def get_octal(self, c: str, i: _util.StringIter) -> Optional[str]:
         """Get octal."""
 
         index = i.index
@@ -844,7 +878,7 @@ class _ReplaceParser(object):
 
         return ''.join(value) if value else None
 
-    def parse_octal(self, text, i):
+    def parse_octal(self, text: str, i: _util.StringIter) -> None:
         """Parse octal value."""
 
         value = int(text, 8)
@@ -861,28 +895,28 @@ class _ReplaceParser(object):
             if self.use_format and value in _CURLY_BRACKETS_ORD:
                 self.handle_format(chr(value), i)
             elif value <= 0xFF:
-                self.result.append('\\%03o' % value)
+                self.result.append('\\{:03o}'.format(value))
             else:
                 self.result.append(chr(value))
 
-    def get_named_unicode(self, i):
+    def get_named_unicode(self, i: _util.StringIter) -> str:
         """Get named Unicode."""
 
         index = i.index
         value = []
         try:
             if next(i) != '{':
-                raise SyntaxError("Named Unicode missing '{'' at %d!" % (i.index - 1))
+                raise SyntaxError("Named Unicode missing '{{' at {}!".format(i.index - 1))
             c = next(i)
             while c != '}':
                 value.append(c)
                 c = next(i)
         except StopIteration:
-            raise SyntaxError("Unmatched '}' at %d!" % index)
+            raise SyntaxError("Unmatched '}}' at {}!".format(index))
 
         return ''.join(value)
 
-    def parse_named_unicode(self, i):
+    def parse_named_unicode(self, i: _util.StringIter) -> None:
         """Parse named Unicode."""
 
         value = ord(_unicodedata.lookup(self.get_named_unicode(i)))
@@ -895,11 +929,11 @@ class _ReplaceParser(object):
         if self.use_format and value in _CURLY_BRACKETS_ORD:
             self.handle_format(chr(value), i)
         elif value <= 0xFF:
-            self.result.append('\\%03o' % value)
+            self.result.append('\\{:03o}'.format(value))
         else:
             self.result.append(chr(value))
 
-    def get_wide_unicode(self, i):
+    def get_wide_unicode(self, i: _util.StringIter) -> str:
         """Get narrow Unicode."""
 
         value = []
@@ -908,23 +942,23 @@ class _ReplaceParser(object):
             if c == '0':
                 value.append(c)
             else:  # pragma: no cover
-                raise SyntaxError('Invalid wide Unicode character at %d!' % (i.index - 1))
+                raise SyntaxError('Invalid wide Unicode character at {}!'.format(i.index - 1))
 
         c = next(i)
         if c in ('0', '1'):
             value.append(c)
         else:  # pragma: no cover
-            raise SyntaxError('Invalid wide Unicode character at %d!' % (i.index - 1))
+            raise SyntaxError('Invalid wide Unicode character at {}!'.format(i.index - 1))
 
         for x in range(4):
             c = next(i)
             if c.lower() in _HEX:
                 value.append(c)
             else:  # pragma: no cover
-                raise SyntaxError('Invalid wide Unicode character at %d!' % (i.index - 1))
+                raise SyntaxError('Invalid wide Unicode character at {}!'.format(i.index - 1))
         return ''.join(value)
 
-    def get_narrow_unicode(self, i):
+    def get_narrow_unicode(self, i: _util.StringIter) -> str:
         """Get narrow Unicode."""
 
         value = []
@@ -933,10 +967,10 @@ class _ReplaceParser(object):
             if c.lower() in _HEX:
                 value.append(c)
             else:  # pragma: no cover
-                raise SyntaxError('Invalid Unicode character at %d!' % (i.index - 1))
+                raise SyntaxError('Invalid Unicode character at {}!'.format(i.index - 1))
         return ''.join(value)
 
-    def parse_unicode(self, i, wide=False):
+    def parse_unicode(self, i: _util.StringIter, wide: bool = False) -> None:
         """Parse Unicode."""
 
         text = self.get_wide_unicode(i) if wide else self.get_narrow_unicode(i)
@@ -950,11 +984,11 @@ class _ReplaceParser(object):
         if self.use_format and value in _CURLY_BRACKETS_ORD:
             self.handle_format(chr(value), i)
         elif value <= 0xFF:
-            self.result.append('\\%03o' % value)
+            self.result.append('\\{:03o}'.format(value))
         else:
             self.result.append(chr(value))
 
-    def get_byte(self, i):
+    def get_byte(self, i: _util.StringIter) -> str:
         """Get byte."""
 
         value = []
@@ -963,10 +997,10 @@ class _ReplaceParser(object):
             if c.lower() in _HEX:
                 value.append(c)
             else:  # pragma: no cover
-                raise SyntaxError('Invalid byte character at %d!' % (i.index - 1))
+                raise SyntaxError('Invalid byte character at {}!'.format(i.index - 1))
         return ''.join(value)
 
-    def parse_bytes(self, i):
+    def parse_bytes(self, i: _util.StringIter) -> None:
         """Parse byte."""
 
         value = int(self.get_byte(i), 16)
@@ -979,9 +1013,9 @@ class _ReplaceParser(object):
         if self.use_format and value in _CURLY_BRACKETS_ORD:
             self.handle_format(chr(value), i)
         else:
-            self.result.append('\\%03o' % value)
+            self.result.append('\\{:03o}'.format(value))
 
-    def get_named_group(self, t, i):
+    def get_named_group(self, t: str, i: _util.StringIter) -> str:
         """Get group number."""
 
         index = i.index
@@ -989,7 +1023,7 @@ class _ReplaceParser(object):
         try:
             c = next(i)
             if c != "<":
-                raise SyntaxError("Group missing '<' at %d!" % (i.index - 1))
+                raise SyntaxError("Group missing '<' at {}!".format(i.index - 1))
             value.append(c)
             c = next(i)
             if c in _DIGIT:
@@ -1009,17 +1043,17 @@ class _ReplaceParser(object):
                     c = next(i)
                 value.append(c)
             else:
-                raise SyntaxError("Invalid group character at %d!" % (i.index - 1))
+                raise SyntaxError("Invalid group character at {}!".format(i.index - 1))
         except StopIteration:
-            raise SyntaxError("Unmatched '<' at %d!" % index)
+            raise SyntaxError("Unmatched '<' at {}!".format(index))
 
         return ''.join(value)
 
-    def get_group(self, t, i):
+    def get_group(self, t: str, i: _util.StringIter) -> Optional[str]:
         """Get group number."""
 
+        value = []
         try:
-            value = []
             if t in _DIGIT and t != '0':
                 value.append(t)
                 t = next(i)
@@ -1031,22 +1065,22 @@ class _ReplaceParser(object):
             pass
         return ''.join(value) if value else None
 
-    def format_next(self, i):
+    def format_next(self, i: _util.StringIter) -> str:
         """Get next format char."""
 
         c = next(i)
         return self.format_references(next(i), i) if c == '\\' else c
 
-    def format_references(self, t, i):
+    def format_references(self, t: str, i: _util.StringIter) -> str:
         """Handle format references."""
 
         octal = self.get_octal(t, i)
         if octal:
-            value = int(octal, 8)
-            if value > 0xFF and self.is_bytes:
+            o = int(octal, 8)
+            if o > 0xFF and self.is_bytes:
                 # Re fails on octal greater than `0o377` or `0xFF`
                 raise ValueError("octal escape value outside of range 0-0o377!")
-            value = chr(value)
+            value = chr(o)
         elif t in _STANDARD_ESCAPES or t == '\\':
             value = _BACK_SLASH_TRANSLATION['\\' + t]
         elif not self.is_bytes and t == "U":
@@ -1062,7 +1096,7 @@ class _ReplaceParser(object):
             value = '\\'
         return value
 
-    def reference(self, t, i):
+    def reference(self, t: str, i: _util.StringIter) -> None:
         """Handle references."""
         octal = self.get_octal(t, i)
         if t in _OCTAL and octal:
@@ -1106,12 +1140,12 @@ class _ReplaceParser(object):
                 value = self.convert_case(value, self.span_stack[-1])
             self.result.append(value)
 
-    def parse_template(self, pattern):
+    def _parse_template(self, template: str) -> str:
         """Parse template."""
 
-        i = _util.StringIter((self._original.decode('latin-1') if self.is_bytes else self._original))
-
         self.result = [""]
+
+        i = _util.StringIter(template)
 
         while True:
             try:
@@ -1137,13 +1171,19 @@ class _ReplaceParser(object):
             self.result.append("")
             self.slot += 1
 
-        if self.is_bytes:
-            self._template = "".join(self.literal_slots).encode('latin-1')
-        else:
-            self._template = "".join(self.literal_slots)
-        self.groups, self.literals = _sre_parse.parse_template(self._template, pattern)
+        return "".join(self.literal_slots)
 
-    def span_case(self, i, case):
+    def parse_template(self) -> None:
+        """Parse template."""
+
+        if isinstance(self._original, bytes):
+            self._template = self._parse_template(self._original.decode('latin-1')).encode('latin-1')
+        else:
+            self._template = self._parse_template(self._original)
+
+        self.groups, self.literals = _sre_parse.parse_template(self._template, self.pattern)
+
+    def span_case(self, i: _util.StringIter, case: int) -> None:
         """Uppercase or lowercase the next range of characters until end marker is found."""
 
         # A new \L, \C or \E should pop the last in the stack.
@@ -1176,7 +1216,7 @@ class _ReplaceParser(object):
         if count == len(self.span_stack):
             self.span_stack.pop()
 
-    def convert_case(self, value, case):
+    def convert_case(self, value: str, case: int) -> str:
         """Convert case."""
 
         if self.is_bytes:
@@ -1190,7 +1230,7 @@ class _ReplaceParser(object):
         else:
             return value.lower() if case == _LOWER else value.upper()
 
-    def single_case(self, i, case):
+    def single_case(self, i: _util.StringIter, case: int) -> None:
         """Uppercase or lowercase the next character."""
 
         # Pop a previous case if we have consecutive ones.
@@ -1209,11 +1249,13 @@ class _ReplaceParser(object):
                     self.result.append(t)
                     raise
             elif self.single_stack:
-                self.result.append(self.convert_case(t, self.get_single_stack()))
+                this_case = self.get_single_stack()
+                if this_case is not None:
+                    self.result.append(self.convert_case(t, this_case))
         except StopIteration:
             pass
 
-    def get_single_stack(self):
+    def get_single_stack(self) -> Optional[int]:
         """Get the correct single stack item to use."""
 
         single = None
@@ -1221,7 +1263,7 @@ class _ReplaceParser(object):
             single = self.single_stack.pop()
         return single
 
-    def handle_format_group(self, field, text):
+    def handle_format_group(self, field: str, text: List[Tuple[int, Any]]) -> None:
         """Handle format group."""
 
         # Handle auto incrementing group indexes
@@ -1244,11 +1286,13 @@ class _ReplaceParser(object):
 
         self.handle_group(field, tuple(text), True)
 
-    def handle_group(self, text, capture=None, is_format=False):
+    def handle_group(
+        self,
+        text: str,
+        capture: Optional[Tuple[Tuple[int, Any], ...]] = None,
+        is_format: bool = False
+    ) -> None:
         """Handle groups."""
-
-        if capture is None:
-            capture = tuple() if self.is_bytes else ''
 
         if len(self.result) > 1:
             self.literal_slots.append("".join(self.result))
@@ -1270,49 +1314,60 @@ class _ReplaceParser(object):
                 (
                     (self.span_stack[-1] if self.span_stack else None),
                     self.get_single_stack(),
-                    capture
+                    (tuple() if self.is_bytes else '') if capture is None else capture
                 )
             )
         )
         self.slot += 1
 
-    def get_base_template(self):
+    def get_base_template(self) -> AnyStr:
         """Return the unmodified template before expansion."""
 
         return self._original
 
-    def parse(self, pattern, template, use_format=False):
+    def parse(self) -> 'ReplaceTemplate[AnyStr]':
         """Parse template."""
 
-        if isinstance(template, bytes):
-            self.is_bytes = True
-        else:
-            self.is_bytes = False
-        if isinstance(pattern.pattern, bytes) != self.is_bytes:
+        if not isinstance(self.pattern.pattern, type(self._original)):
             raise TypeError('Pattern string type must match replace template string type!')
-        self._original = template
-        self.use_format = use_format
-        self.parse_template(pattern)
+
+        self.parse_template()
 
         return ReplaceTemplate(
             tuple(self.groups),
             tuple(self.group_slots),
             tuple(self.literals),
-            hash(pattern),
+            hash(self.pattern),
             self.use_format,
             self.is_bytes
         )
 
 
-class ReplaceTemplate(_util.Immutable):
+class ReplaceTemplate(_util.Immutable, Generic[AnyStr]):
     """Replacement template expander."""
 
     __slots__ = ("groups", "group_slots", "literals", "pattern_hash", "use_format", "_hash", "_bytes")
 
-    def __init__(self, groups, group_slots, literals, pattern_hash, use_format, is_bytes):
+    groups: Tuple[Tuple[int, int], ...]
+    group_slots: Tuple[Tuple[int, Tuple[Optional[int], Optional[int], Any]], ...]
+    literals: Tuple[Optional[AnyStr], ...]
+    pattern_hash: int
+    use_format: bool
+    _hash: int
+    _bytes: bool
+
+    def __init__(
+        self,
+        groups: Tuple[Tuple[int, int], ...],
+        group_slots: Tuple[Tuple[int, Tuple[Optional[int], Optional[int], Any]], ...],
+        literals: Tuple[Optional[AnyStr], ...],
+        pattern_hash: int,
+        use_format: bool,
+        is_bytes: bool
+    ) -> None:
         """Initialize."""
 
-        super(ReplaceTemplate, self).__init__(
+        super().__init__(
             use_format=use_format,
             groups=groups,
             group_slots=group_slots,
@@ -1328,17 +1383,17 @@ class ReplaceTemplate(_util.Immutable):
             )
         )
 
-    def __call__(self, m):
+    def __call__(self, m: Optional[Match[AnyStr]]) -> AnyStr:
         """Call."""
 
         return self.expand(m)
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         """Hash."""
 
         return self._hash
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
         """Equal."""
 
         return (
@@ -1351,7 +1406,7 @@ class ReplaceTemplate(_util.Immutable):
             self._bytes == other._bytes
         )
 
-    def __ne__(self, other):
+    def __ne__(self, other: Any) -> bool:
         """Equal."""
 
         return (
@@ -1364,43 +1419,43 @@ class ReplaceTemplate(_util.Immutable):
             self._bytes != self._bytes
         )
 
-    def __repr__(self):  # pragma: no cover
+    def __repr__(self) -> str:  # pragma: no cover
         """Representation."""
 
-        return "%s.%s(%r, %r, %r, %r, %r)" % (
+        return "{}.{}({!r}, {!r}, {!r}, {!r}, {!r})".format(
             self.__module__, self.__class__.__name__,
             self.groups, self.group_slots, self.literals,
             self.pattern_hash, self.use_format
         )
 
-    def _get_group_index(self, index):
+    def _get_group_index(self, index: int) -> int:
         """Find and return the appropriate group index."""
 
-        g_index = None
+        g_index = 0
         for group in self.groups:
             if group[0] == index:
                 g_index = group[1]
                 break
         return g_index
 
-    def _get_group_attributes(self, index):
+    def _get_group_attributes(self, index: int) -> Tuple[Optional[int], Optional[int], Any]:
         """Find and return the appropriate group case."""
 
-        g_case = (None, None, -1)
+        g_case = (None, None, -1)  # type: Tuple[Optional[int], Optional[int], Any]
         for group in self.group_slots:
             if group[0] == index:
                 g_case = group[1]
                 break
         return g_case
 
-    def expand(self, m):
+    def expand(self, m: Optional[Match[AnyStr]]) -> AnyStr:
         """Using the template, expand the string."""
 
         if m is None:
             raise ValueError("Match is None!")
 
         sep = m.string[:0]
-        if isinstance(sep, bytes) != self._bytes:
+        if not isinstance(sep, bytes if self._bytes else str):
             raise TypeError('Match string type does not match expander string type!')
         text = []
         # Expand string
@@ -1415,14 +1470,17 @@ class ReplaceTemplate(_util.Immutable):
                     try:
                         l = m.group(g_index)
                     except IndexError:  # pragma: no cover
-                        raise IndexError("'%d' is out of range!" % g_index)
+                        raise IndexError("'{}' is out of range!".format(g_index))
                 else:
                     # String format replace
                     try:
                         obj = m.group(g_index)
                     except IndexError:  # pragma: no cover
-                        raise IndexError("'%d' is out of range!" % g_index)
-                    l = _util.format_string(m, obj, capture, self._bytes)
+                        raise IndexError("'{}' is out of range!".format(g_index))
+                    if isinstance(sep, bytes):
+                        l = _util.format_bytes(obj, capture)
+                    else:
+                        l = _util.format_string(obj, capture)
                 if span_case is not None:
                     if span_case == _LOWER:
                         l = l.lower()
@@ -1438,7 +1496,7 @@ class ReplaceTemplate(_util.Immutable):
         return sep.join(text)
 
 
-def _pickle(r):
+def _pickle(r):  # type: ignore[no-untyped-def]
     """Pickle."""
 
     return ReplaceTemplate, (r.groups, r.group_slots, r.literals, r.pattern_hash, r.use_format, r._bytes)

--- a/backrefs/_bre_parse.py
+++ b/backrefs/_bre_parse.py
@@ -1469,12 +1469,16 @@ class ReplaceTemplate(_util.Immutable, Generic[AnyStr]):
                     # Non format replace
                     try:
                         l = m.group(g_index)
+                        if l is None:
+                            raise TypeError("Index '{}' returned None type instead of str".format(g_index))
                     except IndexError:  # pragma: no cover
                         raise IndexError("'{}' is out of range!".format(g_index))
                 else:
                     # String format replace
                     try:
                         obj = m.group(g_index)
+                        if obj is None:
+                            raise TypeError("Index '{}' returned None type instead of str".format(g_index))
                     except IndexError:  # pragma: no cover
                         raise IndexError("'{}' is out of range!".format(g_index))
                     if isinstance(sep, bytes):

--- a/backrefs/_bregex_parse.py
+++ b/backrefs/_bregex_parse.py
@@ -7,17 +7,11 @@ Copyright (c) 2011 - 2020 Isaac Muse <isaacmuse@gmail.com>
 import unicodedata as _unicodedata
 import copyreg as _copyreg
 from . import util as _util
-import regex as _regex
-
-try:  # pragma: no cover
-    from regex import __version__ as _regex_version
-except ImportError:  # pragma: no cover
-    from regex.regex import __version__ as _regex_version
-
-try:  # pragma: no cover
-    from regex import _compile_replacement_helper
-except ImportError:  # pragma: no cover
-    from regex.regex import _compile_replacement_helper
+import regex as _regex  # type: ignore[import]
+from typing import Generic, AnyStr, Tuple, Optional, Any, Dict, List, Union, cast
+from ._bregex_typing import Pattern, Match
+from regex.regex import __version__ as _regex_version  # type: ignore[import]
+from regex.regex import _compile_replacement_helper
 
 _REGEX_COMMENT_FIX = tuple([int(x) for x in _regex_version.split('.')]) > (2, 4, 136)
 
@@ -71,7 +65,7 @@ class GlobalRetryException(Exception):
     """Global retry exception."""
 
 
-class _SearchParser(object):
+class _SearchParser(Generic[AnyStr]):
     """Search Template."""
 
     _new_refs = ("e", "R", "Q", "E")
@@ -79,7 +73,14 @@ class _SearchParser(object):
     _line_break = r'(?>\r\n|[\n\v\f\r\x85\u2028\u2029])'
     _bytes_line_break = r'(?>\r\n|[\n\v\f\r\x85])'
 
-    def __init__(self, search, re_verbose=False, re_version=0):
+    verbose: bool
+    version: int
+    global_flag_swap: Dict[str, bool]
+    temp_global_flag_swap: Dict[str, bool]
+    is_bytes: bool
+    search: AnyStr
+
+    def __init__(self, search: AnyStr, re_verbose: bool = False, re_version: int = 0) -> None:
         """Initialize."""
 
         if isinstance(search, bytes):
@@ -95,13 +96,13 @@ class _SearchParser(object):
         self.re_version = re_version
         self.search = search
 
-    def process_quotes(self, text):
+    def process_quotes(self, text: str) -> str:
         """Process quotes."""
 
         escaped = False
         in_quotes = False
         current = []
-        quoted = []
+        quoted = []  # type: List[str]
         i = _util.StringIter(text)
 
         for t in i:
@@ -135,7 +136,7 @@ class _SearchParser(object):
 
         return "".join(current)
 
-    def verbose_comment(self, t, i):
+    def verbose_comment(self, t: str, i: _util.StringIter) -> List[str]:
         """Handle verbose comments."""
 
         current = []
@@ -161,7 +162,7 @@ class _SearchParser(object):
             current.append(t)
         return current
 
-    def flags(self, text, scoped=False):
+    def flags(self, text: str, scoped: bool = False) -> None:
         """Analyze flags."""
 
         global_retry = False
@@ -185,7 +186,7 @@ class _SearchParser(object):
         if global_retry:
             raise GlobalRetryException('Global Retry')
 
-    def reference(self, t, i, in_group=False):
+    def reference(self, t: str, i: _util.StringIter, in_group: bool = False) -> List[str]:
         """Handle references."""
 
         current = []
@@ -198,7 +199,7 @@ class _SearchParser(object):
             current.extend(["\\", t])
         return current
 
-    def get_posix(self, i):
+    def get_posix(self, i: _util.StringIter) -> Optional[str]:
         """Get POSIX."""
 
         index = i.index
@@ -229,7 +230,7 @@ class _SearchParser(object):
             value = []
         return ''.join(value) if value else None
 
-    def get_comments(self, i):
+    def get_comments(self, i: _util.StringIter) -> Optional[str]:
         """Get comments."""
 
         index = i.index
@@ -257,11 +258,11 @@ class _SearchParser(object):
                 c = next(i)
             value.append(c)
         except StopIteration:
-            raise SyntaxError("Unmatched '(' at %d!" % (index - 1))
+            raise SyntaxError("Unmatched '(' at {}!".format(index - 1))
 
         return ''.join(value) if value else None
 
-    def get_flags(self, i, version0, scoped=False):
+    def get_flags(self, i: _util.StringIter, version0: bool, scoped: bool = False) -> Optional[str]:
         """Get flags."""
 
         index = i.index
@@ -300,7 +301,7 @@ class _SearchParser(object):
 
         return ''.join(value) if value else None
 
-    def subgroup(self, t, i):
+    def subgroup(self, t: str, i: _util.StringIter) -> List[str]:
         """Handle parenthesis."""
 
         # (?flags)
@@ -322,7 +323,7 @@ class _SearchParser(object):
             t = flags
             self.flags(flags[2:-1], scoped=True)
 
-        current = []
+        current = []  # type: List[str]
         try:
             while t != ')':
                 if not current:
@@ -339,15 +340,15 @@ class _SearchParser(object):
             current.append(t)
         return current
 
-    def char_groups(self, t, i):
+    def char_groups(self, t: str, i: _util.StringIter) -> List[str]:
         """Handle character groups."""
 
         current = []
         pos = i.index - 1
         found = 0
-        sub_first = None
+        sub_first = 0
         escaped = False
-        first = None
+        first = 0
 
         try:
             while True:
@@ -405,7 +406,7 @@ class _SearchParser(object):
             current.append(t)
         return current
 
-    def normal(self, t, i):
+    def normal(self, t: str, i: _util.StringIter) -> List[str]:
         """Handle normal chars."""
 
         current = []
@@ -426,7 +427,7 @@ class _SearchParser(object):
             current.append(t)
         return current
 
-    def main_group(self, i):
+    def main_group(self, i: _util.StringIter) -> List[str]:
         """The main group: group 0."""
 
         current = []
@@ -438,8 +439,8 @@ class _SearchParser(object):
                 break
         return current
 
-    def parse(self):
-        """Apply search template."""
+    def _parse(self, search: str) -> str:
+        """Begin parsing."""
 
         self.verbose = bool(self.re_verbose)
         self.version = self.re_version if self.re_version else _regex.DEFAULT_VERSION
@@ -453,9 +454,7 @@ class _SearchParser(object):
         }
 
         new_pattern = []
-        text = self.process_quotes(self.search.decode('latin-1') if self.is_bytes else self.search)
-
-        i = _util.StringIter(text)
+        i = _util.StringIter(self.process_quotes(search))
 
         retry = True
         while retry:
@@ -481,28 +480,42 @@ class _SearchParser(object):
                 }
                 i.rewind(i.index)
                 retry = True
+        return "".join(new_pattern)
 
-        return "".join(new_pattern).encode('latin-1') if self.is_bytes else "".join(new_pattern)
+    def parse(self) -> AnyStr:
+        """Apply search template."""
+
+        if isinstance(self.search, bytes):
+            return self._parse(self.search.decode('latin-1')).encode('latin-1')
+        else:
+            return self._parse(self.search)
 
 
-class _ReplaceParser(object):
+class _ReplaceParser(Generic[AnyStr]):
     """Pre-replace template."""
 
-    def __init__(self):
+    def __init__(self, pattern: Pattern[AnyStr], template: AnyStr, use_format: bool = False) -> None:
         """Initialize."""
 
+        self.pattern = pattern  # type: Pattern[AnyStr]
+        self._original = template  # type: AnyStr
+        self._template = template  # type: AnyStr
+        self.use_format = use_format
         self.end_found = False
-        self.group_slots = []
-        self.literal_slots = []
-        self.result = []
-        self.span_stack = []
-        self.single_stack = []
+        self.group_slots = []  # type: List[Tuple[int, Tuple[Optional[int], Optional[int], Any]]]
+        self.literal_slots = []  # type: List[str]
+        self.result = []  # type: List[str]
+        self.span_stack = []  # type: List[int]
+        self.single_stack = []  # type: List[int]
+        self.literals = []  # type: List[Optional[AnyStr]]
+        self.groups = []  # type: List[Tuple[int, int]]
         self.slot = 0
         self.manual = False
         self.auto = False
         self.auto_index = 0
+        self.is_bytes = isinstance(self._original, bytes)
 
-    def parse_format_index(self, text):
+    def parse_format_index(self, text: str) -> Union[int, str]:
         """Parse format index."""
 
         base = 10
@@ -516,17 +529,17 @@ class _ReplaceParser(object):
             elif char == "x":
                 base = 16
         try:
-            text = int(text, base)
+            idx = int(text, base)  # type: Union[int, str]
         except Exception:
-            pass
-        return text
+            idx = text
+        return idx
 
-    def get_format(self, c, i):
+    def get_format(self, c: str, i: _util.StringIter) -> Tuple[str, List[Tuple[int, Any]]]:
         """Get format group."""
 
         index = i.index
         field = ''
-        value = []
+        value = []  # type: List[Tuple[int, Any]]
 
         try:
             if c == '}':
@@ -534,23 +547,24 @@ class _ReplaceParser(object):
                 value.append((_util.FMT_INDEX, -1))
             else:
                 # Field
+                temp = []  # type: List[str]
                 if c in _LETTERS_UNDERSCORE:
                     # Handle name
-                    value.append(c)
+                    temp.append(c)
                     c = self.format_next(i)
                     while c in _WORD:
-                        value.append(c)
+                        temp.append(c)
                         c = self.format_next(i)
                 elif c in _DIGIT:
                     # Handle group number
-                    value.append(c)
+                    temp.append(c)
                     c = self.format_next(i)
                     while c in _DIGIT:
-                        value.append(c)
+                        temp.append(c)
                         c = self.format_next(i)
 
                 # Try and covert to integer index
-                field = ''.join(value).strip()
+                field = ''.join(temp).strip()
                 try:
                     value = [(_util.FMT_FIELD, str(int(field, 10)))]
                 except ValueError:
@@ -569,7 +583,7 @@ class _ReplaceParser(object):
                                 findex.append(c)
                                 c = self.format_next(i)
                         except StopIteration:
-                            raise SyntaxError("Unmatched '[' at %d" % (sindex - 1))
+                            raise SyntaxError("Unmatched '[' at {}".format(sindex - 1))
                         idx = self.parse_format_index(''.join(findex))
                         if isinstance(idx, int):
                             value.append((_util.FMT_INDEX, idx))
@@ -594,13 +608,13 @@ class _ReplaceParser(object):
                 if c == '!':
                     c = self.format_next(i)
                     if c not in _FMT_CONV_TYPE:
-                        raise SyntaxError("Invalid conversion type at %d!" % (i.index - 1))
+                        raise SyntaxError("Invalid conversion type at {}!".format(i.index - 1))
                     value.append((_util.FMT_CONV, c))
                     c = self.format_next(i)
 
                 # Format spec
                 if c == ':':
-                    fill = None
+                    fill = None  # type: Optional[str]
                     width = []
                     align = None
                     convert = None
@@ -632,7 +646,7 @@ class _ReplaceParser(object):
                             fill = None
                         if fill is not None:
                             if c not in ('<', '>', '^'):
-                                raise SyntaxError('Invalid format spec char at %d!' % (i.index - 1))
+                                raise SyntaxError('Invalid format spec char at {}!'.format(i.index - 1))
                             align = c
                             c = self.format_next(i)
 
@@ -649,21 +663,29 @@ class _ReplaceParser(object):
                         convert = c
                         c = self.format_next(i)
 
-                    if fill and self.is_bytes:
-                        fill = fill.encode('latin-1')
-                    elif not fill:
-                        fill = b' ' if self.is_bytes else ' '
+                    if not fill:
+                        fill = ' '
 
-                    value.append((_util.FMT_SPEC, (fill, align, (int(''.join(width)) if width else 0), convert)))
+                    value.append(
+                        (
+                            _util.FMT_SPEC,
+                            (
+                                fill.encode('latin-1') if self.is_bytes else fill,
+                                align,
+                                (int(''.join(width)) if width else 0),
+                                convert
+                            )
+                        )
+                    )
 
             if c != '}':
-                raise SyntaxError("Unmatched '{' at %d" % (index - 1))
+                raise SyntaxError("Unmatched '{{' at {}".format(index - 1))
         except StopIteration:
-            raise SyntaxError("Unmatched '{' at %d!" % (index - 1))
+            raise SyntaxError("Unmatched '{{' at {}!".format(index - 1))
 
         return field, value
 
-    def handle_format(self, t, i):
+    def handle_format(self, t: str, i: _util.StringIter) -> None:
         """Handle format."""
 
         if t == '{':
@@ -680,9 +702,9 @@ class _ReplaceParser(object):
                 self.get_single_stack()
                 self.result.append(t)
             else:
-                raise SyntaxError("Unmatched '}' at %d!" % (i.index - 2))
+                raise SyntaxError("Unmatched '}}' at {}!".format(i.index - 2))
 
-    def get_octal(self, c, i):
+    def get_octal(self, c: str, i: _util.StringIter) -> Optional[str]:
         """Get octal."""
 
         index = i.index
@@ -713,7 +735,7 @@ class _ReplaceParser(object):
 
         return ''.join(value) if value else None
 
-    def parse_octal(self, text, i):
+    def parse_octal(self, text: str, i: _util.StringIter) -> None:
         """Parse octal value."""
 
         value = int(text, 8)
@@ -730,28 +752,28 @@ class _ReplaceParser(object):
             if self.use_format and value in _CURLY_BRACKETS_ORD:
                 self.handle_format(chr(value), i)
             elif value <= 0xFF:
-                self.result.append('\\%03o' % value)
+                self.result.append('\\{:03o}'.format(value))
             else:
                 self.result.append(chr(value))
 
-    def get_named_unicode(self, i):
+    def get_named_unicode(self, i: _util.StringIter) -> str:
         """Get named Unicode."""
 
         index = i.index
         value = []
         try:
             if next(i) != '{':
-                raise SyntaxError("Named Unicode missing '{' at %d!" % (i.index - 1))
+                raise SyntaxError("Named Unicode missing '{{' at {}!".format(i.index - 1))
             c = next(i)
             while c != '}':
                 value.append(c)
                 c = next(i)
         except StopIteration:
-            raise SyntaxError("Unmatched '{' at %d!" % index)
+            raise SyntaxError("Unmatched '{{' at {}!".format(index))
 
         return ''.join(value)
 
-    def parse_named_unicode(self, i):
+    def parse_named_unicode(self, i: _util.StringIter) -> None:
         """Parse named Unicode."""
 
         value = ord(_unicodedata.lookup(self.get_named_unicode(i)))
@@ -764,11 +786,11 @@ class _ReplaceParser(object):
         if self.use_format and value in _CURLY_BRACKETS_ORD:
             self.handle_format(chr(value), i)
         elif value <= 0xFF:
-            self.result.append('\\%03o' % value)
+            self.result.append('\\{:03o}'.format(value))
         else:
             self.result.append(chr(value))
 
-    def get_wide_unicode(self, i):
+    def get_wide_unicode(self, i: _util.StringIter) -> str:
         """Get narrow Unicode."""
 
         value = []
@@ -777,23 +799,23 @@ class _ReplaceParser(object):
             if c == '0':
                 value.append(c)
             else:  # pragma: no cover
-                raise SyntaxError('Invalid wide Unicode character at %d!' % (i.index - 1))
+                raise SyntaxError('Invalid wide Unicode character at {}!'.format(i.index - 1))
 
         c = next(i)
         if c in ('0', '1'):
             value.append(c)
         else:  # pragma: no cover
-            raise SyntaxError('Invalid wide Unicode character at %d!' % (i.index - 1))
+            raise SyntaxError('Invalid wide Unicode character at {}!'.format(i.index - 1))
 
         for x in range(4):
             c = next(i)
             if c.lower() in _HEX:
                 value.append(c)
             else:  # pragma: no cover
-                raise SyntaxError('Invalid wide Unicode character at %d!' % (i.index - 1))
+                raise SyntaxError('Invalid wide Unicode character at {}!'.format(i.index - 1))
         return ''.join(value)
 
-    def get_narrow_unicode(self, i):
+    def get_narrow_unicode(self, i: _util.StringIter) -> str:
         """Get narrow Unicode."""
 
         value = []
@@ -802,10 +824,10 @@ class _ReplaceParser(object):
             if c.lower() in _HEX:
                 value.append(c)
             else:  # pragma: no cover
-                raise SyntaxError('Invalid Unicode character at %d!' % (i.index - 1))
+                raise SyntaxError('Invalid Unicode character at {}!'.format(i.index - 1))
         return ''.join(value)
 
-    def parse_unicode(self, i, wide=False):
+    def parse_unicode(self, i: _util.StringIter, wide: bool = False) -> None:
         """Parse Unicode."""
 
         text = self.get_wide_unicode(i) if wide else self.get_narrow_unicode(i)
@@ -819,11 +841,11 @@ class _ReplaceParser(object):
         if self.use_format and value in _CURLY_BRACKETS_ORD:
             self.handle_format(chr(value), i)
         elif value <= 0xFF:
-            self.result.append('\\%03o' % value)
+            self.result.append('\\{:03o}'.format(value))
         else:
             self.result.append(chr(value))
 
-    def get_byte(self, i):
+    def get_byte(self, i: _util.StringIter) -> str:
         """Get byte."""
 
         value = []
@@ -832,10 +854,10 @@ class _ReplaceParser(object):
             if c.lower() in _HEX:
                 value.append(c)
             else:  # pragma: no cover
-                raise SyntaxError('Invalid byte character at %d!' % (i.index - 1))
+                raise SyntaxError('Invalid byte character at {}!'.format(i.index - 1))
         return ''.join(value)
 
-    def parse_bytes(self, i):
+    def parse_bytes(self, i: _util.StringIter) -> None:
         """Parse byte."""
 
         value = int(self.get_byte(i), 16)
@@ -848,9 +870,9 @@ class _ReplaceParser(object):
         if self.use_format and value in _CURLY_BRACKETS_ORD:
             self.handle_format(chr(value), i)
         else:
-            self.result.append('\\%03o' % value)
+            self.result.append('\\{:03o}'.format(value))
 
-    def get_named_group(self, t, i):
+    def get_named_group(self, t: str, i: _util.StringIter) -> str:
         """Get group number."""
 
         index = i.index
@@ -858,7 +880,7 @@ class _ReplaceParser(object):
         try:
             c = next(i)
             if c != "<":
-                raise SyntaxError("Group missing '<' at %d!" % (i.index - 1))
+                raise SyntaxError("Group missing '<' at {}!".format(i.index - 1))
             value.append(c)
             c = next(i)
             if c in _DIGIT:
@@ -878,17 +900,17 @@ class _ReplaceParser(object):
                     c = next(i)
                 value.append(c)
             else:
-                raise SyntaxError("Invalid group character at %d!" % (i.index - 1))
+                raise SyntaxError("Invalid group character at {}!".format(i.index - 1))
         except StopIteration:
-            raise SyntaxError("Unmatched '<' at %d!" % index)
+            raise SyntaxError("Unmatched '<' at {}!".format(index))
 
         return ''.join(value)
 
-    def get_group(self, t, i):
+    def get_group(self, t: str, i: _util.StringIter) -> Optional[str]:
         """Get group number."""
 
+        value = []
         try:
-            value = []
             if t in _DIGIT and t != '0':
                 value.append(t)
                 t = next(i)
@@ -900,22 +922,22 @@ class _ReplaceParser(object):
             pass
         return ''.join(value) if value else None
 
-    def format_next(self, i):
+    def format_next(self, i: _util.StringIter) -> str:
         """Get next format char."""
 
         c = next(i)
         return self.format_references(next(i), i) if c == '\\' else c
 
-    def format_references(self, t, i):
+    def format_references(self, t: str, i: _util.StringIter) -> str:
         """Handle format references."""
 
         octal = self.get_octal(t, i)
         if octal:
-            value = int(octal, 8)
-            if value > 0xFF and self.is_bytes:
+            o = int(octal, 8)
+            if o > 0xFF and self.is_bytes:
                 # Re fails on octal greater than `0o377` or `0xFF`
                 raise ValueError("octal escape value outside of range 0-0o377!")
-            value = chr(value)
+            value = chr(o)
         elif t in _STANDARD_ESCAPES or t == '\\':
             value = _BACK_SLASH_TRANSLATION['\\' + t]
         elif not self.is_bytes and t == "U":
@@ -931,7 +953,7 @@ class _ReplaceParser(object):
             value = '\\'
         return value
 
-    def reference(self, t, i):
+    def reference(self, t: str, i: _util.StringIter) -> None:
         """Handle references."""
         octal = self.get_octal(t, i)
         if t in _OCTAL and octal:
@@ -975,7 +997,11 @@ class _ReplaceParser(object):
                 value = self.convert_case(value, self.span_stack[-1])
             self.result.append(value)
 
-    def regex_parse_template(self, template, pattern):
+    def regex_parse_template(
+        self,
+        template: AnyStr,
+        pattern: Pattern[AnyStr]
+    ) -> Tuple[List[Tuple[int, int]], List[Optional[AnyStr]]]:
         """
         Parse template for the regex module.
 
@@ -985,9 +1011,9 @@ class _ReplaceParser(object):
         instead.
         """
 
-        groups = []
-        literals = []
-        replacements = _compile_replacement_helper(pattern, template)
+        groups = []  # type: List[Tuple[int, int]]
+        literals = []  # type: List[Optional[AnyStr]]
+        replacements = _compile_replacement_helper(pattern, template)  # type: List[Union[int, AnyStr]]
         count = 0
         for part in replacements:
             if isinstance(part, int):
@@ -998,12 +1024,12 @@ class _ReplaceParser(object):
             count += 1
         return groups, literals
 
-    def parse_template(self, pattern):
+    def _parse_template(self, template: str) -> str:
         """Parse template."""
 
-        i = _util.StringIter((self._original.decode('latin-1') if self.is_bytes else self._original))
-
         self.result = [""]
+
+        i = _util.StringIter(template)
 
         while True:
             try:
@@ -1029,13 +1055,19 @@ class _ReplaceParser(object):
             self.result.append("")
             self.slot += 1
 
-        if self.is_bytes:
-            self._template = "".join(self.literal_slots).encode('latin-1')
-        else:
-            self._template = "".join(self.literal_slots)
-        self.groups, self.literals = self.regex_parse_template(self._template, pattern)
+        return "".join(self.literal_slots)
 
-    def span_case(self, i, case):
+    def parse_template(self) -> None:
+        """Parse template."""
+
+        if isinstance(self._original, bytes):
+            self._template = self._parse_template(self._original.decode('latin-1')).encode('latin-1')
+        else:
+            self._template = self._parse_template(self._original)
+
+        self.groups, self.literals = self.regex_parse_template(self._template, self.pattern)
+
+    def span_case(self, i: _util.StringIter, case: int) -> None:
         """Uppercase or lowercase the next range of characters until end marker is found."""
 
         # A new \L, \C or \E should pop the last in the stack.
@@ -1068,7 +1100,7 @@ class _ReplaceParser(object):
         if count == len(self.span_stack):
             self.span_stack.pop()
 
-    def convert_case(self, value, case):
+    def convert_case(self, value: str, case: int) -> str:
         """Convert case."""
 
         if self.is_bytes:
@@ -1082,7 +1114,7 @@ class _ReplaceParser(object):
         else:
             return value.lower() if case == _LOWER else value.upper()
 
-    def single_case(self, i, case):
+    def single_case(self, i: _util.StringIter, case: int) -> None:
         """Uppercase or lowercase the next character."""
 
         # Pop a previous case if we have consecutive ones.
@@ -1100,12 +1132,14 @@ class _ReplaceParser(object):
                 except StopIteration:
                     self.result.append(t)
                     raise
-            elif self.single_stack:
-                self.result.append(self.convert_case(t, self.get_single_stack()))
+            else:
+                this_case = self.get_single_stack()
+                if this_case is not None:
+                    self.result.append(self.convert_case(t, this_case))
         except StopIteration:
             pass
 
-    def get_single_stack(self):
+    def get_single_stack(self) -> Optional[int]:
         """Get the correct single stack item to use."""
 
         single = None
@@ -1113,7 +1147,7 @@ class _ReplaceParser(object):
             single = self.single_stack.pop()
         return single
 
-    def handle_format_group(self, field, text):
+    def handle_format_group(self, field: str, text: List[Tuple[int, Any]]) -> None:
         """Handle format group."""
 
         # Handle auto incrementing group indexes
@@ -1136,11 +1170,13 @@ class _ReplaceParser(object):
 
         self.handle_group(field, tuple(text), True)
 
-    def handle_group(self, text, capture=None, is_format=False):
+    def handle_group(
+        self,
+        text: str,
+        capture: Optional[Tuple[Tuple[int, Any], ...]] = None,
+        is_format: bool = False
+    ) -> None:
         """Handle groups."""
-
-        if capture is None:
-            capture = tuple() if self.is_bytes else ''
 
         if len(self.result) > 1:
             self.literal_slots.append("".join(self.result))
@@ -1162,49 +1198,60 @@ class _ReplaceParser(object):
                 (
                     (self.span_stack[-1] if self.span_stack else None),
                     self.get_single_stack(),
-                    capture
+                    (tuple() if self.is_bytes else '') if capture is None else capture
                 )
             )
         )
         self.slot += 1
 
-    def get_base_template(self):
+    def get_base_template(self) -> AnyStr:
         """Return the unmodified template before expansion."""
 
         return self._original
 
-    def parse(self, pattern, template, use_format=False):
+    def parse(self) -> 'ReplaceTemplate[AnyStr]':
         """Parse template."""
 
-        if isinstance(template, bytes):
-            self.is_bytes = True
-        else:
-            self.is_bytes = False
-        if isinstance(pattern.pattern, bytes) != self.is_bytes:
+        if not isinstance(self.pattern.pattern, type(self._original)):
             raise TypeError('Pattern string type must match replace template string type!')
-        self._original = template
-        self.use_format = use_format
-        self.parse_template(pattern)
+
+        self.parse_template()
 
         return ReplaceTemplate(
             tuple(self.groups),
             tuple(self.group_slots),
             tuple(self.literals),
-            hash(pattern),
+            hash(self.pattern),
             self.use_format,
             self.is_bytes
         )
 
 
-class ReplaceTemplate(_util.Immutable):
+class ReplaceTemplate(_util.Immutable, Generic[AnyStr]):
     """Replacement template expander."""
 
     __slots__ = ("groups", "group_slots", "literals", "pattern_hash", "use_format", "_hash", "_bytes")
 
-    def __init__(self, groups, group_slots, literals, pattern_hash, use_format, is_bytes):
+    groups: Tuple[Tuple[int, int], ...]
+    group_slots: Tuple[Tuple[int, Tuple[Optional[int], Optional[int], Any]], ...]
+    literals: Tuple[Optional[AnyStr], ...]
+    pattern_hash: int
+    use_format: bool
+    _hash: int
+    _bytes: bool
+
+    def __init__(
+        self,
+        groups: Tuple[Tuple[int, int], ...],
+        group_slots: Tuple[Tuple[int, Tuple[Optional[int], Optional[int], Any]], ...],
+        literals: Tuple[Optional[AnyStr], ...],
+        pattern_hash: int,
+        use_format: bool,
+        is_bytes: bool
+    ) -> None:
         """Initialize."""
 
-        super(ReplaceTemplate, self).__init__(
+        super().__init__(
             use_format=use_format,
             groups=groups,
             group_slots=group_slots,
@@ -1220,17 +1267,17 @@ class ReplaceTemplate(_util.Immutable):
             )
         )
 
-    def __call__(self, m):
+    def __call__(self, m: Optional[Match[AnyStr]]) -> AnyStr:
         """Call."""
 
         return self.expand(m)
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         """Hash."""
 
         return self._hash
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
         """Equal."""
 
         return (
@@ -1243,7 +1290,7 @@ class ReplaceTemplate(_util.Immutable):
             self._bytes == other._bytes
         )
 
-    def __ne__(self, other):
+    def __ne__(self, other: Any) -> bool:
         """Equal."""
 
         return (
@@ -1256,65 +1303,71 @@ class ReplaceTemplate(_util.Immutable):
             self._bytes != other._bytes
         )
 
-    def __repr__(self):  # pragma: no cover
+    def __repr__(self) -> str:  # pragma: no cover
         """Representation."""
 
-        return "%s.%s(%r, %r, %r, %r, %r)" % (
+        return "{}.{}({!r}, {!r}, {!r}, {!r}, {!r})".format(
             self.__module__, self.__class__.__name__,
             self.groups, self.group_slots, self.literals,
             self.pattern_hash, self.use_format
         )
 
-    def _get_group_index(self, index):
+    def _get_group_index(self, index: int) -> int:
         """Find and return the appropriate group index."""
 
-        g_index = None
+        g_index = 0
         for group in self.groups:
             if group[0] == index:
                 g_index = group[1]
                 break
         return g_index
 
-    def _get_group_attributes(self, index):
+    def _get_group_attributes(self, index: int) -> Tuple[Optional[int], Optional[int], Any]:
         """Find and return the appropriate group case."""
 
-        g_case = (None, None, -1)
+        g_case = (None, None, -1)  # type: Tuple[Optional[int], Optional[int], Any]
         for group in self.group_slots:
             if group[0] == index:
                 g_case = group[1]
                 break
         return g_case
 
-    def expand(self, m):
+    def expand(self, m: Optional[Match[AnyStr]]) -> AnyStr:
         """Using the template, expand the string."""
 
         if m is None:
             raise ValueError("Match is None!")
 
-        sep = m.string[:0]
+        sep = m.re.pattern[:0]
         if isinstance(sep, bytes) != self._bytes:
             raise TypeError('Match string type does not match expander string type!')
         text = []
         # Expand string
-        for x in range(0, len(self.literals)):
-            index = x
-            l = self.literals[x]
+        for index in range(0, len(self.literals)):
+            l = self.literals[index]  # type: Optional[AnyStr]
             if l is None:
                 g_index = self._get_group_index(index)
                 span_case, single_case, capture = self._get_group_attributes(index)
                 if not self.use_format:
                     # Non format replace
                     try:
-                        l = m.group(g_index)
+                        l = cast(Optional[AnyStr], m.group(g_index))
+                        if l is None:
+                            raise TypeError("Index '{}' returned None type instead of str".format(g_index))
                     except IndexError:  # pragma: no cover
-                        raise IndexError("'%d' is out of range!" % capture)
+                        raise IndexError("'{}' is out of range!".format(g_index))
                 else:
                     # String format replace
                     try:
-                        obj = m.captures(g_index)
+                        obj = cast(Optional[AnyStr], m.captures(g_index))
+                        if obj is None:
+                            raise TypeError("Index '{}' returned None type instead of str".format(g_index))
                     except IndexError:  # pragma: no cover
-                        raise IndexError("'%d' is out of range!" % g_index)
-                    l = _util.format_string(m, obj, capture, self._bytes)
+                        raise IndexError("'{}' is out of range!".format(g_index))
+                    if isinstance(sep, bytes):
+                        l = _util.format_bytes(obj, capture)
+                    else:
+                        l = _util.format_string(obj, capture)
                 if span_case is not None:
                     if span_case == _LOWER:
                         l = l.lower()
@@ -1330,7 +1383,7 @@ class ReplaceTemplate(_util.Immutable):
         return sep.join(text)
 
 
-def _pickle(r):
+def _pickle(r):  # type: ignore[no-untyped-def]
     """Pickle."""
 
     return ReplaceTemplate, (r.groups, r.group_slots, r.literals, r.pattern_hash, r.use_format, r._bytes)

--- a/backrefs/_bregex_parse.py
+++ b/backrefs/_bregex_parse.py
@@ -1359,9 +1359,9 @@ class ReplaceTemplate(_util.Immutable, Generic[AnyStr]):
                 else:
                     # String format replace
                     try:
-                        obj = cast(Optional[AnyStr], m.captures(g_index))
-                        if obj is None:
-                            raise TypeError("Index '{}' returned None type instead of str".format(g_index))
+                        obj = cast(List[AnyStr], m.captures(g_index))
+                        if not obj:
+                            raise TypeError("Index '{}' returned no captures".format(g_index))
                     except IndexError:  # pragma: no cover
                         raise IndexError("'{}' is out of range!".format(g_index))
                     if isinstance(sep, bytes):

--- a/backrefs/_bregex_parse.py
+++ b/backrefs/_bregex_parse.py
@@ -1338,7 +1338,7 @@ class ReplaceTemplate(_util.Immutable, Generic[AnyStr]):
         if m is None:
             raise ValueError("Match is None!")
 
-        sep = m.re.pattern[:0]
+        sep = m.re.pattern[:0]  # type: AnyStr
         if isinstance(sep, bytes) != self._bytes:
             raise TypeError('Match string type does not match expander string type!')
         text = []

--- a/backrefs/_bregex_typing.py
+++ b/backrefs/_bregex_typing.py
@@ -1,109 +1,20 @@
 """Typing objects for the Regex library."""
-from typing import Mapping, Union, Generic, Tuple, Optional, Set, List, Iterator, Callable, Any, AnyStr
+from typing import AnyStr
+import regex  # type: ignore[import]
+import sys
 
+if sys.version_info >= (3, 7):
+    from typing import _alias  # type: ignore[attr-defined]
 
-class Pattern(Generic[AnyStr]):
-    """
-    Pattern type for the Regex library.
+    if sys.version_info >= (3, 9):
+        Pattern = _alias(type(regex.compile('')), 1)
+        Match = _alias(type(regex.compile('').match('')), 1)
+    else:
+        Pattern = _alias(type(regex.compile('')), AnyStr)
+        Match = _alias(type(regex.compile('').match('')), AnyStr)
 
-    Only specify what we need to.
-    """
+elif sys.version_info:
+    from typing import _TypeAlias  # type: ignore[attr-defined]
 
-    pattern: AnyStr
-    flags: int
-    groupindex: Mapping[str, int]
-    groups: Tuple[Optional[AnyStr], ...]
-    named_lists: Mapping[str, Set[Union[str, bytes]]]
-    scanner: Any
-
-    def search(self, string: AnyStr, *args: Any, **kwargs: Any) -> 'Optional[Match[AnyStr]]':
-        """Search."""
-
-    def match(self, string: AnyStr, *args: Any, **kwargs: Any) -> 'Optional[Match[AnyStr]]':
-        """Match."""
-
-    def fullmatch(self, string: AnyStr, *args: Any, **kwargs: Any) -> 'Optional[Match[AnyStr]]':
-        """Full match."""
-
-    def split(self, string: AnyStr, *args: Any, **kwargs: Any) -> List[AnyStr]:
-        """Split."""
-
-    def splititer(self, string: AnyStr, *args: Any, **kwargs: Any) -> Iterator[AnyStr]:
-        """Split as iterator."""
-
-    def findall(self, string: AnyStr, *args: Any, **kwargs: Any) -> Union[List[AnyStr], List[Tuple[AnyStr, ...]]]:
-        """Find all."""
-
-    def finditer(self, string: AnyStr, *args: Any, **kwargs: Any) -> Iterator['Match[AnyStr]']:
-        """Find as iterator."""
-
-    def sub(self, repl: Union[AnyStr, Callable[..., AnyStr]], string: AnyStr, *args: Any, **kwargs: Any) -> AnyStr:
-        """Substitute."""
-
-    def subf(self, repl: Union[AnyStr, Callable[..., AnyStr]], string: AnyStr, *args: Any, **kwargs: Any) -> AnyStr:
-        """Substitute with format string."""
-
-    def subn(
-        self, repl: Union[AnyStr, Callable[..., AnyStr]], string: AnyStr, *args: Any, **kwargs: Any
-    ) -> Tuple[AnyStr, int]:
-        """Substitute and return replacement count."""
-
-    def subfn(
-        self, repl: Union[AnyStr, Callable[..., AnyStr]], string: AnyStr, *args: Any, **kwargs: Any
-    ) -> Tuple[AnyStr, int]:
-        """Substitute with format string and return replacement count."""
-
-
-class Match(Generic[AnyStr]):
-    """
-    Match type for the Regex library.
-
-    Only specify what we need to.
-    """
-
-    re: Pattern[AnyStr]
-    string: Optional[AnyStr]
-    pos: int
-    endpos: int
-    regs: Tuple[Tuple[int, int], ...]
-    lastindex: int
-    fuzzy_counts: Tuple[int, ...]
-    fuzzy_changes: Tuple[List[int], ...]
-    lastgroup: Optional[str]
-    partial: bool
-
-    def group(self, *index: Union[str, int]) -> Union[Optional[AnyStr], Tuple[Optional[AnyStr], ...]]:
-        """Get group."""
-
-    def groups(self, default: Optional[Any] = None) -> Union[AnyStr, Optional[Any]]:
-        """Get groups."""
-
-    def groupdict(self, default: Optional[Any] = None) -> Mapping[str, Optional[Any]]:
-        """Get group dictionary."""
-
-    def captures(self, *index: Union[str, int]) -> Union[List[AnyStr], Tuple[List[AnyStr], ...]]:
-        """Get captures."""
-
-    def capturesdict(self) -> Mapping[str, List[AnyStr]]:
-        """Get captures dictionary."""
-
-    def start(self, *index: Union[str, int]) -> Union[int, Tuple[int, ...]]:
-        """Get start position by group."""
-
-    def end(self, *index: Union[str, int]) -> Union[int, Tuple[int, ...]]:
-        """Get end position by group."""
-
-    def detach_string(self) -> None:
-        """Detach string."""
-
-    def span(self, *index: Union[str, int]) -> Union[Tuple[int, int], Tuple[Tuple[int, int], ...]]:
-        """Return span of groups."""
-
-    def spans(self, *index: Union[str, int]) -> Union[List[Tuple[int, int]], Tuple[List[Tuple[int, int]], ...]]:
-        """Return span of groups."""
-
-    def expand(self, template: AnyStr) -> AnyStr:
-        """Expand replacement template."""
-
-    def expandf(self, template: AnyStr) -> AnyStr:
-        """Expand format replacement template."""
+    Pattern = _TypeAlias('Pattern', AnyStr, type(regex.compile('')), lambda p: p.pattern)
+    Match = _TypeAlias('Match', AnyStr, type(regex.compile('').match('')), lambda m: m.re.pattern)

--- a/backrefs/_bregex_typing.py
+++ b/backrefs/_bregex_typing.py
@@ -1,0 +1,109 @@
+"""Typing objects for the Regex library."""
+from typing import Mapping, Union, Generic, Tuple, Optional, Set, List, Iterator, Callable, Any, AnyStr
+
+
+class Pattern(Generic[AnyStr]):
+    """
+    Pattern type for the Regex library.
+
+    Only specify what we need to.
+    """
+
+    pattern: AnyStr
+    flags: int
+    groupindex: Mapping[str, int]
+    groups: Tuple[Optional[AnyStr], ...]
+    named_lists: Mapping[str, Set[Union[str, bytes]]]
+    scanner: Any
+
+    def search(self, string: AnyStr, *args: Any, **kwargs: Any) -> 'Optional[Match[AnyStr]]':
+        """Search."""
+
+    def match(self, string: AnyStr, *args: Any, **kwargs: Any) -> 'Optional[Match[AnyStr]]':
+        """Match."""
+
+    def fullmatch(self, string: AnyStr, *args: Any, **kwargs: Any) -> 'Optional[Match[AnyStr]]':
+        """Full match."""
+
+    def split(self, string: AnyStr, *args: Any, **kwargs: Any) -> List[AnyStr]:
+        """Split."""
+
+    def splititer(self, string: AnyStr, *args: Any, **kwargs: Any) -> Iterator[AnyStr]:
+        """Split as iterator."""
+
+    def findall(self, string: AnyStr, *args: Any, **kwargs: Any) -> Union[List[AnyStr], List[Tuple[AnyStr, ...]]]:
+        """Find all."""
+
+    def finditer(self, string: AnyStr, *args: Any, **kwargs: Any) -> Iterator['Match[AnyStr]']:
+        """Find as iterator."""
+
+    def sub(self, repl: Union[AnyStr, Callable[..., AnyStr]], string: AnyStr, *args: Any, **kwargs: Any) -> AnyStr:
+        """Substitute."""
+
+    def subf(self, repl: Union[AnyStr, Callable[..., AnyStr]], string: AnyStr, *args: Any, **kwargs: Any) -> AnyStr:
+        """Substitute with format string."""
+
+    def subn(
+        self, repl: Union[AnyStr, Callable[..., AnyStr]], string: AnyStr, *args: Any, **kwargs: Any
+    ) -> Tuple[AnyStr, int]:
+        """Substitute and return replacement count."""
+
+    def subfn(
+        self, repl: Union[AnyStr, Callable[..., AnyStr]], string: AnyStr, *args: Any, **kwargs: Any
+    ) -> Tuple[AnyStr, int]:
+        """Substitute with format string and return replacement count."""
+
+
+class Match(Generic[AnyStr]):
+    """
+    Match type for the Regex library.
+
+    Only specify what we need to.
+    """
+
+    re: Pattern[AnyStr]
+    string: Optional[AnyStr]
+    pos: int
+    endpos: int
+    regs: Tuple[Tuple[int, int], ...]
+    lastindex: int
+    fuzzy_counts: Tuple[int, ...]
+    fuzzy_changes: Tuple[List[int], ...]
+    lastgroup: Optional[str]
+    partial: bool
+
+    def group(self, *index: Union[str, int]) -> Union[Optional[AnyStr], Tuple[Optional[AnyStr], ...]]:
+        """Get group."""
+
+    def groups(self, default: Optional[Any] = None) -> Union[AnyStr, Optional[Any]]:
+        """Get groups."""
+
+    def groupdict(self, default: Optional[Any] = None) -> Mapping[str, Optional[Any]]:
+        """Get group dictionary."""
+
+    def captures(self, *index: Union[str, int]) -> Union[List[AnyStr], Tuple[List[AnyStr], ...]]:
+        """Get captures."""
+
+    def capturesdict(self) -> Mapping[str, List[AnyStr]]:
+        """Get captures dictionary."""
+
+    def start(self, *index: Union[str, int]) -> Union[int, Tuple[int, ...]]:
+        """Get start position by group."""
+
+    def end(self, *index: Union[str, int]) -> Union[int, Tuple[int, ...]]:
+        """Get end position by group."""
+
+    def detach_string(self) -> None:
+        """Detach string."""
+
+    def span(self, *index: Union[str, int]) -> Union[Tuple[int, int], Tuple[Tuple[int, int], ...]]:
+        """Return span of groups."""
+
+    def spans(self, *index: Union[str, int]) -> Union[List[Tuple[int, int]], Tuple[List[Tuple[int, int]], ...]]:
+        """Return span of groups."""
+
+    def expand(self, template: AnyStr) -> AnyStr:
+        """Expand replacement template."""
+
+    def expandf(self, template: AnyStr) -> AnyStr:
+        """Expand format replacement template."""

--- a/backrefs/bregex.py
+++ b/backrefs/bregex.py
@@ -163,7 +163,7 @@ def _apply_search_backrefs(
                 pattern, re_verbose, re_version, type(pattern)
             )  # type: Union[AnyStr, Pattern[AnyStr]]
         else:  # pragma: no cover
-            p = _bregex_parse._SearchParser(pattern, re_verbose, re_version).parse()
+            p = _bregex_parse._SearchParser(cast(AnyStr, pattern), re_verbose, re_version).parse()
     elif isinstance(pattern, Bregex):
         if flags:
             raise ValueError("Cannot process flags argument with a compiled pattern")
@@ -215,25 +215,25 @@ class Bregex(_util.Immutable, Generic[AnyStr]):
     def pattern(self) -> AnyStr:
         """Return pattern."""
 
-        return self._pattern.pattern
+        return cast(AnyStr, self._pattern.pattern)
 
     @property
     def flags(self) -> int:
         """Return flags."""
 
-        return self._pattern.flags
+        return cast(int, self._pattern.flags)
 
     @property
     def groupindex(self) -> Mapping[str, int]:
         """Return group index."""
 
-        return self._pattern.groupindex
+        return cast(Mapping[str, int], self._pattern.groupindex)
 
     @property
     def groups(self) -> Tuple[Optional[AnyStr], ...]:
         """Return groups."""
 
-        return self._pattern.groups
+        return cast(Tuple[Optional[AnyStr], ...], self._pattern.groups)
 
     @property
     def scanner(self) -> Any:
@@ -303,7 +303,7 @@ class Bregex(_util.Immutable, Generic[AnyStr]):
     def named_lists(self) -> Mapping[str, Set[Union[str, bytes]]]:
         """Returned named lists."""
 
-        return self._pattern.named_lists
+        return cast(Mapping[str, Set[Union[str, bytes]]], self._pattern.named_lists)
 
     def search(
         self,
@@ -323,7 +323,7 @@ class Bregex(_util.Immutable, Generic[AnyStr]):
     ) -> Optional[Match[AnyStr]]:
         """Apply `match`."""
 
-        return self._pattern.match(string, *args, **kwargs)
+        return cast(Optional[Match[AnyStr]], self._pattern.match(string, *args, **kwargs))
 
     def fullmatch(
         self,
@@ -333,7 +333,7 @@ class Bregex(_util.Immutable, Generic[AnyStr]):
     ) -> Optional[Match[AnyStr]]:
         """Apply `fullmatch`."""
 
-        return self._pattern.fullmatch(string, *args, **kwargs)
+        return cast(Optional[Match[AnyStr]], self._pattern.fullmatch(string, *args, **kwargs))
 
     def split(
         self,
@@ -343,7 +343,7 @@ class Bregex(_util.Immutable, Generic[AnyStr]):
     ) -> List[AnyStr]:
         """Apply `split`."""
 
-        return self._pattern.split(string, *args, **kwargs)
+        return cast(List[AnyStr], self._pattern.split(string, *args, **kwargs))
 
     def splititer(
         self,
@@ -353,7 +353,7 @@ class Bregex(_util.Immutable, Generic[AnyStr]):
     ) -> Iterator[AnyStr]:
         """Apply `splititer`."""
 
-        return self._pattern.splititer(string, *args, **kwargs)
+        return cast(Iterator[AnyStr], self._pattern.splititer(string, *args, **kwargs))
 
     def findall(
         self,
@@ -363,7 +363,7 @@ class Bregex(_util.Immutable, Generic[AnyStr]):
     ) -> Union[List[AnyStr], List[Tuple[AnyStr, ...]]]:
         """Apply `findall`."""
 
-        return self._pattern.findall(string, *args, **kwargs)
+        return cast(Union[List[AnyStr], List[Tuple[AnyStr, ...]]], self._pattern.findall(string, *args, **kwargs))
 
     def finditer(
         self,
@@ -373,7 +373,7 @@ class Bregex(_util.Immutable, Generic[AnyStr]):
     ) -> Iterator[Match[AnyStr]]:
         """Apply `finditer`."""
 
-        return self._pattern.finditer(string, *args, **kwargs)
+        return cast(Iterator[Match[AnyStr]], self._pattern.finditer(string, *args, **kwargs))
 
     def sub(
         self,
@@ -384,7 +384,7 @@ class Bregex(_util.Immutable, Generic[AnyStr]):
     ) -> AnyStr:
         """Apply `sub`."""
 
-        return self._pattern.sub(self._auto_compile(repl), string, *args, **kwargs)
+        return cast(AnyStr, self._pattern.sub(self._auto_compile(repl), string, *args, **kwargs))
 
     def subf(
         self,
@@ -395,7 +395,7 @@ class Bregex(_util.Immutable, Generic[AnyStr]):
     ) -> AnyStr:  # noqa A002
         """Apply `sub` with format style replace."""
 
-        return self._pattern.subf(self._auto_compile(repl, True), string, *args, **kwargs)
+        return cast(AnyStr, self._pattern.subf(self._auto_compile(repl, True), string, *args, **kwargs))
 
     def subn(
         self,
@@ -406,7 +406,7 @@ class Bregex(_util.Immutable, Generic[AnyStr]):
     ) -> Tuple[AnyStr, int]:
         """Apply `subn` with format style replace."""
 
-        return self._pattern.subn(self._auto_compile(repl), string, *args, **kwargs)
+        return cast(Tuple[AnyStr, int], self._pattern.subn(self._auto_compile(repl), string, *args, **kwargs))
 
     def subfn(
         self,
@@ -417,7 +417,7 @@ class Bregex(_util.Immutable, Generic[AnyStr]):
     ) -> Tuple[AnyStr, int]:  # noqa A002
         """Apply `subn` after applying backrefs."""
 
-        return self._pattern.subfn(self._auto_compile(repl, True), string, *args, **kwargs)
+        return cast(Tuple[AnyStr, int], self._pattern.subfn(self._auto_compile(repl, True), string, *args, **kwargs))
 
 
 def compile(  # noqa A001

--- a/backrefs/bregex.py
+++ b/backrefs/bregex.py
@@ -14,12 +14,14 @@ Add the ability to use the following backrefs with re:
 Licensed under MIT
 Copyright (c) 2015 - 2020 Isaac Muse <isaacmuse@gmail.com>
 """
-import regex as _regex
+import regex as _regex  # type: ignore[import]
 import copyreg as _copyreg
 from functools import lru_cache as _lru_cache
 from . import util as _util
 from . import _bregex_parse
 from ._bregex_parse import ReplaceTemplate
+from typing import AnyStr, Union, Type, Callable, Any, Optional, Generic, Mapping, Tuple, List, Iterator, Set, cast
+from ._bregex_typing import Pattern, Match
 
 __all__ = (
     "expand", "expandf", "match", "fullmatch", "search", "sub", "subf", "subn", "subfn", "split", "splititer",
@@ -81,20 +83,30 @@ _REGEX_TYPE = type(_regex.compile('', 0))
 
 
 @_lru_cache(maxsize=_MAXCACHE)
-def _cached_search_compile(pattern, re_verbose, re_version, pattern_type):
+def _cached_search_compile(
+    pattern: AnyStr,
+    re_verbose: bool,
+    re_version: bool,
+    pattern_type: Type[AnyStr]
+) -> AnyStr:
     """Cached search compile."""
 
     return _bregex_parse._SearchParser(pattern, re_verbose, re_version).parse()
 
 
 @_lru_cache(maxsize=_MAXCACHE)
-def _cached_replace_compile(pattern, repl, flags, pattern_type):
+def _cached_replace_compile(
+    pattern: Pattern[AnyStr],
+    repl: AnyStr,
+    flags: int,
+    pattern_type: Type[AnyStr]
+) -> ReplaceTemplate[AnyStr]:
     """Cached replace compile."""
 
-    return _bregex_parse._ReplaceParser().parse(pattern, repl, bool(flags & FORMAT))
+    return _bregex_parse._ReplaceParser(pattern, repl, bool(flags & FORMAT)).parse()
 
 
-def _get_cache_size(replace=False):
+def _get_cache_size(replace: bool = False) -> int:
     """Get size of cache."""
 
     if not replace:
@@ -104,32 +116,38 @@ def _get_cache_size(replace=False):
     return size
 
 
-def _purge_cache():
+def _purge_cache() -> None:
     """Purge the cache."""
 
     _cached_replace_compile.cache_clear()
     _cached_search_compile.cache_clear()
 
 
-def _is_replace(obj):
+def _is_replace(obj: Any) -> bool:
     """Check if object is a replace object."""
 
     return isinstance(obj, ReplaceTemplate)
 
 
-def _apply_replace_backrefs(m, repl=None, flags=0):
+def _apply_replace_backrefs(
+    m: Optional[Match[AnyStr]],
+    repl: Union[ReplaceTemplate[AnyStr], AnyStr],
+    flags: int = 0
+) -> AnyStr:
     """Expand with either the `ReplaceTemplate` or compile on the fly, or return None."""
 
     if m is None:
         raise ValueError("Match is None!")
-    else:
-        if isinstance(repl, ReplaceTemplate):
-            return repl.expand(m)
-        elif isinstance(repl, (str, bytes)):
-            return _bregex_parse._ReplaceParser().parse(m.re, repl, bool(flags & FORMAT)).expand(m)
+
+    if isinstance(repl, ReplaceTemplate):
+        return repl.expand(m)
+    return _bregex_parse._ReplaceParser(m.re, repl, bool(flags & FORMAT)).parse().expand(m)
 
 
-def _apply_search_backrefs(pattern, flags=0):
+def _apply_search_backrefs(
+    pattern: Union[AnyStr, Pattern[AnyStr], 'Bregex[AnyStr]'],
+    flags: int = 0
+) -> Union[AnyStr, Pattern[AnyStr]]:
     """Apply the search backrefs to the search pattern."""
 
     if isinstance(pattern, (str, bytes)):
@@ -141,22 +159,25 @@ def _apply_search_backrefs(pattern, flags=0):
         else:
             re_version = 0
         if not (flags & DEBUG):
-            pattern = _cached_search_compile(pattern, re_verbose, re_version, type(pattern))
+            p = _cached_search_compile(
+                pattern, re_verbose, re_version, type(pattern)
+            )  # type: Union[AnyStr, Pattern[AnyStr]]
         else:  # pragma: no cover
-            pattern = _bregex_parse._SearchParser(pattern, re_verbose, re_version).parse()
+            p = _bregex_parse._SearchParser(pattern, re_verbose, re_version).parse()
     elif isinstance(pattern, Bregex):
         if flags:
             raise ValueError("Cannot process flags argument with a compiled pattern")
-        pattern = pattern._pattern
+        p = pattern._pattern
     elif isinstance(pattern, _REGEX_TYPE):
         if flags:
             raise ValueError("Cannot process flags argument with a compiled pattern!")
+        p = pattern
     else:
         raise TypeError("Not a string or compiled pattern!")
-    return pattern
+    return p
 
 
-def _assert_expandable(repl, use_format=False):
+def _assert_expandable(repl: Any, use_format: bool = False) -> None:
     """Check if replace template is expandable."""
 
     if isinstance(repl, ReplaceTemplate):
@@ -169,7 +190,242 @@ def _assert_expandable(repl, use_format=False):
         raise TypeError("Expected string, buffer, or compiled replace!")
 
 
-def compile(pattern, flags=0, auto_compile=None, **kwargs):  # noqa A001
+###########################
+# API
+##########################
+class Bregex(_util.Immutable, Generic[AnyStr]):
+    """Bregex object."""
+
+    _pattern: Pattern[AnyStr]
+    auto_compile: bool
+    _hash: int
+
+    __slots__ = ("_pattern", "auto_compile", "_hash")
+
+    def __init__(self, pattern: Pattern[AnyStr], auto_compile: bool = True) -> None:
+        """Initialization."""
+
+        super().__init__(
+            _pattern=pattern,
+            auto_compile=auto_compile,
+            _hash=hash((type(self), type(pattern), pattern, auto_compile))
+        )
+
+    @property
+    def pattern(self) -> AnyStr:
+        """Return pattern."""
+
+        return self._pattern.pattern
+
+    @property
+    def flags(self) -> int:
+        """Return flags."""
+
+        return self._pattern.flags
+
+    @property
+    def groupindex(self) -> Mapping[str, int]:
+        """Return group index."""
+
+        return self._pattern.groupindex
+
+    @property
+    def groups(self) -> Tuple[Optional[AnyStr], ...]:
+        """Return groups."""
+
+        return self._pattern.groups
+
+    @property
+    def scanner(self) -> Any:
+        """Return scanner."""
+
+        return self._pattern.scanner
+
+    def __hash__(self) -> int:
+        """Hash."""
+
+        return self._hash
+
+    def __eq__(self, other: Any) -> bool:
+        """Equal."""
+
+        return (
+            isinstance(other, Bregex) and
+            self._pattern == other._pattern and
+            self.auto_compile == other.auto_compile
+        )
+
+    def __ne__(self, other: Any) -> bool:
+        """Equal."""
+
+        return (
+            not isinstance(other, Bregex) or
+            self._pattern != other._pattern or
+            self.auto_compile != other.auto_compile
+        )
+
+    def __repr__(self) -> str:  # pragma: no cover
+        """Representation."""
+
+        return '{}.{}({!r}, auto_compile={!r})'.format(
+            self.__module__, self.__class__.__name__, self._pattern, self.auto_compile
+        )
+
+    def _auto_compile(
+        self,
+        template: Union[AnyStr, Callable[..., AnyStr]],
+        use_format: bool = False
+    ) -> Union[AnyStr, Callable[..., AnyStr]]:
+        """Compile replacements."""
+
+        if isinstance(template, ReplaceTemplate):
+            if use_format != template.use_format:
+                raise ValueError("Compiled replace cannot be a format object!")
+        elif isinstance(template, ReplaceTemplate) or (isinstance(template, (str, bytes)) and self.auto_compile):
+            return self.compile(template, (FORMAT if use_format and not isinstance(template, ReplaceTemplate) else 0))
+        elif isinstance(template, (str, bytes)) and use_format:
+            # Reject an attempt to run format replace when auto-compiling
+            # of template strings has been disabled and we are using a
+            # template string.
+            raise AttributeError('Format replaces cannot be called without compiling replace template!')
+        return template
+
+    def compile(  # noqa A001
+        self,
+        repl: Union[AnyStr, Callable[..., AnyStr]],
+        flags: int = 0
+    ) -> Callable[..., AnyStr]:
+        """Compile replace."""
+
+        return compile_replace(self._pattern, repl, flags)
+
+    @property
+    def named_lists(self) -> Mapping[str, Set[Union[str, bytes]]]:
+        """Returned named lists."""
+
+        return self._pattern.named_lists
+
+    def search(
+        self,
+        string: AnyStr,
+        *args: Any,
+        **kwargs: Any
+    ) -> Optional[Match[AnyStr]]:
+        """Apply `search`."""
+
+        return self._pattern.search(string, *args, **kwargs)
+
+    def match(
+        self,
+        string: AnyStr,
+        *args: Any,
+        **kwargs: Any
+    ) -> Optional[Match[AnyStr]]:
+        """Apply `match`."""
+
+        return self._pattern.match(string, *args, **kwargs)
+
+    def fullmatch(
+        self,
+        string: AnyStr,
+        *args: Any,
+        **kwargs: Any
+    ) -> Optional[Match[AnyStr]]:
+        """Apply `fullmatch`."""
+
+        return self._pattern.fullmatch(string, *args, **kwargs)
+
+    def split(
+        self,
+        string: AnyStr,
+        *args: Any,
+        **kwargs: Any
+    ) -> List[AnyStr]:
+        """Apply `split`."""
+
+        return self._pattern.split(string, *args, **kwargs)
+
+    def splititer(
+        self,
+        string: AnyStr,
+        *args: Any,
+        **kwargs: Any
+    ) -> Iterator[AnyStr]:
+        """Apply `splititer`."""
+
+        return self._pattern.splititer(string, *args, **kwargs)
+
+    def findall(
+        self,
+        string: AnyStr,
+        *args: Any,
+        **kwargs: Any
+    ) -> Union[List[AnyStr], List[Tuple[AnyStr, ...]]]:
+        """Apply `findall`."""
+
+        return self._pattern.findall(string, *args, **kwargs)
+
+    def finditer(
+        self,
+        string: AnyStr,
+        *args: Any,
+        **kwargs: Any
+    ) -> Iterator[Match[AnyStr]]:
+        """Apply `finditer`."""
+
+        return self._pattern.finditer(string, *args, **kwargs)
+
+    def sub(
+        self,
+        repl: Union[AnyStr, Callable[..., AnyStr]],
+        string: AnyStr,
+        *args: Any,
+        **kwargs: Any
+    ) -> AnyStr:
+        """Apply `sub`."""
+
+        return self._pattern.sub(self._auto_compile(repl), string, *args, **kwargs)
+
+    def subf(
+        self,
+        repl: Union[AnyStr, Callable[..., AnyStr]],
+        string: AnyStr,
+        *args: Any,
+        **kwargs: Any
+    ) -> AnyStr:  # noqa A002
+        """Apply `sub` with format style replace."""
+
+        return self._pattern.subf(self._auto_compile(repl, True), string, *args, **kwargs)
+
+    def subn(
+        self,
+        repl: Union[AnyStr, Callable[..., AnyStr]],
+        string: AnyStr,
+        *args: Any,
+        **kwargs: Any
+    ) -> Tuple[AnyStr, int]:
+        """Apply `subn` with format style replace."""
+
+        return self._pattern.subn(self._auto_compile(repl), string, *args, **kwargs)
+
+    def subfn(
+        self,
+        repl: Union[AnyStr, Callable[..., AnyStr]],
+        string: AnyStr,
+        *args: Any,
+        **kwargs: Any
+    ) -> Tuple[AnyStr, int]:  # noqa A002
+        """Apply `subn` after applying backrefs."""
+
+        return self._pattern.subfn(self._auto_compile(repl, True), string, *args, **kwargs)
+
+
+def compile(  # noqa A001
+    pattern: Union[AnyStr, Pattern[AnyStr], 'Bregex[AnyStr]'],
+    flags: int = 0,
+    auto_compile: Optional[bool] = None,
+    **kwargs: Any
+) -> 'Bregex[AnyStr]':
     """Compile both the search or search and replace into one object."""
 
     if isinstance(pattern, Bregex):
@@ -185,22 +441,29 @@ def compile(pattern, flags=0, auto_compile=None, **kwargs):  # noqa A001
         return Bregex(compile_search(pattern, flags, **kwargs), auto_compile)
 
 
-def compile_search(pattern, flags=0, **kwargs):
+def compile_search(
+    pattern: Union[AnyStr, Pattern[AnyStr], 'Bregex[AnyStr]'],
+    flags: int = 0,
+    **kwargs: Any
+) -> Pattern[AnyStr]:
     """Compile with extended search references."""
 
-    return _regex.compile(_apply_search_backrefs(pattern, flags), flags, **kwargs)
+    return cast(Pattern[AnyStr], _regex.compile(_apply_search_backrefs(pattern, flags), flags, **kwargs))
 
 
-def compile_replace(pattern, repl, flags=0):
+def compile_replace(
+    pattern: Pattern[AnyStr],
+    repl: Union[AnyStr, Callable[..., AnyStr]],
+    flags: int = 0
+) -> Callable[..., AnyStr]:
     """Construct a method that can be used as a replace method for `sub`, `subn`, etc."""
 
-    call = None
     if pattern is not None and isinstance(pattern, _REGEX_TYPE):
         if isinstance(repl, (str, bytes)):
             if not (pattern.flags & DEBUG):
                 call = _cached_replace_compile(pattern, repl, flags, type(repl))
             else:  # pragma: no cover
-                call = _bregex_parse._ReplaceParser().parse(pattern, repl, bool(flags & FORMAT))
+                call = _bregex_parse._ReplaceParser(pattern, repl, bool(flags & FORMAT)).parse()
         elif isinstance(repl, ReplaceTemplate):
             if flags:
                 raise ValueError("Cannot process flags argument with a ReplaceTemplate!")
@@ -214,298 +477,235 @@ def compile_replace(pattern, repl, flags=0):
     return call
 
 
-###########################
-# API
-##########################
-class Bregex(_util.Immutable):
-    """Bregex object."""
-
-    __slots__ = ("_pattern", "auto_compile", "_hash")
-
-    def __init__(self, pattern, auto_compile=True):
-        """Initialization."""
-
-        super(Bregex, self).__init__(
-            _pattern=pattern,
-            auto_compile=auto_compile,
-            _hash=hash((type(self), type(pattern), pattern, auto_compile))
-        )
-
-    @property
-    def pattern(self):
-        """Return pattern."""
-
-        return self._pattern.pattern
-
-    @property
-    def flags(self):
-        """Return flags."""
-
-        return self._pattern.flags
-
-    @property
-    def groupindex(self):
-        """Return group index."""
-
-        return self._pattern.groupindex
-
-    @property
-    def groups(self):
-        """Return groups."""
-
-        return self._pattern.groups
-
-    @property
-    def scanner(self):
-        """Return scanner."""
-
-        return self._pattern.scanner
-
-    def __hash__(self):
-        """Hash."""
-
-        return self._hash
-
-    def __eq__(self, other):
-        """Equal."""
-
-        return (
-            isinstance(other, Bregex) and
-            self._pattern == other._pattern and
-            self.auto_compile == other.auto_compile
-        )
-
-    def __ne__(self, other):
-        """Equal."""
-
-        return (
-            not isinstance(other, Bregex) or
-            self._pattern != other._pattern or
-            self.auto_compile != other.auto_compile
-        )
-
-    def __repr__(self):  # pragma: no cover
-        """Representation."""
-
-        return '%s.%s(%r, auto_compile=%r)' % (
-            self.__module__, self.__class__.__name__, self._pattern, self.auto_compile
-        )
-
-    def _auto_compile(self, template, use_format=False):
-        """Compile replacements."""
-
-        is_replace = _is_replace(template)
-        is_string = isinstance(template, (str, bytes))
-        if is_replace and use_format != template.use_format:
-            raise ValueError("Compiled replace cannot be a format object!")
-        if is_replace or (is_string and self.auto_compile):
-            return self.compile(template, (FORMAT if use_format and not is_replace else 0))
-        elif is_string and use_format:
-            # Reject an attempt to run format replace when auto-compiling
-            # of template strings has been disabled and we are using a
-            # template string.
-            raise AttributeError('Format replaces cannot be called without compiling replace template!')
-        else:
-            return template
-
-    def compile(self, repl, flags=0):  # noqa A001
-        """Compile replace."""
-
-        return compile_replace(self._pattern, repl, flags)
-
-    def search(self, string, *args, **kwargs):
-        """Apply `search`."""
-
-        return self._pattern.search(string, *args, **kwargs)
-
-    def match(self, string, *args, **kwargs):
-        """Apply `match`."""
-
-        return self._pattern.match(string, *args, **kwargs)
-
-    def fullmatch(self, string, *args, **kwargs):
-        """Apply `fullmatch`."""
-
-        return self._pattern.fullmatch(string, *args, **kwargs)
-
-    def split(self, string, *args, **kwargs):
-        """Apply `split`."""
-
-        return self._pattern.split(string, *args, **kwargs)
-
-    def splititer(self, string, *args, **kwargs):
-        """Apply `splititer`."""
-
-        return self._pattern.splititer(string, *args, **kwargs)
-
-    def findall(self, string, *args, **kwargs):
-        """Apply `findall`."""
-
-        return self._pattern.findall(string, *args, **kwargs)
-
-    def finditer(self, string, *args, **kwargs):
-        """Apply `finditer`."""
-
-        return self._pattern.finditer(string, *args, **kwargs)
-
-    def sub(self, repl, string, *args, **kwargs):
-        """Apply `sub`."""
-
-        return self._pattern.sub(self._auto_compile(repl), string, *args, **kwargs)
-
-    def subf(self, repl, string, *args, **kwargs):  # noqa A002
-        """Apply `sub` with format style replace."""
-
-        return self._pattern.subf(self._auto_compile(repl, True), string, *args, **kwargs)
-
-    def subn(self, repl, string, *args, **kwargs):
-        """Apply `subn` with format style replace."""
-
-        return self._pattern.subn(self._auto_compile(repl), string, *args, **kwargs)
-
-    def subfn(self, repl, string, *args, **kwargs):  # noqa A002
-        """Apply `subn` after applying backrefs."""
-
-        return self._pattern.subfn(self._auto_compile(repl, True), string, *args, **kwargs)
-
-
-def purge():
+def purge() -> None:
     """Purge caches."""
 
     _purge_cache()
     _regex.purge()
 
 
-def expand(m, repl):
+def expand(m: Optional[Match[AnyStr]], repl: Union[ReplaceTemplate[AnyStr], AnyStr]) -> AnyStr:
     """Expand the string using the replace pattern or function."""
 
     _assert_expandable(repl)
     return _apply_replace_backrefs(m, repl)
 
 
-def expandf(m, format):  # noqa A002
+def expandf(m: Optional[Match[AnyStr]], repl: Union[ReplaceTemplate[AnyStr], AnyStr]) -> AnyStr:
     """Expand the string using the format replace pattern or function."""
 
-    _assert_expandable(format, True)
-    return _apply_replace_backrefs(m, format, flags=FORMAT)
+    _assert_expandable(repl, True)
+    return _apply_replace_backrefs(m, repl, flags=FORMAT)
 
 
-def match(pattern, string, *args, **kwargs):
+def match(
+    pattern: Union[AnyStr, Pattern[AnyStr], 'Bregex[AnyStr]'],
+    string: AnyStr,
+    *args: Any,
+    **kwargs: Any
+) -> Optional[Match[AnyStr]]:
     """Wrapper for `match`."""
 
     flags = args[2] if len(args) > 2 else kwargs.get('flags', 0)
-    return _regex.match(_apply_search_backrefs(pattern, flags), string, *args, **kwargs)
+    return cast(
+        Optional[Match[AnyStr]],
+        _regex.match(_apply_search_backrefs(pattern, flags), string, *args, **kwargs)
+    )
 
 
-def fullmatch(pattern, string, *args, **kwargs):
+def fullmatch(
+    pattern: Union[AnyStr, Pattern[AnyStr], 'Bregex[AnyStr]'],
+    string: AnyStr,
+    *args: Any,
+    **kwargs: Any
+) -> Optional[Match[AnyStr]]:
     """Wrapper for `fullmatch`."""
 
     flags = args[2] if len(args) > 2 else kwargs.get('flags', 0)
-    return _regex.fullmatch(_apply_search_backrefs(pattern, flags), string, *args, **kwargs)
+    return cast(
+        Optional[Match[AnyStr]],
+        _regex.fullmatch(_apply_search_backrefs(pattern, flags), string, *args, **kwargs)
+    )
 
 
-def search(pattern, string, *args, **kwargs):
+def search(
+    pattern: Union[AnyStr, Pattern[AnyStr], 'Bregex[AnyStr]'],
+    string: AnyStr,
+    *args: Any,
+    **kwargs: Any
+) -> Optional[Match[AnyStr]]:
     """Wrapper for `search`."""
 
     flags = args[2] if len(args) > 2 else kwargs.get('flags', 0)
-    return _regex.search(_apply_search_backrefs(pattern, flags), string, *args, **kwargs)
+    return cast(
+        Optional[Match[AnyStr]],
+        _regex.search(_apply_search_backrefs(pattern, flags), string, *args, **kwargs)
+    )
 
 
-def sub(pattern, repl, string, *args, **kwargs):
+def sub(
+    pattern: Union[AnyStr, Pattern[AnyStr], 'Bregex[AnyStr]'],
+    repl: Union[AnyStr, Callable[..., AnyStr]],
+    string: AnyStr,
+    *args: Any,
+    **kwargs: Any
+) -> AnyStr:
     """Wrapper for `sub`."""
 
     flags = args[4] if len(args) > 4 else kwargs.get('flags', 0)
     is_replace = _is_replace(repl)
     is_string = isinstance(repl, (str, bytes))
-    if is_replace and repl.use_format:
+    if is_replace and cast(ReplaceTemplate[AnyStr], repl).use_format:
         raise ValueError("Compiled replace cannot be a format object!")
 
     pattern = compile_search(pattern, flags)
-    return _regex.sub(
-        pattern, (compile_replace(pattern, repl) if is_replace or is_string else repl), string,
-        *args, **kwargs
+    return cast(
+        AnyStr,
+        _regex.sub(
+            pattern, (compile_replace(pattern, repl) if is_replace or is_string else repl), string,
+            *args, **kwargs
+        )
     )
 
 
-def subf(pattern, format, string, *args, **kwargs):  # noqa A002
+def subf(
+    pattern: Union[AnyStr, Pattern[AnyStr], 'Bregex[AnyStr]'],
+    repl: Union[AnyStr, Callable[..., AnyStr]],
+    string: AnyStr,
+    *args: Any,
+    **kwargs: Any
+) -> AnyStr:
     """Wrapper for `subf`."""
 
     flags = args[4] if len(args) > 4 else kwargs.get('flags', 0)
-    is_replace = _is_replace(format)
-    is_string = isinstance(format, (str, bytes))
-    if is_replace and not format.use_format:
+    is_replace = _is_replace(repl)
+    is_string = isinstance(repl, (str, bytes))
+    if is_replace and not cast(ReplaceTemplate[AnyStr], repl).use_format:
         raise ValueError("Compiled replace is not a format object!")
 
     pattern = compile_search(pattern, flags)
     rflags = FORMAT if is_string else 0
-    return _regex.sub(
-        pattern, (compile_replace(pattern, format, flags=rflags) if is_replace or is_string else format), string,
-        *args, **kwargs
+    return cast(
+        AnyStr,
+        _regex.sub(
+            pattern, (compile_replace(pattern, repl, flags=rflags) if is_replace or is_string else repl), string,
+            *args, **kwargs
+        )
     )
 
 
-def subn(pattern, repl, string, *args, **kwargs):
+def subn(
+    pattern: Union[AnyStr, Pattern[AnyStr], 'Bregex[AnyStr]'],
+    repl: Union[AnyStr, Callable[..., AnyStr]],
+    string: AnyStr,
+    *args: Any,
+    **kwargs: Any
+) -> Tuple[AnyStr, int]:
     """Wrapper for `subn`."""
 
     flags = args[4] if len(args) > 4 else kwargs.get('flags', 0)
     is_replace = _is_replace(repl)
     is_string = isinstance(repl, (str, bytes))
-    if is_replace and repl.use_format:
+    if is_replace and cast(ReplaceTemplate[AnyStr], repl).use_format:
         raise ValueError("Compiled replace cannot be a format object!")
 
     pattern = compile_search(pattern, flags)
-    return _regex.subn(
-        pattern, (compile_replace(pattern, repl) if is_replace or is_string else repl), string,
-        *args, **kwargs
+    return cast(
+        Tuple[AnyStr, int],
+        _regex.subn(
+            pattern, (compile_replace(pattern, repl) if is_replace or is_string else repl), string,
+            *args, **kwargs
+        )
     )
 
 
-def subfn(pattern, format, string, *args, **kwargs):  # noqa A002
+def subfn(
+    pattern: Union[AnyStr, Pattern[AnyStr], 'Bregex[AnyStr]'],
+    repl: Union[AnyStr, Callable[..., AnyStr]],
+    string: AnyStr,
+    *args: Any,
+    **kwargs: Any
+) -> Tuple[AnyStr, int]:
     """Wrapper for `subfn`."""
 
     flags = args[4] if len(args) > 4 else kwargs.get('flags', 0)
-    is_replace = _is_replace(format)
-    is_string = isinstance(format, (str, bytes))
-    if is_replace and not format.use_format:
+    is_replace = _is_replace(repl)
+    is_string = isinstance(repl, (str, bytes))
+    if is_replace and not cast(ReplaceTemplate[AnyStr], repl).use_format:
         raise ValueError("Compiled replace is not a format object!")
 
     pattern = compile_search(pattern, flags)
     rflags = FORMAT if is_string else 0
-    return _regex.subn(
-        pattern, (compile_replace(pattern, format, flags=rflags) if is_replace or is_string else format), string,
-        *args, **kwargs
+    return cast(
+        Tuple[AnyStr, int],
+        _regex.subn(
+            pattern, (compile_replace(pattern, repl, flags=rflags) if is_replace or is_string else repl), string,
+            *args, **kwargs
+        )
     )
 
 
-def split(pattern, string, *args, **kwargs):
+def split(
+    pattern: Union[AnyStr, Pattern[AnyStr], 'Bregex[AnyStr]'],
+    string: AnyStr,
+    *args: Any,
+    **kwargs: Any
+) -> List[AnyStr]:
     """Wrapper for `split`."""
 
     flags = args[3] if len(args) > 3 else kwargs.get('flags', 0)
-    return _regex.split(_apply_search_backrefs(pattern, flags), string, *args, **kwargs)
+    return cast(
+        List[AnyStr],
+        _regex.split(_apply_search_backrefs(pattern, flags), string, *args, **kwargs)
+    )
 
 
-def splititer(pattern, string, *args, **kwargs):
+def splititer(
+    pattern: Union[AnyStr, Pattern[AnyStr], 'Bregex[AnyStr]'],
+    string: AnyStr,
+    *args: Any,
+    **kwargs: Any
+) -> Iterator[AnyStr]:
     """Wrapper for `splititer`."""
 
     flags = args[3] if len(args) > 3 else kwargs.get('flags', 0)
-    return _regex.splititer(_apply_search_backrefs(pattern, flags), string, *args, **kwargs)
+    return cast(
+        Iterator[AnyStr],
+        _regex.splititer(_apply_search_backrefs(pattern, flags), string, *args, **kwargs)
+    )
 
 
-def findall(pattern, string, *args, **kwargs):
+def findall(
+    pattern: Union[AnyStr, Pattern[AnyStr], 'Bregex[AnyStr]'],
+    string: AnyStr,
+    *args: Any,
+    **kwargs: Any
+) -> Union[List[AnyStr], List[Tuple[AnyStr, ...]]]:
     """Wrapper for `findall`."""
 
     flags = args[2] if len(args) > 2 else kwargs.get('flags', 0)
-    return _regex.findall(_apply_search_backrefs(pattern, flags), string, *args, **kwargs)
+    return cast(
+        Union[List[AnyStr], List[Tuple[AnyStr, ...]]],
+        _regex.findall(_apply_search_backrefs(pattern, flags), string, *args, **kwargs)
+    )
 
 
-def finditer(pattern, string, *args, **kwargs):
+def finditer(
+    pattern: Union[AnyStr, Pattern[AnyStr], 'Bregex[AnyStr]'],
+    string: AnyStr,
+    *args: Any,
+    **kwargs: Any
+) -> Iterator[Match[AnyStr]]:
     """Wrapper for `finditer`."""
 
     flags = args[2] if len(args) > 2 else kwargs.get('flags', 0)
-    return _regex.finditer(_apply_search_backrefs(pattern, flags), string, *args, **kwargs)
+    return cast(
+        Iterator[Match[AnyStr]],
+        _regex.finditer(_apply_search_backrefs(pattern, flags), string, *args, **kwargs)
+    )
 
 
-def _pickle(p):
+def _pickle(p):  # type: ignore[no-untyped-def]
     return Bregex, (p._pattern, p.auto_compile)
 
 

--- a/backrefs/uniprops/__init__.py
+++ b/backrefs/uniprops/__init__.py
@@ -1,6 +1,7 @@
 """Unicode Properties."""
 from . import unidata
 import sys
+from typing import Optional
 
 UNICODE_RANGE = '\u0000-\U0010ffff'
 ASCII_RANGE = '\x00-\xff'
@@ -12,7 +13,7 @@ MODE_ASCII = 1
 MODE_UNICODE = 2
 
 
-def fmt_string(value, is_bytes):
+def fmt_string(value: str, is_bytes: bool) -> str:
     """Format for bytes string."""
 
     if is_bytes:
@@ -21,7 +22,7 @@ def fmt_string(value, is_bytes):
         return value
 
 
-def get_gc_property(value, mode=MODE_UNICODE):
+def get_gc_property(value: str, mode: int = MODE_UNICODE) -> str:
     """Get `GC` property."""
 
     obj = unidata.ascii_properties if mode != MODE_UNICODE else unidata.unicode_properties
@@ -54,7 +55,7 @@ def get_gc_property(value, mode=MODE_UNICODE):
     return value
 
 
-def get_binary_property(value, mode=MODE_UNICODE):
+def get_binary_property(value: str, mode: int = MODE_UNICODE) -> str:
     """Get `BINARY` property."""
 
     obj = unidata.ascii_binary if mode != MODE_UNICODE else unidata.unicode_binary
@@ -68,7 +69,7 @@ def get_binary_property(value, mode=MODE_UNICODE):
     return fmt_string(obj[value], mode == MODE_ASCII)
 
 
-def get_canonical_combining_class_property(value, mode=MODE_UNICODE):
+def get_canonical_combining_class_property(value: str, mode: int = MODE_UNICODE) -> str:
     """Get `CANONICAL COMBINING CLASS` property."""
 
     obj = unidata.ascii_canonical_combining_class if mode != MODE_UNICODE else unidata.unicode_canonical_combining_class
@@ -82,7 +83,7 @@ def get_canonical_combining_class_property(value, mode=MODE_UNICODE):
     return fmt_string(obj[value], mode == MODE_ASCII)
 
 
-def get_east_asian_width_property(value, mode=MODE_UNICODE):
+def get_east_asian_width_property(value: str, mode: int = MODE_UNICODE) -> str:
     """Get `EAST ASIAN WIDTH` property."""
 
     obj = unidata.ascii_east_asian_width if mode != MODE_UNICODE else unidata.unicode_east_asian_width
@@ -96,7 +97,7 @@ def get_east_asian_width_property(value, mode=MODE_UNICODE):
     return fmt_string(obj[value], mode == MODE_ASCII)
 
 
-def get_grapheme_cluster_break_property(value, mode=MODE_UNICODE):
+def get_grapheme_cluster_break_property(value: str, mode: int = MODE_UNICODE) -> str:
     """Get `GRAPHEME CLUSTER BREAK` property."""
 
     obj = unidata.ascii_grapheme_cluster_break if mode != MODE_UNICODE else unidata.unicode_grapheme_cluster_break
@@ -110,7 +111,7 @@ def get_grapheme_cluster_break_property(value, mode=MODE_UNICODE):
     return fmt_string(obj[value], mode == MODE_ASCII)
 
 
-def get_line_break_property(value, mode=MODE_UNICODE):
+def get_line_break_property(value: str, mode: int = MODE_UNICODE) -> str:
     """Get `LINE BREAK` property."""
 
     obj = unidata.ascii_line_break if mode != MODE_UNICODE else unidata.unicode_line_break
@@ -124,7 +125,7 @@ def get_line_break_property(value, mode=MODE_UNICODE):
     return fmt_string(obj[value], mode == MODE_ASCII)
 
 
-def get_sentence_break_property(value, mode=MODE_UNICODE):
+def get_sentence_break_property(value: str, mode: int = MODE_UNICODE) -> str:
     """Get `SENTENCE BREAK` property."""
 
     obj = unidata.ascii_sentence_break if mode != MODE_UNICODE else unidata.unicode_sentence_break
@@ -138,7 +139,7 @@ def get_sentence_break_property(value, mode=MODE_UNICODE):
     return fmt_string(obj[value], mode == MODE_ASCII)
 
 
-def get_word_break_property(value, mode=MODE_UNICODE):
+def get_word_break_property(value: str, mode: int = MODE_UNICODE) -> str:
     """Get `WORD BREAK` property."""
 
     obj = unidata.ascii_word_break if mode != MODE_UNICODE else unidata.unicode_word_break
@@ -152,7 +153,7 @@ def get_word_break_property(value, mode=MODE_UNICODE):
     return fmt_string(obj[value], mode == MODE_ASCII)
 
 
-def get_hangul_syllable_type_property(value, mode=MODE_UNICODE):
+def get_hangul_syllable_type_property(value: str, mode: int = MODE_UNICODE) -> str:
     """Get `HANGUL SYLLABLE TYPE` property."""
 
     obj = unidata.ascii_hangul_syllable_type if mode != MODE_UNICODE else unidata.unicode_hangul_syllable_type
@@ -166,7 +167,7 @@ def get_hangul_syllable_type_property(value, mode=MODE_UNICODE):
     return fmt_string(obj[value], mode == MODE_ASCII)
 
 
-def get_indic_positional_category_property(value, mode=MODE_UNICODE):
+def get_indic_positional_category_property(value: str, mode: int = MODE_UNICODE) -> str:
     """Get `INDIC POSITIONAL/MATRA CATEGORY` property."""
 
     obj = unidata.ascii_indic_positional_category if mode != MODE_UNICODE else unidata.unicode_indic_positional_category
@@ -181,7 +182,7 @@ def get_indic_positional_category_property(value, mode=MODE_UNICODE):
     return fmt_string(obj[value], mode == MODE_ASCII)
 
 
-def get_indic_syllabic_category_property(value, mode=MODE_UNICODE):
+def get_indic_syllabic_category_property(value: str, mode: int = MODE_UNICODE) -> str:
     """Get `INDIC SYLLABIC CATEGORY` property."""
 
     obj = unidata.ascii_indic_syllabic_category if mode != MODE_UNICODE else unidata.unicode_indic_syllabic_category
@@ -195,7 +196,7 @@ def get_indic_syllabic_category_property(value, mode=MODE_UNICODE):
     return fmt_string(obj[value], mode == MODE_ASCII)
 
 
-def get_decomposition_type_property(value, mode=MODE_UNICODE):
+def get_decomposition_type_property(value: str, mode: int = MODE_UNICODE) -> str:
     """Get `DECOMPOSITION TYPE` property."""
 
     obj = unidata.ascii_decomposition_type if mode != MODE_UNICODE else unidata.unicode_decomposition_type
@@ -209,7 +210,7 @@ def get_decomposition_type_property(value, mode=MODE_UNICODE):
     return fmt_string(obj[value], mode == MODE_ASCII)
 
 
-def get_nfc_quick_check_property(value, mode=MODE_UNICODE):
+def get_nfc_quick_check_property(value: str, mode: int = MODE_UNICODE) -> str:
     """Get `NFC QUICK CHECK` property."""
 
     obj = unidata.ascii_nfc_quick_check if mode != MODE_UNICODE else unidata.unicode_nfc_quick_check
@@ -223,7 +224,7 @@ def get_nfc_quick_check_property(value, mode=MODE_UNICODE):
     return fmt_string(obj[value], mode == MODE_ASCII)
 
 
-def get_nfd_quick_check_property(value, mode=MODE_UNICODE):
+def get_nfd_quick_check_property(value: str, mode: int = MODE_UNICODE) -> str:
     """Get `NFD QUICK CHECK` property."""
 
     obj = unidata.ascii_nfd_quick_check if mode != MODE_UNICODE else unidata.unicode_nfd_quick_check
@@ -237,7 +238,7 @@ def get_nfd_quick_check_property(value, mode=MODE_UNICODE):
     return fmt_string(obj[value], mode == MODE_ASCII)
 
 
-def get_nfkc_quick_check_property(value, mode=MODE_UNICODE):
+def get_nfkc_quick_check_property(value: str, mode: int = MODE_UNICODE) -> str:
     """Get `NFKC QUICK CHECK` property."""
 
     obj = unidata.ascii_nfkc_quick_check if mode != MODE_UNICODE else unidata.unicode_nfkc_quick_check
@@ -251,7 +252,7 @@ def get_nfkc_quick_check_property(value, mode=MODE_UNICODE):
     return fmt_string(obj[value], mode == MODE_ASCII)
 
 
-def get_nfkd_quick_check_property(value, mode=MODE_UNICODE):
+def get_nfkd_quick_check_property(value: str, mode: int = MODE_UNICODE) -> str:
     """Get `NFKD QUICK CHECK` property."""
 
     obj = unidata.ascii_nfkd_quick_check if mode != MODE_UNICODE else unidata.unicode_nfkd_quick_check
@@ -265,7 +266,7 @@ def get_nfkd_quick_check_property(value, mode=MODE_UNICODE):
     return fmt_string(obj[value], mode == MODE_ASCII)
 
 
-def get_numeric_type_property(value, mode=MODE_UNICODE):
+def get_numeric_type_property(value: str, mode: int = MODE_UNICODE) -> str:
     """Get `NUMERIC TYPE` property."""
 
     obj = unidata.ascii_numeric_type if mode != MODE_UNICODE else unidata.unicode_numeric_type
@@ -279,7 +280,7 @@ def get_numeric_type_property(value, mode=MODE_UNICODE):
     return fmt_string(obj[value], mode == MODE_ASCII)
 
 
-def get_numeric_value_property(value, mode=MODE_UNICODE):
+def get_numeric_value_property(value: str, mode: int = MODE_UNICODE) -> str:
     """Get `NUMERIC VALUE` property."""
 
     obj = unidata.ascii_numeric_values if mode != MODE_UNICODE else unidata.unicode_numeric_values
@@ -293,7 +294,7 @@ def get_numeric_value_property(value, mode=MODE_UNICODE):
     return fmt_string(obj[value], mode == MODE_ASCII)
 
 
-def get_age_property(value, mode=MODE_UNICODE):
+def get_age_property(value: str, mode: int = MODE_UNICODE) -> str:
     """Get `AGE` property."""
 
     obj = unidata.ascii_age if mode != MODE_UNICODE else unidata.unicode_age
@@ -307,7 +308,7 @@ def get_age_property(value, mode=MODE_UNICODE):
     return fmt_string(obj[value], mode == MODE_ASCII)
 
 
-def get_joining_type_property(value, mode=MODE_UNICODE):
+def get_joining_type_property(value: str, mode: int = MODE_UNICODE) -> str:
     """Get `JOINING TYPE` property."""
 
     obj = unidata.ascii_joining_type if mode != MODE_UNICODE else unidata.unicode_joining_type
@@ -321,7 +322,7 @@ def get_joining_type_property(value, mode=MODE_UNICODE):
     return fmt_string(obj[value], mode == MODE_ASCII)
 
 
-def get_joining_group_property(value, mode=MODE_UNICODE):
+def get_joining_group_property(value: str, mode: int = MODE_UNICODE) -> str:
     """Get `JOINING GROUP` property."""
 
     obj = unidata.ascii_joining_group if mode != MODE_UNICODE else unidata.unicode_joining_group
@@ -335,7 +336,7 @@ def get_joining_group_property(value, mode=MODE_UNICODE):
     return fmt_string(obj[value], mode == MODE_ASCII)
 
 
-def get_script_property(value, mode=MODE_UNICODE):
+def get_script_property(value: str, mode: int = MODE_UNICODE) -> str:
     """Get `SC` property."""
 
     obj = unidata.ascii_scripts if mode != MODE_UNICODE else unidata.unicode_scripts
@@ -349,7 +350,7 @@ def get_script_property(value, mode=MODE_UNICODE):
     return fmt_string(obj[value], mode == MODE_ASCII)
 
 
-def get_script_extension_property(value, mode=MODE_UNICODE):
+def get_script_extension_property(value: str, mode: int = MODE_UNICODE) -> str:
     """Get `SCX` property."""
 
     obj = unidata.ascii_script_extensions if mode != MODE_UNICODE else unidata.unicode_script_extensions
@@ -363,7 +364,7 @@ def get_script_extension_property(value, mode=MODE_UNICODE):
     return fmt_string(obj[value], mode == MODE_ASCII)
 
 
-def get_block_property(value, mode=MODE_UNICODE):
+def get_block_property(value: str, mode: int = MODE_UNICODE) -> str:
     """Get `BLK` property."""
 
     obj = unidata.ascii_blocks if mode != MODE_UNICODE else unidata.unicode_blocks
@@ -377,7 +378,7 @@ def get_block_property(value, mode=MODE_UNICODE):
     return fmt_string(obj[value], mode == MODE_ASCII)
 
 
-def get_bidi_property(value, mode=MODE_UNICODE):
+def get_bidi_property(value: str, mode: int = MODE_UNICODE) -> str:
     """Get `BC` property."""
 
     obj = unidata.ascii_bidi_classes if mode != MODE_UNICODE else unidata.unicode_bidi_classes
@@ -391,7 +392,7 @@ def get_bidi_property(value, mode=MODE_UNICODE):
     return fmt_string(obj[value], mode == MODE_ASCII)
 
 
-def get_bidi_paired_bracket_type_property(value, mode=MODE_UNICODE):
+def get_bidi_paired_bracket_type_property(value: str, mode: int = MODE_UNICODE) -> str:
     """Get `BPT` property."""
 
     obj = unidata.ascii_bidi_paired_bracket_type if mode != MODE_UNICODE else unidata.unicode_bidi_paired_bracket_type
@@ -405,10 +406,13 @@ def get_bidi_paired_bracket_type_property(value, mode=MODE_UNICODE):
     return fmt_string(obj[value], mode == MODE_ASCII)
 
 
-def get_vertical_orientation_property(value, mode=MODE_UNICODE):
+def get_vertical_orientation_property(value: str, mode: int = MODE_UNICODE) -> str:
     """Get `VO` property."""
 
-    obj = unidata.ascii_vertical_orientation if mode != MODE_UNICODE else unidata.unicode_vertical_orientation
+    if mode != MODE_UNICODE:
+        obj = unidata.ascii_vertical_orientation  # type: ignore[attr-defined]
+    else:
+        obj = unidata.unicode_vertical_orientation  # type: ignore[attr-defined]
 
     if value.startswith('^'):
         negated = value[1:]
@@ -419,7 +423,7 @@ def get_vertical_orientation_property(value, mode=MODE_UNICODE):
     return fmt_string(obj[value], mode == MODE_ASCII)
 
 
-def get_is_property(value, mode=MODE_UNICODE):
+def get_is_property(value: str, mode: int = MODE_UNICODE) -> str:
     """Get shortcut for `SC` or `Binary` property."""
 
     if value.startswith('^'):
@@ -448,7 +452,7 @@ def get_is_property(value, mode=MODE_UNICODE):
     return fmt_string(obj[value], mode == MODE_ASCII)
 
 
-def get_in_property(value, mode=MODE_UNICODE):
+def get_in_property(value: str, mode: int = MODE_UNICODE) -> str:
     """Get shortcut for `Block` property."""
 
     if value.startswith('^'):
@@ -469,13 +473,13 @@ def get_in_property(value, mode=MODE_UNICODE):
     return fmt_string(obj[value], mode == MODE_ASCII)
 
 
-def _is_binary(name):
+def _is_binary(name: str) -> bool:
     """Check if name is an enum (not a binary) property."""
 
     return name in unidata.unicode_binary or name in unidata.unicode_alias['binary']
 
 
-def get_unicode_property(prop, value=None, mode=MODE_UNICODE):
+def get_unicode_property(prop: str, value: Optional[str] = None, mode: int = MODE_UNICODE) -> str:
     """Retrieve the Unicode category from the table."""
 
     if value is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,12 @@ strict = true
 show_error_codes = true
 
 [[tool.mypy.overrides]]
+module = [
+    'backrefs.uniprops.*',
+    'backrefs._bregex_typing'
+]
+warn_unused_ignores = false
+
+[[tool.mypy.overrides]]
 module = 'backrefs.uniprops.*'
 implicit_reexport = true
-warn_unused_ignores = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,15 @@ requires = [
 ]
 
 build-backend = "setuptools.build_meta"
+
+[tool.mypy]
+files = [
+    "backrefs/*.py"
+]
+strict = true
+show_error_codes = true
+
+[[tool.mypy.overrides]]
+module = 'backrefs.uniprops.*'
+implicit_reexport = true
+warn_unused_ignores = false

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-cov
 mock
+mypy

--- a/setup.py
+++ b/setup.py
@@ -86,12 +86,12 @@ setup(
     author_email='Isaac.Muse@gmail.com',
     url='https://github.com/facelessuser/backrefs',
     packages=find_packages(exclude=['tools', 'tests']),
+    package_data={"backrefs": ["py.typed"]},
     install_requires=get_requirements("requirements/project.txt"),
     extras_require={
         'extras': get_requirements("requirements/extras.txt")
     },
     zip_safe=False,
-    package_data={},
     license='MIT License',
     classifiers=[
         'Development Status :: %s' % DEVSTATUS,
@@ -105,6 +105,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
-        'Topic :: Software Development :: Libraries :: Python Modules'
+        'Topic :: Software Development :: Libraries :: Python Modules',
+        'Typing :: Typed'
     ]
 )

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -997,13 +997,13 @@ class TestReplaceTemplate(unittest.TestCase):
 
         pattern = re.compile(r"(some)(.+?)(pattern)(!)")
         with pytest.raises(sre_constants.error):
-            _bre_parse._ReplaceParser().parse(pattern, '\\1\\l\\')
+            _bre_parse._ReplaceParser(pattern, '\\1\\l\\').parse()
 
         with pytest.raises(sre_constants.error):
-            _bre_parse._ReplaceParser().parse(pattern, '\\1\\L\\')
+            _bre_parse._ReplaceParser(pattern, '\\1\\L\\').parse()
 
         with pytest.raises(sre_constants.error):
-            _bre_parse._ReplaceParser().parse(pattern, '\\1\\')
+            _bre_parse._ReplaceParser(pattern, '\\1\\').parse()
 
     def test_line_break(self):
         r"""Test line break \R."""
@@ -1134,8 +1134,8 @@ class TestReplaceTemplate(unittest.TestCase):
         """Test retrieval of the replace template original string."""
 
         pattern = re.compile(r"(some)(.+?)(pattern)(!)")
-        template = _bre_parse._ReplaceParser()
-        template.parse(pattern, r'\c\1\2\C\3\E\4')
+        template = _bre_parse._ReplaceParser(pattern, r'\c\1\2\C\3\E\4')
+        template.parse()
 
         self.assertEqual(r'\c\1\2\C\3\E\4', template.get_base_template())
 
@@ -1578,7 +1578,7 @@ class TestReplaceTemplate(unittest.TestCase):
 
         text = "Replace with function test!"
         pattern = bre.compile_search('(.+)')
-        repl = _bre_parse._ReplaceParser().parse(pattern, 'Success!')
+        repl = _bre_parse._ReplaceParser(pattern, 'Success!').parse()
         expand = bre.compile_replace(pattern, repl)
 
         m = pattern.match(text)
@@ -2125,7 +2125,7 @@ class TestExceptions(unittest.TestCase):
         """Test when a compile occurs on a template with flags passed."""
 
         pattern = re.compile('test')
-        template = _bre_parse._ReplaceParser().parse(pattern, 'whatever')
+        template = _bre_parse._ReplaceParser(pattern, 'whatever').parse()
 
         with pytest.raises(ValueError) as excinfo:
             bre.compile_replace(pattern, template, bre.FORMAT)

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -1970,6 +1970,18 @@ class TestReplaceTemplate(unittest.TestCase):
 class TestExceptions(unittest.TestCase):
     """Test Exceptions."""
 
+    def test_bad_group(self):
+        """Test bad group."""
+
+        with pytest.raises(TypeError):
+            bre.compile(r'(test)|(what)').sub(r'\2', 'test')
+
+    def test_bad_format_group(self):
+        """Test bad format group."""
+
+        with pytest.raises(TypeError):
+            bre.compile(r'(test)|(what)').subf(r'{2}', 'test')
+
     def test_immutable(self):
         """Test immutable object."""
 

--- a/tests/test_bregex.py
+++ b/tests/test_bregex.py
@@ -759,13 +759,13 @@ class TestReplaceTemplate(unittest.TestCase):
 
         pattern = regex.compile(r"(some)(.+?)(pattern)(!)")
         with pytest.raises(_regex_core.error):
-            _bregex_parse._ReplaceParser().parse(pattern, '\\1\\l\\')
+            _bregex_parse._ReplaceParser(pattern, '\\1\\l\\').parse()
 
         with pytest.raises(_regex_core.error):
-            _bregex_parse._ReplaceParser().parse(pattern, '\\1\\L\\')
+            _bregex_parse._ReplaceParser(pattern, '\\1\\L\\').parse()
 
         with pytest.raises(_regex_core.error):
-            _bregex_parse._ReplaceParser().parse(pattern, '\\1\\')
+            _bregex_parse._ReplaceParser(pattern, '\\1\\').parse()
 
     def test_line_break(self):
         r"""Test line break \R."""
@@ -844,8 +844,8 @@ class TestReplaceTemplate(unittest.TestCase):
         """Test retrieval of the replace template original string."""
 
         pattern = regex.compile(r"(some)(.+?)(pattern)(!)")
-        template = _bregex_parse._ReplaceParser()
-        template.parse(pattern, r'\c\1\2\C\3\E\4')
+        template = _bregex_parse._ReplaceParser(pattern, r'\c\1\2\C\3\E\4')
+        template.parse()
 
         self.assertEqual(r'\c\1\2\C\3\E\4', template.get_base_template())
 
@@ -1285,7 +1285,7 @@ class TestReplaceTemplate(unittest.TestCase):
 
         text = "Replace with template test!"
         pattern = bregex.compile_search('(.+)')
-        repl = _bregex_parse._ReplaceParser().parse(pattern, 'Success!')
+        repl = _bregex_parse._ReplaceParser(pattern, 'Success!').parse()
         expand = bregex.compile_replace(pattern, repl)
 
         m = pattern.match(text)
@@ -1795,7 +1795,7 @@ class TestExceptions(unittest.TestCase):
         """Test when a compile occurs on a template with flags passed."""
 
         pattern = regex.compile('test')
-        template = _bregex_parse._ReplaceParser().parse(pattern, 'whatever')
+        template = _bregex_parse._ReplaceParser(pattern, 'whatever').parse()
 
         with pytest.raises(ValueError) as excinfo:
             bregex.compile_replace(pattern, template, bregex.FORMAT)

--- a/tests/test_bregex.py
+++ b/tests/test_bregex.py
@@ -20,6 +20,13 @@ PY39_PLUS = (3, 9) <= sys.version_info
 class TestSearchTemplate(unittest.TestCase):
     """Search template tests."""
 
+    def test_named_lists_attribute(self):
+        """Test named list attribute."""
+
+        pattern1 = bregex.compile(r'\L<name>', name=['blue', 'green'])
+        pattern2 = regex.compile(r'\L<name>', name=['blue', 'green'])
+        self.assertEqual(pattern1.named_lists, pattern2.named_lists)
+
     def test_named_lists(self):
         """Test named lists."""
 
@@ -1675,6 +1682,18 @@ class TestReplaceTemplate(unittest.TestCase):
 
 class TestExceptions(unittest.TestCase):
     """Test Exceptions."""
+
+    def test_bad_group(self):
+        """Test bad group."""
+
+        with pytest.raises(TypeError):
+            bregex.compile(r'(test)|(what)').sub(r'\2', 'test')
+
+    def test_bad_format_group(self):
+        """Test bad format group."""
+
+        with pytest.raises(TypeError):
+            bregex.compile(r'(test)|(what)').subf(r'{2}', 'test')
 
     def test_immutable(self):
         """Test immutable object."""

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -89,3 +89,5 @@ class TestVersion(unittest.TestCase):
             Version(1, 2, 3, pre=1)
         with self.assertRaises(ValueError):
             Version(1, 2, 3, dev=1)
+        with self.assertRaises(ValueError):
+            parse_version('bad&version')

--- a/tools/unipropgen.py
+++ b/tools/unipropgen.py
@@ -24,8 +24,8 @@ ASCII_UNUSED = frozenset([x for x in range(0x80, UNICODE_RANGE[1] + 1)])
 ALL_ASCII = frozenset([x for x in range(ASCII_RANGE[0], ASCII_RANGE[1] + 1)])
 HEADER = '''\
 """Unicode Properties from Unicode version {} (autogen)."""
-
-'''
+{}'''
+TYPING = 'from typing import Dict\n\n'
 
 
 def uniformat(value):
@@ -248,8 +248,8 @@ def gen_blocks(output, ascii_props=False, append=False, prefix="", aliases=None)
 
     with codecs.open(output, 'a' if append else 'w', 'utf-8') as f:
         if not append:
-            f.write(HEADER.format(UNIVERSION))
-        f.write('%s_blocks = {' % prefix)
+            f.write(HEADER.format(UNIVERSION, TYPING))
+        f.write('%s_blocks: Dict[str, str] = {' % prefix)
         no_block = []
         last = -1
         found = set(['noblock'])
@@ -353,9 +353,9 @@ def gen_ccc(output, ascii_props=False, append=False, prefix="", aliases=None):
 
     with codecs.open(output, 'a' if append else 'w', 'utf-8') as f:
         if not append:
-            f.write(HEADER.format(UNIVERSION))
+            f.write(HEADER.format(UNIVERSION, TYPING))
         # Write out the Unicode properties
-        f.write('%s_canonical_combining_class = {\n' % prefix)
+        f.write('%s_canonical_combining_class: Dict[str, str] = {\n' % prefix)
         count = len(obj) - 1
         i = 0
         for k1, v1 in sorted(obj.items()):
@@ -442,9 +442,9 @@ def gen_scripts(
 
     with codecs.open(output, 'a' if append else 'w', 'utf-8') as f:
         if not append:
-            f.write(HEADER.format(UNIVERSION))
+            f.write(HEADER.format(UNIVERSION, TYPING))
         # Write out the Unicode properties
-        f.write('%s_%s = {\n' % (prefix, obj_name))
+        f.write('%s_%s: Dict[str, str] = {\n' % (prefix, obj_name))
         count = len(obj) - 1
         i = 0
         for k1, v1 in sorted(obj.items()):
@@ -457,9 +457,9 @@ def gen_scripts(
 
     with codecs.open(output_ext, 'a' if append else 'w', 'utf-8') as f:
         if not append:
-            f.write(HEADER.format(UNIVERSION))
+            f.write(HEADER.format(UNIVERSION, TYPING))
         # Write out the Unicode properties
-        f.write('%s_%s = {\n' % (prefix, obj_ext_name))
+        f.write('%s_%s: Dict[str, str] = {\n' % (prefix, obj_ext_name))
         count = len(obj2) - 1
         i = 0
         for k1, v1 in sorted(obj2.items()):
@@ -511,9 +511,9 @@ def gen_enum(
 
     with codecs.open(output, 'a' if append else 'w', 'utf-8') as f:
         if not append:
-            f.write(HEADER.format(UNIVERSION))
+            f.write(HEADER.format(UNIVERSION, TYPING))
         # Write out the Unicode properties
-        f.write('%s_%s = {\n' % (prefix, obj_name))
+        f.write('%s_%s: Dict[str, str] = {\n' % (prefix, obj_name))
         count = len(obj) - 1
         i = 0
         for k1, v1 in sorted(obj.items()):
@@ -567,9 +567,9 @@ def gen_age(output, ascii_props=False, append=False, prefix="", aliases=None):
 
     with codecs.open(output, 'a' if append else 'w', 'utf-8') as f:
         if not append:
-            f.write(HEADER)
+            f.write(HEADER.format(UNIVERSION, TYPING))
         # Write out the Unicode properties
-        f.write('%s_age = {\n' % prefix)
+        f.write('%s_age: Dict[str, str] = {\n' % prefix)
         count = len(obj) - 1
         i = 0
         for k1, v1 in sorted(obj.items()):
@@ -629,10 +629,10 @@ def gen_nf_quick_check(output, ascii_props=False, append=False, prefix="", alias
 
     with codecs.open(output, 'a' if append else 'w', 'utf-8') as f:
         if not append:
-            f.write(HEADER.format(UNIVERSION))
+            f.write(HEADER.format(UNIVERSION, TYPING))
         for key, value in sorted(nf.items()):
             # Write out the Unicode properties
-            f.write('%s_%s = {\n' % (prefix, key.replace('quickcheck', '_quick_check')))
+            f.write('%s_%s: Dict[str, str] = {\n' % (prefix, key.replace('quickcheck', '_quick_check')))
             count = len(value) - 1
             i = 0
             for k1, v1 in sorted(value.items()):
@@ -749,9 +749,9 @@ def gen_binary(table, output, ascii_props=False, append=False, prefix="", aliase
 
     with codecs.open(output, 'a' if append else 'w', 'utf-8') as f:
         if not append:
-            f.write(HEADER.format(UNIVERSION))
+            f.write(HEADER.format(UNIVERSION, TYPING))
         # Write out the Unicode properties
-        f.write('%s_binary = {\n' % prefix)
+        f.write('%s_binary: Dict[str, str] = {\n' % prefix)
         count = len(binary) - 1
         i = 0
         for k1, v1 in sorted(binary.items()):
@@ -800,8 +800,8 @@ def gen_bidi(output, ascii_props=False, append=False, prefix="", aliases=None):
 
     with codecs.open(output, 'a' if append else 'w', 'utf-8') as f:
         if not append:
-            f.write(HEADER.format(UNIVERSION))
-        f.write('%s_bidi_classes = {\n' % prefix)
+            f.write(HEADER.format(UNIVERSION, TYPING))
+        f.write('%s_bidi_classes: Dict[str, str] = {\n' % prefix)
         count = len(bidi_class) - 1
         i = 0
         for k1, v1 in sorted(bidi_class.items()):
@@ -978,8 +978,8 @@ def gen_alias(nonbinary, binary, output):
             alias['binary'][k] = v
 
     with codecs.open(output, 'w', 'utf-8') as f:
-        f.write(HEADER.format(UNIVERSION))
-        f.write('%s_alias = {\n' % prefix)
+        f.write(HEADER.format(UNIVERSION, TYPING))
+        f.write('%s_alias: Dict[str, Dict[str, str]] = {\n' % prefix)
         count = len(alias) - 1
         i = 0
         for k1, v1 in sorted(alias.items()):
@@ -1181,9 +1181,9 @@ def gen_properties(output, files, aliases, ascii_props=False, append=False):
 
     with codecs.open(files['gc'], 'a' if append else 'w', 'utf-8') as f:
         if not append:
-            f.write(HEADER.format(UNIVERSION))
+            f.write(HEADER.format(UNIVERSION, TYPING))
         # Write out the Unicode properties
-        f.write('%s_properties = {\n' % prefix)
+        f.write('%s_properties: Dict[str, Dict[str, str]] = {\n' % prefix)
         count = len(table) - 1
         i = 0
         for k1, v1 in sorted(table.items()):
@@ -1205,7 +1205,7 @@ def gen_properties(output, files, aliases, ascii_props=False, append=False):
 
     if not append:
         with codecs.open(os.path.join(output, '__init__.py'), 'w') as f:
-            f.write(HEADER.format(UNIVERSION))
+            f.write(HEADER.format(UNIVERSION, ''))
             for x in sorted(files):
                 f.write('from .%s import *  # noqa\n' % os.path.basename(files[x])[:-3])
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ deps=
     -rrequirements/extras.txt
     -rrequirements/test.txt
 commands=
+    {envbindir}/mypy
     {envbindir}/py.test --cov backrefs --cov-append tests
     {envbindir}/coverage html -d {envtmpdir}/coverage
     {envbindir}/coverage xml


### PR DESCRIPTION
This is an attempt at static typing. One thing to note, we needed to use types for Regex, so we had to create types for `Match` and `Pattern` for `Regex`. We needed to reuse these types in our API, so the only thing that seemed reasonable was to create some typed classes we could use in `_bregex_typing.py`. They match the `Regex` object structures and provide the necessary typing info. I'm not sure if this is the correct way or not.  I guess you could provide stub files, but then how do you reuse those types in your API? It seemed we needed to stub them directly in or code.

I guess people using our lib can reuse our internal types 🤷🏻.

Things were tricky with these objects simply because you can't just include the class and set them as a type. And simply calling `type(regex.compile(''))` isn't really sufficient for then reusing them with `AnyStr` and such. This was about the best way I could come up with, and I have no idea if this is proper or not.

Resolves #166 