### PR TITLE
Replace use of Optional in type annotations

### DIFF
--- a/backrefs/_bre_parse.py
+++ b/backrefs/_bre_parse.py
@@ -11,7 +11,7 @@ import copyreg as _copyreg
 from . import util as _util
 import unicodedata as _unicodedata
 from . import uniprops as _uniprops
-from typing import Generic, AnyStr, Optional, Match, Any, Pattern
+from typing import Generic, AnyStr, Match, Any, Pattern
 
 if sys.version_info >= (3, 11):
     import re._parser as _parser  # type: ignore[import]
@@ -88,7 +88,7 @@ class _SearchParser(Generic[AnyStr]):
     is_bytes: bool
     search: AnyStr
 
-    def __init__(self, search: AnyStr, re_verbose: bool = False, re_unicode: Optional[bool] = None) -> None:
+    def __init__(self, search: AnyStr, re_verbose: bool = False, re_unicode: bool | None = None) -> None:
         """Initialize."""
 
         if isinstance(search, bytes):
@@ -312,7 +312,7 @@ class _SearchParser(Generic[AnyStr]):
             current.extend(["\\", t])
         return current
 
-    def get_comments(self, i: _util.StringIter) -> Optional[str]:
+    def get_comments(self, i: _util.StringIter) -> str | None:
         """Get comments."""
 
         index = i.index
@@ -343,7 +343,7 @@ class _SearchParser(Generic[AnyStr]):
 
         return ''.join(value)
 
-    def get_flags(self, i: _util.StringIter, scoped: bool = False) -> Optional[str]:
+    def get_flags(self, i: _util.StringIter, scoped: bool = False) -> str | None:
         """Get flags."""
 
         index = i.index
@@ -464,7 +464,7 @@ class _SearchParser(Generic[AnyStr]):
                 elif t == "[":
                     index = i.index
                     try:
-                        prop = self.get_unicode_property(i, True)  # type: Optional[tuple[str, str]]
+                        prop = self.get_unicode_property(i, True)  # type: tuple[str, str] | None
                     except Exception:
                         prop = None
                         i.rewind(i.index - index)
@@ -546,7 +546,7 @@ class _SearchParser(Generic[AnyStr]):
     def unicode_props(
         self,
         props: str,
-        prop_value: Optional[str],
+        prop_value: str | None,
         in_group: bool = False,
         negate: bool = False
     ) -> list[str]:
@@ -659,12 +659,12 @@ class _ReplaceParser(Generic[AnyStr]):
         self._template = template  # type: AnyStr
         self.use_format = use_format
         self.end_found = False
-        self.group_slots = []  # type: list[tuple[int, tuple[Optional[int], Optional[int], Any]]]
+        self.group_slots = []  # type: list[tuple[int, tuple[int | None, int | None, Any]]]
         self.literal_slots = []  # type: list[str]
         self.result = []  # type: list[str]
         self.span_stack = []  # type: list[int]
         self.single_stack = []  # type: list[int]
-        self.literals = []  # type: list[Optional[AnyStr]]
+        self.literals = []  # type: list[AnyStr | None]
         self.groups = []  # type: list[tuple[int, int]]
         self.slot = 0
         self.manual = False
@@ -764,7 +764,7 @@ class _ReplaceParser(Generic[AnyStr]):
 
                 # Format spec
                 if c == ':':
-                    fill = None  # type: Optional[str]
+                    fill = None  # type: str | None
                     width = []
                     align = None
                     convert = None
@@ -854,7 +854,7 @@ class _ReplaceParser(Generic[AnyStr]):
             else:
                 raise SyntaxError("Unmatched '}}' at {}!".format(i.index - 2))
 
-    def get_octal(self, c: str, i: _util.StringIter) -> Optional[str]:
+    def get_octal(self, c: str, i: _util.StringIter) -> str | None:
         """Get octal."""
 
         index = i.index
@@ -1056,7 +1056,7 @@ class _ReplaceParser(Generic[AnyStr]):
 
         return ''.join(value)
 
-    def get_group(self, t: str, i: _util.StringIter) -> Optional[str]:
+    def get_group(self, t: str, i: _util.StringIter) -> str | None:
         """Get group number."""
 
         value = []
@@ -1262,7 +1262,7 @@ class _ReplaceParser(Generic[AnyStr]):
         except StopIteration:
             pass
 
-    def get_single_stack(self) -> Optional[int]:
+    def get_single_stack(self) -> int | None:
         """Get the correct single stack item to use."""
 
         single = None
@@ -1296,7 +1296,7 @@ class _ReplaceParser(Generic[AnyStr]):
     def handle_group(
         self,
         text: str,
-        capture: Optional[tuple[tuple[int, Any], ...]] = None,
+        capture: tuple[tuple[int, Any], ...] | None = None,
         is_format: bool = False
     ) -> None:
         """Handle groups."""
@@ -1356,8 +1356,8 @@ class ReplaceTemplate(_util.Immutable, Generic[AnyStr]):
     __slots__ = ("groups", "group_slots", "literals", "pattern_hash", "use_format", "_hash", "_bytes")
 
     groups: tuple[tuple[int, int], ...]
-    group_slots: tuple[tuple[int, tuple[Optional[int], Optional[int], Any]], ...]
-    literals: tuple[Optional[AnyStr], ...]
+    group_slots: tuple[tuple[int, tuple[int | None, int | None, Any]], ...]
+    literals: tuple[AnyStr | None, ...]
     pattern_hash: int
     use_format: bool
     _hash: int
@@ -1366,8 +1366,8 @@ class ReplaceTemplate(_util.Immutable, Generic[AnyStr]):
     def __init__(
         self,
         groups: tuple[tuple[int, int], ...],
-        group_slots: tuple[tuple[int, tuple[Optional[int], Optional[int], Any]], ...],
-        literals: tuple[Optional[AnyStr], ...],
+        group_slots: tuple[tuple[int, tuple[int | None, int | None, Any]], ...],
+        literals: tuple[AnyStr | None, ...],
         pattern_hash: int,
         use_format: bool,
         is_bytes: bool
@@ -1390,7 +1390,7 @@ class ReplaceTemplate(_util.Immutable, Generic[AnyStr]):
             )
         )
 
-    def __call__(self, m: Optional[Match[AnyStr]]) -> AnyStr:
+    def __call__(self, m: Match[AnyStr] | None) -> AnyStr:
         """Call."""
 
         return self.expand(m)
@@ -1445,17 +1445,17 @@ class ReplaceTemplate(_util.Immutable, Generic[AnyStr]):
                 break
         return g_index
 
-    def _get_group_attributes(self, index: int) -> tuple[Optional[int], Optional[int], Any]:
+    def _get_group_attributes(self, index: int) -> tuple[int | None, int | None, Any]:
         """Find and return the appropriate group case."""
 
-        g_case = (None, None, -1)  # type: tuple[Optional[int], Optional[int], Any]
+        g_case = (None, None, -1)  # type: tuple[int | None, int | None, Any]
         for group in self.group_slots:
             if group[0] == index:
                 g_case = group[1]
                 break
         return g_case
 
-    def expand(self, m: Optional[Match[AnyStr]]) -> AnyStr:
+    def expand(self, m: Match[AnyStr] | None) -> AnyStr:
         """Using the template, expand the string."""
 
         if m is None:

--- a/backrefs/bre.py
+++ b/backrefs/bre.py
@@ -33,7 +33,7 @@ from functools import lru_cache as _lru_cache
 from . import util as _util
 from . import _bre_parse
 from ._bre_parse import ReplaceTemplate
-from typing import AnyStr, Pattern, Match, Callable, Any, Optional, Generic, Mapping, Iterator, cast
+from typing import AnyStr, Pattern, Match, Callable, Any, Generic, Mapping, Iterator, cast
 
 __all__ = (
     "expand", "expandf", "search", "match", "fullmatch", "split", "findall", "finditer", "sub", "subf",
@@ -118,7 +118,7 @@ def _is_replace(obj: Any) -> bool:
 
 
 def _apply_replace_backrefs(
-    m: Optional[Match[AnyStr]],
+    m: Match[AnyStr] | None,
     repl: ReplaceTemplate[AnyStr] | AnyStr,
     flags: int = 0
 ) -> AnyStr:
@@ -217,10 +217,10 @@ class Bre(_util.Immutable, Generic[AnyStr]):
         return self._pattern.groupindex
 
     @property
-    def groups(self) -> tuple[Optional[AnyStr], ...]:
+    def groups(self) -> tuple[AnyStr | None, ...]:
         """Return groups."""
 
-        return cast('tuple[Optional[AnyStr], ...]', self._pattern.groups)
+        return cast('tuple[AnyStr | None, ...]', self._pattern.groups)
 
     @property
     def scanner(self) -> Any:
@@ -291,7 +291,7 @@ class Bre(_util.Immutable, Generic[AnyStr]):
         string: AnyStr,
         *args: Any,
         **kwargs: Any
-    ) -> Optional[Match[AnyStr]]:
+    ) -> Match[AnyStr] | None:
         """Apply `search`."""
 
         return self._pattern.search(string, *args, **kwargs)
@@ -301,7 +301,7 @@ class Bre(_util.Immutable, Generic[AnyStr]):
         string: AnyStr,
         *args: Any,
         **kwargs: Any
-    ) -> Optional[Match[AnyStr]]:
+    ) -> Match[AnyStr] | None:
         """Apply `match`."""
 
         return self._pattern.match(string, *args, **kwargs)
@@ -311,7 +311,7 @@ class Bre(_util.Immutable, Generic[AnyStr]):
         string: AnyStr,
         *args: Any,
         **kwargs: Any
-    ) -> Optional[Match[AnyStr]]:
+    ) -> Match[AnyStr] | None:
         """Apply `fullmatch`."""
 
         return self._pattern.fullmatch(string, *args, **kwargs)
@@ -394,7 +394,7 @@ class Bre(_util.Immutable, Generic[AnyStr]):
 def compile(  # noqa A001
     pattern: AnyStr | Pattern[AnyStr] | Bre[AnyStr],
     flags: int = 0,
-    auto_compile: Optional[bool] = None
+    auto_compile: bool | None = None
 ) -> 'Bre[AnyStr]':
     """Compile both the search or search and replace into one object."""
 
@@ -453,14 +453,14 @@ def purge() -> None:
     _re.purge()
 
 
-def expand(m: Optional[Match[AnyStr]], repl: ReplaceTemplate[AnyStr] | AnyStr) -> AnyStr:
+def expand(m: Match[AnyStr] | None, repl: ReplaceTemplate[AnyStr] | AnyStr) -> AnyStr:
     """Expand the string using the replace pattern or function."""
 
     _assert_expandable(repl)
     return _apply_replace_backrefs(m, repl)
 
 
-def expandf(m: Optional[Match[AnyStr]], repl: ReplaceTemplate[AnyStr] | AnyStr) -> AnyStr:
+def expandf(m: Match[AnyStr] | None, repl: ReplaceTemplate[AnyStr] | AnyStr) -> AnyStr:
     """Expand the string using the format replace pattern or function."""
 
     _assert_expandable(repl, True)
@@ -472,7 +472,7 @@ def search(
     string: AnyStr,
     *args: Any,
     **kwargs: Any
-) -> Optional[Match[AnyStr]]:
+) -> Match[AnyStr] | None:
     """Apply `search` after applying backrefs."""
 
     flags = args[2] if len(args) > 2 else kwargs.get('flags', 0)
@@ -484,7 +484,7 @@ def match(
     string: AnyStr,
     *args: Any,
     **kwargs: Any
-) -> Optional[Match[AnyStr]]:
+) -> Match[AnyStr] | None:
     """Apply `match` after applying backrefs."""
 
     flags = args[2] if len(args) > 2 else kwargs.get('flags', 0)
@@ -496,7 +496,7 @@ def fullmatch(
     string: AnyStr,
     *args: Any,
     **kwargs: Any
-) -> Optional[Match[AnyStr]]:
+) -> Match[AnyStr] | None:
     """Apply `fullmatch` after applying backrefs."""
 
     flags = args[2] if len(args) > 2 else kwargs.get('flags', 0)

--- a/backrefs/bregex.py
+++ b/backrefs/bregex.py
@@ -21,7 +21,7 @@ from functools import lru_cache as _lru_cache
 from . import util as _util
 from . import _bregex_parse
 from ._bregex_parse import ReplaceTemplate
-from typing import AnyStr, Callable, Any, Optional, Generic, Mapping, Iterator, cast
+from typing import AnyStr, Callable, Any, Generic, Mapping, Iterator, cast
 from ._bregex_typing import Pattern, Match
 
 __all__ = (
@@ -131,7 +131,7 @@ def _is_replace(obj: Any) -> bool:
 
 
 def _apply_replace_backrefs(
-    m: Optional[Match[AnyStr]],
+    m: Match[AnyStr] | None,
     repl: ReplaceTemplate[AnyStr] | AnyStr,
     flags: int = 0
 ) -> AnyStr:
@@ -231,10 +231,10 @@ class Bregex(_util.Immutable, Generic[AnyStr]):
         return cast(Mapping[str, int], self._pattern.groupindex)
 
     @property
-    def groups(self) -> tuple[Optional[AnyStr], ...]:
+    def groups(self) -> tuple[AnyStr | None, ...]:
         """Return groups."""
 
-        return cast('tuple[Optional[AnyStr], ...]', self._pattern.groups)
+        return cast('tuple[AnyStr | None, ...]', self._pattern.groups)
 
     @property
     def scanner(self) -> Any:
@@ -311,7 +311,7 @@ class Bregex(_util.Immutable, Generic[AnyStr]):
         string: AnyStr,
         *args: Any,
         **kwargs: Any
-    ) -> Optional[Match[AnyStr]]:
+    ) -> Match[AnyStr] | None:
         """Apply `search`."""
 
         return self._pattern.search(string, *args, **kwargs)
@@ -321,20 +321,20 @@ class Bregex(_util.Immutable, Generic[AnyStr]):
         string: AnyStr,
         *args: Any,
         **kwargs: Any
-    ) -> Optional[Match[AnyStr]]:
+    ) -> Match[AnyStr] | None:
         """Apply `match`."""
 
-        return cast(Optional[Match[AnyStr]], self._pattern.match(string, *args, **kwargs))
+        return cast('Match[AnyStr] | None', self._pattern.match(string, *args, **kwargs))
 
     def fullmatch(
         self,
         string: AnyStr,
         *args: Any,
         **kwargs: Any
-    ) -> Optional[Match[AnyStr]]:
+    ) -> Match[AnyStr] | None:
         """Apply `fullmatch`."""
 
-        return cast(Optional[Match[AnyStr]], self._pattern.fullmatch(string, *args, **kwargs))
+        return cast('Match[AnyStr] | None', self._pattern.fullmatch(string, *args, **kwargs))
 
     def split(
         self,
@@ -424,7 +424,7 @@ class Bregex(_util.Immutable, Generic[AnyStr]):
 def compile(  # noqa A001
     pattern: AnyStr | Pattern[AnyStr] | Bregex[AnyStr],
     flags: int = 0,
-    auto_compile: Optional[bool] = None,
+    auto_compile: bool | None = None,
     **kwargs: Any
 ) -> 'Bregex[AnyStr]':
     """Compile both the search or search and replace into one object."""
@@ -485,14 +485,14 @@ def purge() -> None:
     _regex.purge()
 
 
-def expand(m: Optional[Match[AnyStr]], repl: ReplaceTemplate[AnyStr] | AnyStr) -> AnyStr:
+def expand(m: Match[AnyStr] | None, repl: ReplaceTemplate[AnyStr] | AnyStr) -> AnyStr:
     """Expand the string using the replace pattern or function."""
 
     _assert_expandable(repl)
     return _apply_replace_backrefs(m, repl)
 
 
-def expandf(m: Optional[Match[AnyStr]], repl: ReplaceTemplate[AnyStr] | AnyStr) -> AnyStr:
+def expandf(m: Match[AnyStr] | None, repl: ReplaceTemplate[AnyStr] | AnyStr) -> AnyStr:
     """Expand the string using the format replace pattern or function."""
 
     _assert_expandable(repl, True)
@@ -504,12 +504,12 @@ def match(
     string: AnyStr,
     *args: Any,
     **kwargs: Any
-) -> Optional[Match[AnyStr]]:
+) -> Match[AnyStr] | None:
     """Wrapper for `match`."""
 
     flags = args[2] if len(args) > 2 else kwargs.get('flags', 0)
     return cast(
-        Optional[Match[AnyStr]],
+        'Match[AnyStr] | None',
         _regex.match(_apply_search_backrefs(pattern, flags), string, *args, **kwargs)
     )
 
@@ -519,12 +519,12 @@ def fullmatch(
     string: AnyStr,
     *args: Any,
     **kwargs: Any
-) -> Optional[Match[AnyStr]]:
+) -> Match[AnyStr] | None:
     """Wrapper for `fullmatch`."""
 
     flags = args[2] if len(args) > 2 else kwargs.get('flags', 0)
     return cast(
-        Optional[Match[AnyStr]],
+        'Match[AnyStr] | None',
         _regex.fullmatch(_apply_search_backrefs(pattern, flags), string, *args, **kwargs)
     )
 
@@ -534,12 +534,12 @@ def search(
     string: AnyStr,
     *args: Any,
     **kwargs: Any
-) -> Optional[Match[AnyStr]]:
+) -> Match[AnyStr] | None:
     """Wrapper for `search`."""
 
     flags = args[2] if len(args) > 2 else kwargs.get('flags', 0)
     return cast(
-        Optional[Match[AnyStr]],
+        'Match[AnyStr] | None',
         _regex.search(_apply_search_backrefs(pattern, flags), string, *args, **kwargs)
     )
 

--- a/backrefs/uniprops/__init__.py
+++ b/backrefs/uniprops/__init__.py
@@ -1,7 +1,6 @@
 """Unicode Properties."""
 from __future__ import annotations
 from . import unidata
-from typing import Optional
 
 UNICODE_RANGE = '\u0000-\U0010ffff'
 ASCII_RANGE = '\x00-\xff'
@@ -477,7 +476,7 @@ def _is_binary(name: str) -> bool:
     return name in unidata.unicode_binary or name in unidata.unicode_alias['binary']
 
 
-def get_unicode_property(prop: str, value: Optional[str] = None, mode: int = MODE_UNICODE) -> str:
+def get_unicode_property(prop: str, value: str | None = None, mode: int = MODE_UNICODE) -> str:
     """Retrieve the Unicode category from the table."""
 
     if value is not None:


### PR DESCRIPTION
Since we use `from __future__ import annotations` type annotations will be ignored as strings. We can use `type | None` even on older Python versions.