### PR TITLE
Fix: Format replace with no captures in a group should be an empty str

### DIFF
--- a/.pyspelling.yml
+++ b/.pyspelling.yml
@@ -21,7 +21,7 @@ matrix:
       - 'a:is(.magiclink-compare, .magiclink-commit, .magiclink-repository)'
       - 'span.keys'
       - '.MathJax_Preview, .md-nav__link, .md-footer-custom-text, .md-source__repository, .headerlink, .md-icon'
-      - '.md-footer-social__link'
+      - '.md-footer-social__link, .magiclink-issue'
   - pyspelling.filters.url:
 
 - name: markdown

--- a/backrefs/_bre_parse.py
+++ b/backrefs/_bre_parse.py
@@ -722,8 +722,10 @@ class _ReplaceParser(Generic[AnyStr]):
                     value = [(_util.FMT_FIELD, field)]
                     pass
 
+                if c != '[':
+                    value.append((_util.FMT_INDEX, None))
+
                 # Attributes and indexes
-                count = 0
                 while c in ('[', '.'):
                     if c == '[':
                         findex = []
@@ -739,18 +741,12 @@ class _ReplaceParser(Generic[AnyStr]):
                         value.append((_util.FMT_INDEX, idx))
                         c = self.format_next(i)
                     else:
-                        if count == 0:
-                            value.append((_util.FMT_INDEX, -1))
                         findex = []
                         c = self.format_next(i)
                         while c in _WORD:
                             findex.append(c)
                             c = self.format_next(i)
                         value.append((_util.FMT_ATTR, ''.join(findex)))
-                    count += 1
-
-                if count == 0:
-                    value.append((_util.FMT_INDEX, -1))
 
                 # Conversion
                 if c == '!':
@@ -1487,7 +1483,8 @@ class ReplaceTemplate(_util.Immutable, Generic[AnyStr]):
                     l = _util.format_captures(
                         [] if obj is None else [obj],
                         capture,
-                        _util._to_bstr if isinstance(sep, bytes) else _util._to_str
+                        _util._to_bstr if isinstance(sep, bytes) else _util._to_str,
+                        sep
                     )
                 if span_case is not None:
                     if span_case == _LOWER:

--- a/backrefs/_bregex_parse.py
+++ b/backrefs/_bregex_parse.py
@@ -540,7 +540,7 @@ class _ReplaceParser(Generic[AnyStr]):
         try:
             if c == '}':
                 value.append((_util.FMT_FIELD, ''))
-                value.append((_util.FMT_INDEX, -1))
+                value.append((_util.FMT_INDEX, None))
             else:
                 # Field
                 temp = []  # type: List[str]
@@ -567,8 +567,10 @@ class _ReplaceParser(Generic[AnyStr]):
                     value = [(_util.FMT_FIELD, field)]
                     pass
 
+                if c != '[':
+                    value.append((_util.FMT_INDEX, None))
+
                 # Attributes and indexes
-                count = 0
                 while c in ('[', '.'):
                     if c == '[':
                         findex = []
@@ -584,18 +586,12 @@ class _ReplaceParser(Generic[AnyStr]):
                         value.append((_util.FMT_INDEX, idx))
                         c = self.format_next(i)
                     else:
-                        if count == 0:
-                            value.append((_util.FMT_INDEX, -1))
                         findex = []
                         c = self.format_next(i)
                         while c in _WORD:
                             findex.append(c)
                             c = self.format_next(i)
                         value.append((_util.FMT_ATTR, ''.join(findex)))
-                    count += 1
-
-                if count == 0:
-                    value.append((_util.FMT_INDEX, -1))
 
                 # Conversion
                 if c == '!':
@@ -1358,7 +1354,8 @@ class ReplaceTemplate(_util.Immutable, Generic[AnyStr]):
                     l = _util.format_captures(
                         obj,
                         capture,
-                        _util._to_bstr if isinstance(sep, bytes) else _util._to_str
+                        _util._to_bstr if isinstance(sep, bytes) else _util._to_str,
+                        sep
                     )
                 if span_case is not None:
                     if span_case == _LOWER:

--- a/backrefs/util.py
+++ b/backrefs/util.py
@@ -83,7 +83,8 @@ def _to_str(obj: Any) -> str:
 def format_captures(
     captures: List[AnyStr],
     formatting: Tuple[Tuple[int, Any]],
-    converter: Callable[[Any], AnyStr]
+    converter: Callable[[Any], AnyStr],
+    default: AnyStr
 ) -> AnyStr:
     """Perform a string format on a set of captures."""
 
@@ -97,7 +98,10 @@ def format_captures(
             capture = getattr(capture, value)
         elif fmt_type == FMT_INDEX:
             # Index
-            capture = capture[value]
+            if value is not None:
+                capture = capture[value]
+            else:
+                capture = default if not capture else capture[0]
         elif fmt_type == FMT_CONV:
             # Conversion
             if value == 'a':

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -13,6 +13,10 @@
 - **FIX**: Match Re and Regex handling when doing a non-format replacement that references a group that is present in
   the search pattern but has no actual captures. Such a case should not fail, but simply return an empty string for the
   group.
+- **FIX**: Format replacements that that have groups with no captures will yield an empty string as the only capture as
+  long as the user does not try to index into any captures as there are no actual captures. This behavior was a bug in
+  Regex that we duplicated and should now be fixed in the latest Regex (mrabarnett/mrab-regex#439) as well as in
+  Backrefs.
 
 ## 5.1
 

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -841,6 +841,11 @@ class TestSearchTemplate(unittest.TestCase):
 class TestReplaceTemplate(unittest.TestCase):
     """Test replace template."""
 
+    def test_format_existing_group_no_match(self):
+        """Test format replacement with existing group with no match."""
+
+        self.assertEqual(bre.compile(r'(test)|(what)').subf(r'{1}{2}', 'test'), 'test')
+
     def test_existing_group_no_match(self):
         """Test existing group with no match."""
 
@@ -1980,11 +1985,11 @@ class TestReplaceTemplate(unittest.TestCase):
 class TestExceptions(unittest.TestCase):
     """Test Exceptions."""
 
-    def test_bad_format_group(self):
-        """Test bad format group."""
+    def test_format_existing_group_no_match_with_index(self):
+        """Test format group with no match and attempt at indexing."""
 
         with pytest.raises(IndexError):
-            bre.compile(r'(test)|(what)').subf(r'{2}', 'test')
+            bre.compile(r'(test)|(what)').subf(r'{2[0]}', 'test')
 
     def test_immutable(self):
         """Test immutable object."""

--- a/tests/test_bregex.py
+++ b/tests/test_bregex.py
@@ -610,6 +610,11 @@ class TestSearchTemplate(unittest.TestCase):
 class TestReplaceTemplate(unittest.TestCase):
     """Test replace template."""
 
+    def test_format_existing_group_no_match(self):
+        """Test format replacement with existing group with no match."""
+
+        self.assertEqual(bregex.compile(r'(test)|(what)').subf(r'{1}{2}', 'test'), 'test')
+
     def test_existing_group_no_match(self):
         """Test existing group with no match."""
 
@@ -1688,11 +1693,11 @@ class TestReplaceTemplate(unittest.TestCase):
 class TestExceptions(unittest.TestCase):
     """Test Exceptions."""
 
-    def test_bad_format_group(self):
-        """Test bad format group."""
+    def test_format_existing_group_no_match_with_index(self):
+        """Test format group with no match and attempt at indexing."""
 
         with pytest.raises(IndexError):
-            bregex.compile(r'(test)|(what)').subf(r'{2}', 'test')
+            bregex.compile(r'(test)|(what)').subf(r'{2[0]}', 'test')
 
     def test_immutable(self):
         """Test immutable object."""


### PR DESCRIPTION
This only applies if no attempt to index the captures occurs.