### PR TITLE
Fix Unicode property generator script in relation to property values

### DIFF
--- a/backrefs/__meta__.py
+++ b/backrefs/__meta__.py
@@ -193,5 +193,5 @@ def parse_version(ver: str) -> Version:
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(6, 2, 0, "final")
+__version_info__ = Version(6, 2, 1, "final")
 __version__ = __version_info__._get_canonical()

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -3,6 +3,12 @@ icon: lucide/scroll-text
 ---
 # Changelog
 
+## 6.2.1
+
+-   **FIX**: Fix bad name for value for Joining Group, which was previously `non_joining`, but should have been
+   `no_joining_group`.
+-   **FIX**: Update Unicode script to handle unexpected changes in alias of non-explicit value names.
+
 ## 6.2
 
 -   **NEW** Add alias `prefixmatch` for `match` in both `bre` and `bregex`.

--- a/tools/unipropgen.py
+++ b/tools/unipropgen.py
@@ -502,7 +502,11 @@ def gen_enum(
         obj[name] = sorted(s)
 
     if notexplicit:
-        not_explicitly_defined(obj, notexplicit, is_bytes=ascii_props)
+        not_explicitly_defined(
+            obj,
+            aliases.get(format_name(obj_name), {}).get(notexplicit, notexplicit),
+            is_bytes=ascii_props
+        )
 
     # Convert characters values to ranges
     char2range(obj, is_bytes=ascii_props)
@@ -1149,7 +1153,7 @@ def gen_properties(output, files, aliases, ascii_props=False, append=False):
 
     print('Building: Joining Group')
     gen_enum(
-        'DerivedJoiningGroup.txt', 'joining_group', files['jg'], notexplicit='nonjoining',
+        'DerivedJoiningGroup.txt', 'joining_group', files['jg'], notexplicit='nojoininggroup',
         ascii_props=ascii_props, append=append, prefix=prefix, aliases=aliases
     )
 


### PR DESCRIPTION
- `non_joining` should be `no_joining_group`.
- better handle unexpected alias changes.

Fixes #196