### PR TITLE
Deprecate use of `\e` and `\h` in favor of more suitable alternatives

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 - 2022 Isaac Muse
+Copyright (c) 2015 - 2023 Isaac Muse
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -27,22 +27,7 @@ https://facelessuser.github.io/backrefs/
 
 # License
 
-Released under the MIT license.
-
-Copyright (c) 2015 - 2022 Isaac Muse <isaacmuse@gmail.com>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
-documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
-rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
-persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
-Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
-WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+MIT
 
 [github-ci-image]: https://github.com/facelessuser/backrefs/workflows/build/badge.svg?branch=master&event=push
 [github-ci-link]: https://github.com/facelessuser/backrefs/actions?query=workflow%3Abuild+branch%3Amaster

--- a/backrefs/_bre_parse.py
+++ b/backrefs/_bre_parse.py
@@ -288,8 +288,10 @@ class _SearchParser(Generic[AnyStr]):
             mark = self.unicode_props("m", None, in_group=False)[0]
             current.extend(self._grapheme_cluster.format(no_mark, mark, mark))
         elif t == "e":
+            _util.warn_deprecated(R"The \e reference has been deprecated, please use \x1b instead")
             current.append(self._re_escape)
         elif t == "h":
+            _util.warn_deprecated(R"The \h reference has been deprecated, please use \p{Horiz_Space} instead")
             current.extend(self.unicode_props('blank', None, in_group=in_group))
             if in_group:
                 self.found_property = True

--- a/backrefs/_bregex_parse.py
+++ b/backrefs/_bregex_parse.py
@@ -192,6 +192,7 @@ class _SearchParser(Generic[AnyStr]):
         if not in_group and t == "R":
             current.append(self._re_line_break)
         elif t == 'e':
+            _util.warn_deprecated(R"The \e reference has been deprecated, please use \x1b instead")
             current.extend(self._re_escape)
         else:
             current.extend(["\\", t])

--- a/backrefs/bre.py
+++ b/backrefs/bre.py
@@ -16,11 +16,9 @@ Add the ability to use the following backrefs with re:
  - `\PL`, `\P{Lu}`, `\p{^Lu}`                                    - Inverse Unicode properties (search Unicode)
  - `\N{Black Club Suit}`                                         - Unicode character by name (search & replace)
  - `\u0000` and `\U00000000`                                     - Unicode characters (replace)
- - `\e`                                                          - Escape character (search)
  - `\m`                                                          - Starting word boundary (search)
  - `\M`                                                          - Ending word boundary (search)
  - `\R`                                                          - Generic line breaks (search)
- - `\h`                                                          - Horizontal whitespace (search)
  - `\X`                                                          - Simplified grapheme clusters (search)
 
 Licensed under MIT

--- a/backrefs/bregex.py
+++ b/backrefs/bregex.py
@@ -9,7 +9,6 @@ Add the ability to use the following backrefs with re:
  - `\N{Black Club Suit}`                                        - Unicode character by name (replace)
  - `\u0000` and `\U00000000`                                    - Unicode characters (replace)
  - `\R`                                                         - Generic line breaks (search)
- - `\e`                                                         - Escape character (search)
 
 Licensed under MIT
 Copyright (c) 2015 - 2020 Isaac Muse <isaacmuse@gmail.com>

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 6.0
+
+- **NEW**: `\e` and `\h` have both been deprecated in 6.0. Please migrate to using `\x1b` and `\p{Horiz_Space}` in their
+  respective place.
+
 ## 5.4
 
 - **NEW**: Officially support Python 3.11.

--- a/docs/src/markdown/refs.md
+++ b/docs/src/markdown/refs.md
@@ -15,7 +15,7 @@ support.
 
 Back\ References      | Description
 --------------------- |------------
-`\e`                  | Escape character `\x1b`.
+`\e`                  | **Deprecated: Use `\x1b` instead.** Escape character `\x1b`.
 `\Q...\E`             | Quotes (escapes) text for regular expression.  `\E` signifies the end of the quoting. Affects any and all characters no matter where in the regular expression pattern it is placed.
 `\p{UnicodeProperty}` | Unicode property character class. Can be used in character classes `[]`. See [Unicode Properties](#unicode-properties) for more info.
 `\pX`                 | Unicode property character class where `X` is the uppercase letter that represents the General Category property.  For instance, `\pL` would be equivalent to `\p{L}` or `\p{Letter}`.
@@ -25,9 +25,13 @@ Back\ References      | Description
 `\N{UnicodeName}`     | Named characters are are normally ignored in Re, but Backrefs adds support for them.
 `\m`                  | Start word boundary. Translates to `\b(?=\w)`.
 `\M`                  | End word boundary. Translates to `\b(?<=\w)`.
-`\h`                  | Horizontal whitespace. Equivalent to using `[[:blank:]]` or `[\t\p{Zs}]`.
+`\h`                  | **Deprecated: Use `\p{Horiz_Space}` instead.** Horizontal whitespace. Equivalent to using `[[:blank:]]` or `[\t\p{Zs}]`.
 `\R`                  | Generic line breaks. This will use the pattern `(?:\r\n|(?!\r\n)[\n\v\f\r\x85\u2028\u2029])` which is roughly equivalent the to atomic group form that other engines use: `(?>\r\n|[\n\v\f\r\x85\u2028\u2029])`. When applied to byte strings, the pattern `(?:\r\n|(?!\r\n)[\n\v\f\r\x85])` will be used.
 `\X`                  | Grapheme clusters. This will use the pattern `(?:\PM\pM*(?!\pM))` which is roughly equivalent to the atomic group form that other engines have used in the past:  `(?>\PM\pM*)`. This does not implement [full, proper grapheme clusters][grapheme-boundaries] like the 3rd party Regex module does as this would require changes to the Re core engine.
+
+!!! warning "Deprecated 6.0"
+    `\e` and `\h` have both been deprecated in 6.0. Please migrate to using `\x1b` and `\p{Horiz_Space}` in their places
+    respectively.
 
 ### Regex
 
@@ -37,9 +41,12 @@ Back\ References      | Description
 
 Back\ References | Description
 ---------------- | -----------
-`\e`             | Escape character `\x1b`.
+`\e`             | **Deprecated: Use `\x1b` instead.** Escape character `\x1b`.
 `\Q...\E`        | Quotes (escapes) text for regular expression.  `\E` signifies the end of the quoting. Affects any and all characters no matter where in the regular expression pattern it is placed.
 `\R`             | Generic line breaks. When searching a Unicode string, this will use the pattern `(?>\r\n|[\n\v\f\r\x85\u2028\u2029])`, and when applied to byte strings, the pattern `(?>\r\n|[\n\v\f\r\x85])` will be used.
+
+!!! warning "Deprecated 6.0"
+    `\e` has been deprecated in 6.0. Please migrate to using `\x1b` in its place.
 
 ## Replace Back References
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,7 @@ repo_url: https://github.com/facelessuser/backrefs
 edit_uri: tree/master/docs/src/markdown
 site_description: A library to add additional back references to regular expressions.
 copyright: |
-  Copyright &copy; 2015 - 2022 <a href="https://github.com/facelessuser"  target="_blank" rel="noopener">Isaac Muse</a>
+  Copyright &copy; 2015 - 2023 <a href="https://github.com/facelessuser"  target="_blank" rel="noopener">Isaac Muse</a>
 
 docs_dir: docs/src/markdown
 theme:
@@ -20,9 +20,16 @@ theme:
     code: Roboto Mono
   features:
     - navigation.tabs
-    - navigation.sections
     - navigation.top
     - navigation.instant
+    - navigation.sections
+    - navigation.indexes
+    - toc.follow
+    - content.code.copy
+    - navigation.footer
+    - search.share
+    - search.highlight
+    - search.suggest
   pymdownx:
     sponsor: "https://github.com/sponsors/facelessuser"
 

--- a/tests/test_bregex.py
+++ b/tests/test_bregex.py
@@ -147,9 +147,10 @@ class TestSearchTemplate(unittest.TestCase):
     def test_escape_char(self):
         """Test escape char."""
 
-        pattern = bregex.compile_search(
-            r'test\etest[\e]{2}'
-        )
+        with pytest.warns(DeprecationWarning):
+            pattern = bregex.compile_search(
+                r'test\etest[\e]{2}'
+            )
 
         self.assertEqual(
             pattern.pattern,


### PR DESCRIPTION
Resolves #176 