### PR TITLE
Fix issues with scoped flags

### DIFF
--- a/backrefs/_bregex_parse.py
+++ b/backrefs/_bregex_parse.py
@@ -281,7 +281,7 @@ class _SearchParser(Generic[AnyStr]):
                 if toggle:
                     if c not in _SCOPED_FLAGS:
                         raise ValueError('Bad scope')
-                elif version:
+                elif not smells_scoped and version:
                     if c not in _VERSIONS:
                         raise ValueError('Bad version')
                     version = False
@@ -290,10 +290,6 @@ class _SearchParser(Generic[AnyStr]):
                 elif version0 and not smells_global and c == '-':
                     smells_scoped = True
                     toggle = True
-                elif not smells_scoped and version:
-                    if c not in _VERSIONS:
-                        raise ValueError('Bad version')
-                    version = False
                 elif c == 'V':
                     version = True
                     smells_global = True

--- a/backrefs/_bregex_parse.py
+++ b/backrefs/_bregex_parse.py
@@ -30,9 +30,10 @@ _STANDARD_ESCAPES = frozenset(('a', 'b', 'f', 'n', 'r', 't', 'v'))
 _CURLY_BRACKETS = frozenset(('{', '}'))
 _PROPERTY_STRIP = frozenset((' ', '-', '_'))
 _PROPERTY = _WORD | _DIGIT | _PROPERTY_STRIP
-_GLOBAL_FLAGS = frozenset(('L', 'a', 'b', 'e', 'r', 'u', 'p'))
-_SCOPED_FLAGS = frozenset(('i', 'm', 's', 'f', 'w', 'x'))
+_GLOBAL_FLAGS = frozenset(('b', 'e', 'p', 'r', 'u'))
+_SCOPED_FLAGS = frozenset(('a', 'f', 'i', 'L', 'm', 's', 'u', 'w', 'x'))
 _VERSIONS = frozenset(('0', '1'))
+_SCOPED_END = frozenset((':', ')'))
 
 _CURLY_BRACKETS_ORD = frozenset((0x7b, 0x7d))
 
@@ -260,53 +261,66 @@ class _SearchParser(Generic[AnyStr]):
 
         return ''.join(value) if value else None
 
-    def get_flags(self, i: _util.StringIter, version0: bool, scoped: bool = False) -> str | None:
+    def get_flags(self, i: _util.StringIter, version0: bool) -> tuple[str | None, bool]:
         """Get flags."""
 
         index = i.index
         value = ['(']
         version = False
         toggle = False
-        end = ':' if scoped else ')'
+        smells_scoped = False
+        smells_global = False
         try:
             c = next(i)
             if c != '?':
                 i.rewind(1)
-                return None
+                return None, False
             value.append(c)
             c = next(i)
-            while c != end:
+            while c not in _SCOPED_END:
                 if toggle:
                     if c not in _SCOPED_FLAGS:
                         raise ValueError('Bad scope')
-                    toggle = False
-                elif (not version0 or scoped) and c == '-':
-                    toggle = True
                 elif version:
+                    if c not in _VERSIONS:
+                        raise ValueError('Bad version')
+                    version = False
+                elif not version0 and c == '-':
+                    toggle = True
+                elif version0 and not smells_global and c == '-':
+                    smells_scoped = True
+                    toggle = True
+                elif not smells_scoped and version:
                     if c not in _VERSIONS:
                         raise ValueError('Bad version')
                     version = False
                 elif c == 'V':
                     version = True
-                elif c not in _GLOBAL_FLAGS and c not in _SCOPED_FLAGS:
+                    smells_global = True
+                elif c in _GLOBAL_FLAGS:
+                    smells_global = True
+                elif c not in _SCOPED_FLAGS:
                     raise ValueError("Bad flag")
                 value.append(c)
                 c = next(i)
+            if (
+                (smells_global and smells_scoped) or
+                (smells_scoped and c != ':') or
+                (smells_global and c != ')')
+            ):
+                raise ValueError('Bad flag')
+            elif c == ':':
+                smells_scoped = True
+
             value.append(c)
         except Exception:
             i.rewind(i.index - index)
             value = []
 
-        return ''.join(value) if value else None
+        return ''.join(value) if value else None, smells_scoped
 
     def subgroup(self, t: str, i: _util.StringIter) -> list[str]:
         """Handle parenthesis."""
-
-        # (?flags)
-        flags = self.get_flags(i, self.version == _regex.V0)
-        if flags:
-            self.flags(flags[2:-1])
-            return [flags]
 
         # (?#comment)
         comments = self.get_comments(i)
@@ -315,11 +329,13 @@ class _SearchParser(Generic[AnyStr]):
 
         verbose = self.verbose
 
-        # (?flags:pattern)
-        flags = self.get_flags(i, (self.version == _regex.V0), True)
+        # (?flags:pattern) or (?flags)
+        flags, scoped = self.get_flags(i, self.version == _regex.V0)
         if flags:
             t = flags
-            self.flags(flags[2:-1], scoped=True)
+            self.flags(flags[2:-1], scoped=scoped)
+            if not scoped:
+                return [flags]
 
         current = []  # type: list[str]
         try:

--- a/backrefs/_bregex_parse.py
+++ b/backrefs/_bregex_parse.py
@@ -269,7 +269,6 @@ class _SearchParser(Generic[AnyStr]):
         version = False
         toggle = False
         smells_scoped = False
-        smells_global = False
         try:
             c = next(i)
             if c != '?':
@@ -281,31 +280,19 @@ class _SearchParser(Generic[AnyStr]):
                 if toggle:
                     if c not in _SCOPED_FLAGS:
                         raise ValueError('Bad scope')
-                elif not smells_scoped and version:
+                elif version:
                     if c not in _VERSIONS:
                         raise ValueError('Bad version')
                     version = False
-                elif not version0 and c == '-':
-                    toggle = True
-                elif version0 and not smells_global and c == '-':
-                    smells_scoped = True
+                elif c == '-':
                     toggle = True
                 elif c == 'V':
                     version = True
-                    smells_global = True
-                elif c in _GLOBAL_FLAGS:
-                    smells_global = True
-                elif c not in _SCOPED_FLAGS:
+                elif c not in _SCOPED_FLAGS and c not in _GLOBAL_FLAGS:
                     raise ValueError("Bad flag")
                 value.append(c)
                 c = next(i)
-            if (
-                (smells_global and smells_scoped) or
-                (smells_scoped and c != ':') or
-                (smells_global and c != ')')
-            ):
-                raise ValueError('Bad flag')
-            elif c == ':':
+            if c == ':':
                 smells_scoped = True
 
             value.append(c)
@@ -326,6 +313,7 @@ class _SearchParser(Generic[AnyStr]):
         verbose = self.verbose
 
         # (?flags:pattern) or (?flags)
+        # "scoped" only refers to verbose
         flags, scoped = self.get_flags(i, self.version == _regex.V0)
         if flags:
             t = flags

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -7,6 +7,9 @@
     `[[:xdigit:]]`, and  `[[:punct:]]`. To explicitly use standard Unicode rules for these compatibility properties, use
     the Unicode property form instead: `[\p{Alnum}]`, `[\p{Digit}]`, `[\p{Punct}]`, or `[\p{XDigit}]`. This has changed
     to ensure no confusion for users expecting compatible POSIX style character class properties.
+-   **FIX**: Scoped ASCII/Unicode flags (`(?a:pattern)`/`(?u:pattern)`) should be respected for Unicode properties in
+    `bre`.
+-   **FIX**: Fix issues with disabled scoped flags.
 
 ## 5.9
 

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -1994,6 +1994,12 @@ class TestReplaceTemplate(unittest.TestCase):
 class TestExceptions(unittest.TestCase):
     """Test Exceptions."""
 
+    def test_bad_flag(self):
+        """Test bad flag."""
+
+        with self.assertRaises(re.PatternError):
+            bre.compile(r'(?-i)')
+
     def test_format_existing_group_no_match_with_index(self):
         """Test format group with no match and attempt at indexing."""
 

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -21,6 +21,14 @@ else:
 class TestSearchTemplate(unittest.TestCase):
     """Search template tests."""
 
+    def test_inline_unicode(self):
+        """Test inline Unicode/ASCII cases."""
+
+        self.assertTrue(bre.match(r'\p{N}', '\uff19', flags=bre.ASCII) is None)
+        self.assertTrue(bre.match(r'(?u:\p{N})', '\uff19', flags=bre.ASCII) is not None)
+        self.assertTrue(bre.match(r'\p{N}', '\uff19', flags=bre.UNICODE) is not None)
+        self.assertTrue(bre.match(r'(?a:\p{N})', '\uff19', flags=bre.UNICODE) is None)
+
     def test_custom_binary_properties(self):
         """Test new custom binary properties."""
 

--- a/tests/test_bre.py
+++ b/tests/test_bre.py
@@ -11,6 +11,7 @@ import copy
 
 PY39_PLUS = (3, 9) <= sys.version_info
 PY311_PLUS = (3, 11) <= sys.version_info
+PY313_PLUS = (3, 13) <= sys.version_info
 
 if PY311_PLUS:
     import re._constants as _constants
@@ -1997,8 +1998,12 @@ class TestExceptions(unittest.TestCase):
     def test_bad_flag(self):
         """Test bad flag."""
 
-        with self.assertRaises(re.PatternError):
-            bre.compile(r'(?-i)')
+        if PY313_PLUS:
+            with self.assertRaises(re.PatternError):
+                bre.compile(r'(?-i)')
+        else:
+            with self.assertRaises(re.error):
+                bre.compile(r'(?-i)')
 
     def test_format_existing_group_no_match_with_index(self):
         """Test format group with no match and attempt at indexing."""


### PR DESCRIPTION
- Scoped ASCII/Unicode flags (`(?a:pattern)`/`(?u:pattern)`) should be respected for Unicode properties in `bre`.
- Fix issues with disabled scoped flags.