### PR TITLE
Re format replace fixes

### DIFF
--- a/backrefs/__meta__.py
+++ b/backrefs/__meta__.py
@@ -192,5 +192,5 @@ def parse_version(ver: str) -> Version:
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(5, 1, 0, "final")
+__version_info__ = Version(5, 2, 0, "final")
 __version__ = __version_info__._get_canonical()

--- a/backrefs/_bre_parse.py
+++ b/backrefs/_bre_parse.py
@@ -1484,10 +1484,11 @@ class ReplaceTemplate(_util.Immutable, Generic[AnyStr]):
                         obj = m.group(g_index)
                     except IndexError:  # pragma: no cover
                         raise IndexError("'{}' is out of range!".format(g_index))
-                    if isinstance(sep, bytes):
-                        l = _util.format_bytes([] if obj is None else [obj], capture)
-                    else:
-                        l = _util.format_string([] if obj is None else [obj], capture)
+                    l = _util.format_captures(
+                        [] if obj is None else [obj],
+                        capture,
+                        _util._to_bstr if isinstance(sep, bytes) else _util._to_str
+                    )
                 if span_case is not None:
                     if span_case == _LOWER:
                         l = l.lower()

--- a/backrefs/_bregex_parse.py
+++ b/backrefs/_bregex_parse.py
@@ -1355,10 +1355,11 @@ class ReplaceTemplate(_util.Immutable, Generic[AnyStr]):
                         obj = cast(List[AnyStr], m.captures(g_index))
                     except IndexError:  # pragma: no cover
                         raise IndexError("'{}' is out of range!".format(g_index))
-                    if isinstance(sep, bytes):
-                        l = _util.format_bytes(obj, capture)
-                    else:
-                        l = _util.format_string(obj, capture)
+                    l = _util.format_captures(
+                        obj,
+                        capture,
+                        _util._to_bstr if isinstance(sep, bytes) else _util._to_str
+                    )
                 if span_case is not None:
                     if span_case == _LOWER:
                         l = l.lower()

--- a/backrefs/_bregex_parse.py
+++ b/backrefs/_bregex_parse.py
@@ -581,10 +581,7 @@ class _ReplaceParser(Generic[AnyStr]):
                         except StopIteration:
                             raise SyntaxError("Unmatched '[' at {}".format(sindex - 1))
                         idx = self.parse_format_index(''.join(findex))
-                        if isinstance(idx, int):
-                            value.append((_util.FMT_INDEX, idx))
-                        else:
-                            value.append((_util.FMT_INDEX, idx))
+                        value.append((_util.FMT_INDEX, idx))
                         c = self.format_next(i)
                     else:
                         if count == 0:
@@ -1349,15 +1346,13 @@ class ReplaceTemplate(_util.Immutable, Generic[AnyStr]):
                     try:
                         l = cast(Optional[AnyStr], m.group(g_index))
                         if l is None:
-                            raise TypeError("Index '{}' returned None type instead of str".format(g_index))
+                            l = sep
                     except IndexError:  # pragma: no cover
                         raise IndexError("'{}' is out of range!".format(g_index))
                 else:
                     # String format replace
                     try:
                         obj = cast(List[AnyStr], m.captures(g_index))
-                        if not obj:
-                            raise TypeError("Index '{}' returned no captures".format(g_index))
                     except IndexError:  # pragma: no cover
                         raise IndexError("'{}' is out of range!".format(g_index))
                     if isinstance(sep, bytes):

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,9 +1,22 @@
 # Changelog
 
+## 5.2
+
+- **NEW**: Add static typing.
+- **FIX**: Re format replacement captures behave more like Regex in that you can technically index into the captures of
+  a given group in Re, but in Re there is only ever one or zero captures. Documentation was never really explicit on
+  what one should expect if indexing a group in Re occurred. The documentation seemed to vaguely insinuate that it would
+  behave like a Regex capture list, just with one or zero values in the list. In reality, the value was a simple string
+  or `None`. This caused a bug in some cases where you'd have `None` inserted for a group if a group was optional, but
+  referenced in the replacement template. Now the implementation matches the description in the documentation with the
+  documentation now being more explicit about behavior.
+- **FIX**: Match Re and Regex handling when doing a non-format replacement that references a group that is present in
+  the search pattern but has no actual captures. Such a case should not fail, but simply return an empty string for the
+  group.
+
 ## 5.1
 
 - **NEW**: Add support for Python 3.10.
-- **NEW**: Add static typing.
 
 ## 5.0.1
 

--- a/docs/src/markdown/usage.md
+++ b/docs/src/markdown/usage.md
@@ -145,9 +145,9 @@ why.
     'foo bar => BAR FOO'
     ```
 
-2. The second enhancement that Backrefs adds is the ability to use format string alignment features. Here we center the
-  replacement, padding it out to 8 characters using `|` for the padding. We also use casing references (`\C...\E`) to
-  capitalize the replacement group.
+2. The second enhancement that Backrefs adds is the ability to use format string alignment features. In the following
+  example, we center the replacement and pad it out to 8 characters using `|` for the padding. We also use casing
+  references (`\C...\E`) to capitalize the replacement group.
 
     ```pycon3
     >>> bregex.subf(r'(test)', r'\C{0:|^8}\E', 'test')
@@ -177,18 +177,20 @@ why.
     type        ::=  "s"
     ```
 
-    !!! note "Conversion Syntax"
-        In almost all instances, using conversion types won't make sense in a regular expression replace as the objects
-        will already be strings in the needed format, but if you were to use a conversion, ASCII would be assumed, and
-        the object or Unicode string would be encoded with `backslashreplace`.
-
-3. Lastly, Backrefs allows format strings to work for byte strings as well as Unicode strings. This is something that
-   Regex did not allow.
+3. Lastly, our implementation of the [Format Specification Mini-Language][format-spec] (`format_spec`) allows format
+  strings to work for byte strings as well as Unicode strings. This is something that Regex does not allow without
+  Backrefs.
 
     ```pycon3
     >>> bre.subf(br'(test)', br'\C{0:|^8}\E', b'test')
     b'||TEST||'
     ```
+
+    !!! note "Conversion Syntax and Bytes"
+        In almost all instances, using conversion types (`{!s}`, etc.) won't make sense in a regular expression replace
+        as the objects will already be strings in the needed format, but if you were to use a conversion using byte
+        strings, when converting from `bytes` to `str`, ASCII will be the assumed encoding, and the object or Unicode
+        string would be encoded using the `backslashreplace` option as well.
 
 ## Advanced Usage
 

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -841,6 +841,11 @@ class TestSearchTemplate(unittest.TestCase):
 class TestReplaceTemplate(unittest.TestCase):
     """Test replace template."""
 
+    def test_existing_group_no_match(self):
+        """Test existing group with no match."""
+
+        self.assertEqual(bre.compile(r'(test)|(what)').sub(r'\2', 'test'), '')
+
     def test_hash(self):
         """Test hashing of replace."""
 
@@ -1712,7 +1717,7 @@ class TestReplaceTemplate(unittest.TestCase):
         )
         results = expand(pattern.match(text))
         self.assertEqual(
-            'ba',
+            'ababababab',
             results
         )
 
@@ -1744,7 +1749,7 @@ class TestReplaceTemplate(unittest.TestCase):
         )
 
         results = expand(pattern.match(text))
-        self.assertEqual(b'989898', results)
+        self.assertEqual(b'bbb', results)
 
     def test_format_escapes(self):
         """Test format escapes."""
@@ -1970,16 +1975,10 @@ class TestReplaceTemplate(unittest.TestCase):
 class TestExceptions(unittest.TestCase):
     """Test Exceptions."""
 
-    def test_bad_group(self):
-        """Test bad group."""
-
-        with pytest.raises(TypeError):
-            bre.compile(r'(test)|(what)').sub(r'\2', 'test')
-
     def test_bad_format_group(self):
         """Test bad format group."""
 
-        with pytest.raises(TypeError):
+        with pytest.raises(IndexError):
             bre.compile(r'(test)|(what)').subf(r'{2}', 'test')
 
     def test_immutable(self):

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -915,6 +915,11 @@ class TestReplaceTemplate(unittest.TestCase):
         with pytest.raises(TypeError):
             bre.subf(b'test', br'{[test]}', b'test', bre.FORMAT)
 
+    def test_format_ascii_align(self):
+        """Test format ASCII."""
+
+        self.assertEqual(bre.subf('test', r'{0!a:|^8}', 'test'), "|'test'|")
+
     def test_format_conversions(self):
         """Test string format conversion paths."""
 

--- a/tests/test_bregex.py
+++ b/tests/test_bregex.py
@@ -610,6 +610,11 @@ class TestSearchTemplate(unittest.TestCase):
 class TestReplaceTemplate(unittest.TestCase):
     """Test replace template."""
 
+    def test_existing_group_no_match(self):
+        """Test existing group with no match."""
+
+        self.assertEqual(bregex.compile(r'(test)|(what)').sub(r'\2', 'test'), '')
+
     def test_hash(self):
         """Test hashing of replace."""
 
@@ -1683,16 +1688,10 @@ class TestReplaceTemplate(unittest.TestCase):
 class TestExceptions(unittest.TestCase):
     """Test Exceptions."""
 
-    def test_bad_group(self):
-        """Test bad group."""
-
-        with pytest.raises(TypeError):
-            bregex.compile(r'(test)|(what)').sub(r'\2', 'test')
-
     def test_bad_format_group(self):
         """Test bad format group."""
 
-        with pytest.raises(TypeError):
+        with pytest.raises(IndexError):
             bregex.compile(r'(test)|(what)').subf(r'{2}', 'test')
 
     def test_immutable(self):


### PR DESCRIPTION
Re format replacement captures behave more like Regex in that you can
technically index into the captures of a given group in Re, but in Re
there is only ever one or zero captures. Documentation was never really
explicit on what one should expect if indexing a group in Re occurred.
The documentation seemed to vaguely insinuate that it would behave like
a Regex capture list, just with one or zero values in the list. In
reality the value was simple a string or `None`. This caused a bug in
some cases where you'd have `None` inserted for a group if a group was
optional, but referenced in the replacement template. Now the
implementation matches the description in the documentation with the
documentation now being more explicit about behavior.